### PR TITLE
Automatically start oidc flow if oidc is the only allowed login method

### DIFF
--- a/frontend/src/views/AuthLoginView.vue
+++ b/frontend/src/views/AuthLoginView.vue
@@ -66,6 +66,10 @@ onMounted(async () => {
     return;
   }
 
+  if (!supportsLocal.value && supportsOidc.value) {
+    handleOidcLogin();
+  }
+
   try {
     await featuresStore.ensureLoaded();
   } catch (_) {


### PR DESCRIPTION
When `AUTH_MODE = "oidc"`, There isn't much point to show this screen:

<img width="988" height="513" alt="image" src="https://github.com/user-attachments/assets/24701f7b-6c1f-4137-908c-415e64118f0c" />

I think it makes the most sense to start the oidc flow as soon as possible if oidc is the only login method.

If you would like this implemented in a different way, please let me know.

Also, I am having trouble getting the docker container to run after being built to actually test this code, is there anything funky that needs to be done other than `npm install` and `docker build -t explorer .`?