### PR TITLE
Normalize string-type OIDC claims to arrays

### DIFF
--- a/backend/src/services/users/oidcAuth.js
+++ b/backend/src/services/users/oidcAuth.js
@@ -6,10 +6,12 @@ const { nowIso, toClientUser, generateId, normalizeEmail } = require('./utils');
 // Map provider claims/groups to an app roles array
 const deriveRolesFromClaims = (claims = {}, adminGroups = []) => {
   try {
+    const toArray = (v) => (Array.isArray(v) ? v : v != null ? [v] : []);
+
     const groups = []
-      .concat(Array.isArray(claims.groups) ? claims.groups : [])
-      .concat(Array.isArray(claims.roles) ? claims.roles : [])
-      .concat(Array.isArray(claims.entitlements) ? claims.entitlements : [])
+      .concat(toArray(claims.groups))
+      .concat(toArray(claims.roles))
+      .concat(toArray(claims.entitlements))
       .filter((g) => typeof g === 'string' && g.trim())
       .map((g) => g.trim().toLowerCase());
 


### PR DESCRIPTION
This pull request refactors the logic for extracting user roles from OIDC claims in the `deriveRolesFromClaims` function to improve robustness and code readability. The main change is the introduction of a helper function to consistently handle claim values that may be arrays or single values.

**Improvements to role extraction logic:**

* Added a `toArray` helper function to ensure that `claims.groups`, `claims.roles`, and `claims.entitlements` are always treated as arrays. This ensures single string-type values (as returned e.g. by JumpCloud when a user is only a member of a single group) are not discarded but preserved.

#279 