### PR TITLE
fix: pwa name and crossorigin for webmanifest

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -80,8 +80,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="shortcut icon" href="/favicon.ico?v=3" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <meta name="apple-mobile-web-app-title" content="MyWebSite" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <meta name="apple-mobile-web-app-title" content="NextExplorer" />
+    <link rel="manifest" href="/site.webmanifest" crossorigin="use-credentials" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Explorer</title>

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "NextExplorer",
+  "short_name": "NextExplorer",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",


### PR DESCRIPTION
Two fixes / enhancements:

- crossorigin="use-credentials" allows PWA to work behind Cloudflare tunnels

- Change website name to NextExplorer