### PR TITLE
fix: allow for the user to define the address the server uses

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -6,6 +6,7 @@ const { normalizeBoolean } = require('../utils/env');
  */
 module.exports = {
   // Server
+  ADDRESS: process.env.ADDRESS || '0.0.0.0',
   PORT: Number(process.env.PORT) || 3000,
   // Node.js HTTP server request timeout (ms). Set to 0 to disable.
   // Node defaults to 300000ms (5 minutes) on modern versions, which can abort large uploads.

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -220,6 +220,7 @@ const shares = {
 // --- Main Export ---
 module.exports = {
   port: env.PORT,
+  address: env.ADDRESS,
   http: {
     requestTimeoutMs,
   },

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,7 +4,7 @@
  * Tests should import the app directly from ./app.js
  */
 const { createApp } = require('./app');
-const { port, http, features } = require('./config/index');
+const { port, http, features, address } = require('./config/index');
 const logger = require('./utils/logger');
 const { printStartupBanner } = require('./utils/startupBanner');
 const terminalService = require('./services/terminalService');
@@ -16,10 +16,10 @@ const startServer = async () => {
 
   const app = await createApp();
 
-  server = app.listen(port, '0.0.0.0', () => {
+  server = app.listen(port, address, () => {
     const addr = server?.address?.();
     printStartupBanner({
-      listenHost: typeof addr === 'object' && addr ? addr.address : '0.0.0.0',
+      listenHost: typeof addr === 'object' && addr ? addr.address : address,
       listenPort: typeof addr === 'object' && addr ? addr.port : port,
     });
     logger.info({ port }, 'Server is running');


### PR DESCRIPTION
Currently, there is a hard-coded "0.0.0.0" bind in the express config, but this breaks down if the user needs to bind to a specific address (e.g., the server has multiple network interfaces) or if the user is needs IPv6 support (my situation). This is non-breaking, as the 0.0.0.0 bind is still default, but can be overridden with an environment variable.

For IPv6 support, the user can set ADDRESS=:: to bind to all IPv6 interfaces available.

Likewise, users can bind to a specific address (e.g., if the server has more than one public IP) by assigning ADDRESS=1.2.3.4 for the specific interface.

This change also allows for users to run the server on localhost (e.g., ADDRESS=127.0.0.1) and make it accessible through a reverse proxy.

Let me know if there are any issues or questions! Sorry for the second PR, stupid GitHub Copilot is out to get me