### PR TITLE
fix: use repeatable route param to prevent %2F in browse URLs

### DIFF
--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -79,4 +79,23 @@ const requestJson = async (endpoint, options = {}) => {
   return response.json();
 };
 
-export { apiBase, buildUrl, encodePath, normalizePath, requestJson, requestRaw };
+const toPathSegments = (path) => {
+  if (Array.isArray(path)) return path.flatMap((s) => String(s).split('/')).filter(Boolean);
+  return typeof path === 'string' ? path.split('/').filter(Boolean) : [];
+};
+
+const pathParamToString = (param) => {
+  if (Array.isArray(param)) return param.join('/');
+  return typeof param === 'string' ? param : '';
+};
+
+export {
+  apiBase,
+  buildUrl,
+  encodePath,
+  normalizePath,
+  pathParamToString,
+  requestJson,
+  requestRaw,
+  toPathSegments,
+};

--- a/frontend/src/components/BreadCrumb.vue
+++ b/frontend/src/components/BreadCrumb.vue
@@ -6,6 +6,7 @@ import { useRoute } from 'vue-router';
 import { useNavigation } from '@/composables/navigation';
 import { useFileStore } from '@/stores/fileStore';
 import { ellipses } from '@/utils/ellipses';
+import { pathParamToString } from '@/api/http';
 
 const { openBreadcrumb } = useNavigation();
 const { t, te } = useI18n();
@@ -13,8 +14,9 @@ const route = useRoute();
 const fileStore = useFileStore();
 
 const paths = computed(() => {
-  if (route.params.path) {
-    const segments = String(route.params.path).split('/');
+  const pathStr = pathParamToString(route.params.path);
+  if (pathStr) {
+    const segments = pathStr.split('/');
 
     // Special handling for share paths
     if (segments[0] === 'share' && segments.length >= 2) {

--- a/frontend/src/components/FolderViewToolbar.vue
+++ b/frontend/src/components/FolderViewToolbar.vue
@@ -16,6 +16,7 @@ import { useFileStore } from '@/stores/fileStore';
 import { useRoute, useRouter } from 'vue-router';
 import { Bars3Icon, HomeIcon } from '@heroicons/vue/24/outline';
 import { useInputMode } from '@/composables/useInputMode';
+import { pathParamToString } from '@/api/http';
 
 const settings = useSettingsStore();
 const auth = useAuthStore();
@@ -28,8 +29,7 @@ defineEmits(['toggle-sidebar']);
 
 // Check if we're at the volumes home view (no path selected)
 const isVolumesView = computed(() => {
-  const p = route.params.path;
-  const s = Array.isArray(p) ? p.join('/') : p || '';
+  const s = pathParamToString(route.params.path);
   return !s || s.trim() === '';
 });
 

--- a/frontend/src/components/SpotlightSearch.vue
+++ b/frontend/src/components/SpotlightSearch.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useDebounceFn, onKeyStroke } from '@vueuse/core';
 import { MagnifyingGlassIcon } from '@heroicons/vue/24/outline';
 import { search as searchApi, normalizePath } from '@/api';
+import { pathParamToString, toPathSegments } from '@/api/http';
 import { useSpotlightStore } from '@/stores/spotlight';
 import FileIcon from '@/icons/FileIcon.vue';
 import { useI18n } from 'vue-i18n';
@@ -24,8 +25,8 @@ const activeIndex = ref(-1);
 
 const basePath = computed(() => {
   const fromBrowse =
-    route.path.startsWith('/browse') && typeof route.params.path === 'string'
-      ? route.params.path
+    route.path.startsWith('/browse')
+      ? pathParamToString(route.params.path)
       : '';
   const fromQuery = typeof route.query.path === 'string' ? route.query.path : '';
   return normalizePath(fromBrowse || fromQuery || '');
@@ -107,11 +108,11 @@ function openResult(item) {
   if (!isDirectory && item.name) {
     router.push({
       name: 'FolderView',
-      params: { path: normalizedPath },
+      params: { path: toPathSegments(normalizedPath) },
       query: { select: item.name },
     });
   } else {
-    router.push({ name: 'FolderView', params: { path: normalizedPath } });
+    router.push({ name: 'FolderView', params: { path: toPathSegments(normalizedPath) } });
   }
   spotlight.close();
 }

--- a/frontend/src/components/VolMenu.vue
+++ b/frontend/src/components/VolMenu.vue
@@ -3,6 +3,7 @@ import { ServerIcon, ChevronDownIcon } from '@heroicons/vue/24/outline';
 import { getVolumes } from '@/api';
 import { ref, onMounted, computed } from 'vue';
 import { useRoute } from 'vue-router';
+import { pathParamToString } from '@/api/http';
 import { useNavigation } from '@/composables/navigation';
 import { useFeaturesStore } from '@/stores/features';
 import { FolderIcon } from '@heroicons/vue/24/outline';
@@ -22,13 +23,7 @@ onMounted(async () => {
 });
 
 const open = ref(true);
-const currentPath = computed(() => {
-  const path = route.params.path;
-  if (Array.isArray(path)) {
-    return path.join('/');
-  }
-  return typeof path === 'string' ? path : '';
-});
+const currentPath = computed(() => pathParamToString(route.params.path));
 
 const activeVolumeName = computed(() => {
   const path = currentPath.value.trim();

--- a/frontend/src/composables/navigation.js
+++ b/frontend/src/composables/navigation.js
@@ -2,6 +2,7 @@ import { useRouter, useRoute } from 'vue-router';
 import { withViewTransition } from '@/utils';
 import { isEditableExtension } from '@/config/editor';
 import { usePreviewManager } from '@/plugins/preview/manager';
+import { pathParamToString, toPathSegments } from '@/api/http';
 
 export function useNavigation() {
   const router = useRouter();
@@ -18,24 +19,20 @@ export function useNavigation() {
     const kind = typeof item.kind === 'string' ? item.kind : '';
     const name = typeof item.name === 'string' ? item.name : '';
     if (!name && kind !== 'personal') return;
-    const currentPath =
-      typeof route.params.path === 'string'
-        ? route.params.path
-        : Array.isArray(route.params.path)
-          ? route.params.path.join('/')
-          : '';
+    const currentPath = pathParamToString(route.params.path);
 
     if (kind === 'volume') {
-      navigate({ name: 'FolderView', params: { path: name } });
+      navigate({ name: 'FolderView', params: { path: [name] } });
       return;
     }
     if (kind === 'personal') {
-      navigate({ name: 'FolderView', params: { path: 'personal' } });
+      navigate({ name: 'FolderView', params: { path: ['personal'] } });
       return;
     }
     if (kind === 'directory') {
-      const newPath = currentPath ? `${currentPath}/${name}` : name;
-      navigate({ name: 'FolderView', params: { path: newPath } });
+      const segments = toPathSegments(currentPath);
+      segments.push(name);
+      navigate({ name: 'FolderView', params: { path: segments } });
       return;
     }
 
@@ -66,23 +63,16 @@ export function useNavigation() {
       navigate({ name: 'HomeView' });
       return;
     }
-    navigate({ name: 'FolderView', params: { path } });
+    navigate({ name: 'FolderView', params: { path: toPathSegments(path) } });
   };
 
   const goUp = () => {
-    const currentPath =
-      typeof route.params.path === 'string'
-        ? route.params.path
-        : Array.isArray(route.params.path)
-          ? route.params.path.join('/')
-          : '';
-    const segments = currentPath.split('/').filter(Boolean);
+    const segments = toPathSegments(route.params.path);
     if (segments.length === 0) return;
 
     segments.pop();
-    const newPath = segments.join('/');
-    if (newPath) {
-      navigate({ name: 'FolderView', params: { path: newPath } });
+    if (segments.length > 0) {
+      navigate({ name: 'FolderView', params: { path: segments } });
       return;
     }
     navigate({ name: 'HomeView' });

--- a/frontend/src/layouts/BrowserLayout.vue
+++ b/frontend/src/layouts/BrowserLayout.vue
@@ -30,6 +30,7 @@ import {
   InformationCircleIcon,
 } from '@heroicons/vue/24/outline';
 import FolderViewToolbar from '@/components/FolderViewToolbar.vue';
+import { pathParamToString } from '@/api/http';
 
 const route = useRoute();
 const router = useRouter();
@@ -104,8 +105,7 @@ useEventListener(window, 'keydown', (e) => {
 });
 
 const currentPathName = computed(() => {
-  const p = route.params.path;
-  const s = Array.isArray(p) ? p.join('/') : p || '';
+  const s = pathParamToString(route.params.path);
   return s.split('/').filter(Boolean).pop() || 'Volumes';
 });
 useTitle(currentPathName);

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -24,6 +24,7 @@ import { useAuthStore } from '@/stores/auth';
 import { useFeaturesStore } from '@/stores/features';
 import { useAppSettings } from '@/stores/appSettings';
 import { getVolumes } from '@/api';
+import { toPathSegments } from '@/api/http';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -104,7 +105,7 @@ const router = createRouter({
           component: HomeView,
         },
         {
-          path: ':path(.+)',
+          path: ':path+',
           name: 'FolderView',
           component: FolderView,
           meta: { allowGuest: true }, // Allow guest access for share paths
@@ -288,7 +289,7 @@ router.beforeEach(async (to) => {
         if (Array.isArray(volumes)) {
           const first = volumes[0];
           if (first && first.path) {
-            return { name: 'FolderView', params: { path: first.path } };
+            return { name: 'FolderView', params: { path: toPathSegments(first.path) } };
           }
         }
       } catch (_) {

--- a/frontend/src/views/EditorView.vue
+++ b/frontend/src/views/EditorView.vue
@@ -155,6 +155,7 @@ import { useI18n } from 'vue-i18n';
 import { Codemirror } from 'vue-codemirror';
 import { Compartment } from '@codemirror/state';
 import { fetchFileContent, saveFileContent, getRawFileUrl, normalizePath } from '@/api';
+import { pathParamToString } from '@/api/http';
 import { EditorView, keymap } from '@codemirror/view';
 import * as themeBundle from '@fsegurai/codemirror-theme-bundle';
 import {
@@ -240,9 +241,7 @@ const updateTheme = (id) => {
 
 // File Info
 const normalizedPath = computed(() =>
-  normalizePath(
-    Array.isArray(route.params.path) ? route.params.path.join('/') : route.params.path || ''
-  )
+  normalizePath(pathParamToString(route.params.path))
 );
 const hasUnsavedChanges = computed(() => fileContent.value !== originalContent.value);
 const canSave = computed(

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -17,6 +17,7 @@ import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/20/solid';
 import { useEventListener } from '@vueuse/core';
 import { useInputMode } from '@/composables/useInputMode';
 import { useFileDragDrop } from '@/composables/useFileDragDrop';
+import { pathParamToString } from '@/api/http';
 
 const settings = useSettingsStore();
 const fileStore = useFileStore();
@@ -53,7 +54,7 @@ const selectionModel = computed({
 
 const loadFiles = async () => {
   loading.value = true;
-  const path = route.params.path || '';
+  const path = pathParamToString(route.params.path);
   try {
     await fileStore.fetchPathItems(path);
     applySelectionFromQuery();

--- a/frontend/src/views/SearchResultsView.vue
+++ b/frontend/src/views/SearchResultsView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
 import { search as searchApi, normalizePath } from '@/api';
+import { toPathSegments } from '@/api/http';
 import FileIcon from '@/icons/FileIcon.vue';
 
 const route = useRoute();
@@ -43,7 +44,7 @@ function openResult(it) {
   // Open the matched folder itself for directories; open parent for files
   const target = kind === 'dir' ? [it.path, it.name].filter(Boolean).join('/') : it.path || '';
   const normalized = normalizePath(target || '');
-  router.push({ name: 'FolderView', params: { path: normalized } });
+  router.push({ name: 'FolderView', params: { path: toPathSegments(normalized) } });
 }
 
 function toIconItem(it) {

--- a/frontend/src/views/ShareLoginView.vue
+++ b/frontend/src/views/ShareLoginView.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { useAuthStore } from '@/stores/auth';
 import { getShareInfo, verifySharePassword, accessShare, setGuestSession } from '@/api/shares.api';
+import { toPathSegments } from '@/api/http';
 import {
   ShareIcon,
   LockClosedIcon,
@@ -87,7 +88,7 @@ async function handleUserAccess() {
     await accessShare(shareToken.value);
     router.push({
       name: 'FolderView',
-      params: { path: `share/${shareToken.value}` },
+      params: { path: toPathSegments(`share/${shareToken.value}`) },
     });
   } catch (err) {
     logger.error({ err }, 'User access failed');
@@ -110,10 +111,9 @@ async function handleAutoAccess() {
     const targetPath = `share/${shareToken.value}`;
     logger.debug('Redirecting to FolderView with path', targetPath);
 
-    // Redirect to browse the share
     router.push({
       name: 'FolderView',
-      params: { path: targetPath },
+      params: { path: toPathSegments(targetPath) },
     });
   } catch (err) {
     logger.error({ err }, 'Auto-access failed');
@@ -145,10 +145,9 @@ async function handlePasswordSubmit() {
       const targetPath = `share/${shareToken.value}`;
       logger.debug('Redirecting to FolderView with path', targetPath);
 
-      // Redirect to browse the share
       router.push({
         name: 'FolderView',
-        params: { path: targetPath },
+        params: { path: toPathSegments(targetPath) },
       });
     } else if (result.requiresAuth) {
       // User-specific share with password - redirect to login

--- a/frontend/src/views/SharedWithMeView.vue
+++ b/frontend/src/views/SharedWithMeView.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import { getSharedWithMe } from '@/api/shares.api';
+import { toPathSegments } from '@/api/http';
 import {
   ShareIcon,
   ClockIcon,
@@ -132,10 +133,9 @@ const visibleShares = computed(() => {
 const handleOpenShare = (share) => {
   if (isExpired(share)) return;
 
-  // Using named route with params ensures proper URL encoding
   router.push({
     name: 'FolderView',
-    params: { path: `share/${share.shareToken}` },
+    params: { path: toPathSegments(`share/${share.shareToken}`) },
   });
 };
 


### PR DESCRIPTION
Vue Router 4 with :path(.+) encodes forward slashes as %2F in params, producing URLs like /browse%2FFolder. some WAFs will block encoded path separators, returning 400 on page refresh.

Change the FolderView route from :path(.+) to :path+ (repeatable param) and pass path segments as arrays. This produces clean URLs with real / separators that pass through WAF without issues.