### PR TITLE
Open integrated terminal in the current folder

### DIFF
--- a/backend/src/routes/terminal.js
+++ b/backend/src/routes/terminal.js
@@ -1,6 +1,9 @@
 const express = require('express');
 const asyncHandler = require('../utils/asyncHandler');
 const terminalService = require('../services/terminalService');
+const logger = require('../utils/logger');
+const { normalizeRelativePath } = require('../utils/pathUtils');
+const { resolvePathWithAccess } = require('../services/accessManager');
 const { UnauthorizedError, ForbiddenError } = require('../errors/AppError');
 
 const router = express.Router();
@@ -26,7 +29,27 @@ router.post(
       throw new ForbiddenError('Admin privileges required to open terminal.');
     }
 
-    const token = terminalService.createSessionToken(user);
+    let cwd = null;
+    const requestedCwd = req.body?.cwd;
+
+    if (typeof requestedCwd === 'string' && requestedCwd.trim()) {
+      try {
+        const logicalCwd = normalizeRelativePath(requestedCwd);
+        if (logicalCwd) {
+          const { accessInfo, resolved } = await resolvePathWithAccess({ user }, logicalCwd);
+          cwd = accessInfo?.canRead
+            ? await terminalService.resolveWorkingDirectory(resolved)
+            : null;
+        }
+      } catch (error) {
+        logger.warn(
+          { requestedCwd, userId: user.id, err: error },
+          'Failed to resolve terminal working directory; using default shell directory'
+        );
+      }
+    }
+
+    const token = terminalService.createSessionToken(user, { cwd });
 
     res.json({ token });
   })

--- a/backend/src/services/terminalService.js
+++ b/backend/src/services/terminalService.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const fs = require('fs/promises');
 const WebSocket = require('ws');
 const logger = require('../utils/logger');
 
@@ -44,7 +45,17 @@ class TerminalService {
     return this.enabled && this.available;
   }
 
-  createSessionToken(user) {
+  async resolveWorkingDirectory(resolvedPath) {
+    const absolutePath = resolvedPath?.absolutePath;
+    if (!absolutePath) return null;
+
+    const stats = await fs.stat(absolutePath);
+    if (!stats.isDirectory()) return null;
+
+    return absolutePath;
+  }
+
+  createSessionToken(user, options = {}) {
     if (!user || !user.id) {
       const err = new Error('User context is required to create terminal session token.');
       err.status = 400;
@@ -66,10 +77,14 @@ class TerminalService {
     this.sessionTokens.set(token, {
       userId: user.id,
       roles,
+      cwd: typeof options.cwd === 'string' && options.cwd ? options.cwd : null,
       createdAt: now,
     });
 
-    logger.info({ userId: user.id }, 'Created terminal session token');
+    logger.info(
+      { userId: user.id, hasCwd: Boolean(options.cwd) },
+      'Created terminal session token'
+    );
 
     return token;
   }
@@ -131,7 +146,7 @@ class TerminalService {
           'Terminal WebSocket connection established for admin user'
         );
 
-        this.handleConnection(ws);
+        this.handleConnection(ws, session);
       } catch (error) {
         logger.error({ err: error }, 'Error handling terminal WebSocket connection');
         try {
@@ -150,7 +165,7 @@ class TerminalService {
     return wss;
   }
 
-  handleConnection(ws) {
+  handleConnection(ws, session = {}) {
     if (!this.isAvailable() || !this.pty) {
       ws.close(1011, 'Terminal unavailable');
       return;
@@ -158,12 +173,14 @@ class TerminalService {
 
     const terminalId = Date.now().toString();
     const shell = process.env.SHELL || 'bash';
+    const defaultCwd = process.env.HOME || process.cwd();
+    const cwd = session.cwd || defaultCwd;
 
     logger.info(
       {
         terminalId,
         shell,
-        cwd: process.env.HOME,
+        cwd,
         wsReadyState: ws.readyState,
       },
       'Attempting to spawn terminal process'
@@ -174,7 +191,7 @@ class TerminalService {
         name: 'xterm-256color',
         cols: 80,
         rows: 30,
-        cwd: process.env.HOME,
+        cwd,
         env: {
           ...process.env,
           TERM: 'xterm-256color',

--- a/backend/tests/routes/terminal.test.js
+++ b/backend/tests/routes/terminal.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import request from 'supertest';
+import { setupTestEnv, createTestApp } from '../helpers/env-test-utils.js';
+
+let envContext;
+
+const adminUser = {
+  id: 'admin-user',
+  username: 'admin',
+  roles: ['admin'],
+};
+
+const buildApp = () => {
+  const terminalService = envContext.requireFresh('src/services/terminalService');
+  terminalService.enabled = true;
+  terminalService.available = true;
+
+  const terminalRoutes = envContext.requireFresh('src/routes/terminal');
+  const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
+
+  return {
+    app: createTestApp({
+      router: terminalRoutes,
+      mountPath: '/api',
+      user: adminUser,
+      errorHandler,
+    }),
+    terminalService,
+  };
+};
+
+beforeEach(async () => {
+  envContext = await setupTestEnv({
+    tag: 'terminal-routes-test-',
+    modules: [
+      'src/config/env',
+      'src/config/index',
+      'src/routes/terminal',
+      'src/services/accessManager',
+      'src/services/terminalService',
+      'src/utils/pathUtils',
+    ],
+  });
+});
+
+afterEach(async () => {
+  await envContext.cleanup();
+});
+
+describe('Terminal Routes', () => {
+  it('stores the resolved current folder as the terminal session cwd', async () => {
+    const targetDir = path.join(envContext.volumeDir, 'Projects', 'NextExplorer');
+    await fs.mkdir(targetDir, { recursive: true });
+
+    const { app, terminalService } = buildApp();
+    const server = app.listen(0);
+
+    try {
+      const response = await request(server)
+        .post('/api/terminal/session')
+        .send({ cwd: 'Projects/NextExplorer' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.token).toBeTruthy();
+
+      const session = terminalService.validateSessionToken(response.body.token);
+      expect(session.cwd).toBe(targetDir);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/frontend/src/api/terminal.api.js
+++ b/frontend/src/api/terminal.api.js
@@ -1,8 +1,9 @@
 import { requestJson } from './http';
 
 // Issue a short-lived terminal session token (admin only)
-export async function createTerminalSession() {
+export async function createTerminalSession(cwd = '') {
   return requestJson('/api/terminal/session', {
     method: 'POST',
+    body: JSON.stringify({ cwd }),
   });
 }

--- a/frontend/src/components/TerminalMenu.vue
+++ b/frontend/src/components/TerminalMenu.vue
@@ -4,9 +4,11 @@ import { CommandLineIcon, ChevronDownIcon } from '@heroicons/vue/24/outline';
 import { useI18n } from 'vue-i18n';
 import { useTerminalStore } from '@/stores/terminal';
 import { useAuthStore } from '@/stores/auth';
+import { useFileStore } from '@/stores/fileStore';
 
 const terminalStore = useTerminalStore();
 const { toggle, isOpen } = terminalStore;
+const fileStore = useFileStore();
 
 const auth = useAuthStore();
 const isAdmin = computed(
@@ -16,6 +18,10 @@ const isAdmin = computed(
 const { t } = useI18n();
 
 const open = ref(true);
+
+const toggleTerminal = () => {
+  toggle(fileStore.currentPath || '');
+};
 </script>
 
 <template>
@@ -45,7 +51,7 @@ const open = ref(true);
       >
         <div v-if="open" class="overflow-hidden">
           <button
-            @click="toggle"
+            @click="toggleTerminal"
             :class="[
               'cursor-pointer flex w-full items-center gap-3 my-3 rounded-lg transition-colors duration-200 text-sm',
               isOpen ? 'dark:text-white' : 'dark:text-neutral-300/90',

--- a/frontend/src/components/TerminalMenu.vue
+++ b/frontend/src/components/TerminalMenu.vue
@@ -5,10 +5,12 @@ import { useI18n } from 'vue-i18n';
 import { useTerminalStore } from '@/stores/terminal';
 import { useAuthStore } from '@/stores/auth';
 import { useFileStore } from '@/stores/fileStore';
+import { useRoute } from 'vue-router';
 
 const terminalStore = useTerminalStore();
 const { toggle, isOpen } = terminalStore;
 const fileStore = useFileStore();
+const route = useRoute();
 
 const auth = useAuthStore();
 const isAdmin = computed(
@@ -18,9 +20,10 @@ const isAdmin = computed(
 const { t } = useI18n();
 
 const open = ref(true);
+const terminalPath = computed(() => (route.name === 'HomeView' ? '' : fileStore.currentPath || ''));
 
 const toggleTerminal = () => {
-  toggle(fileStore.currentPath || '');
+  toggle(terminalPath.value);
 };
 </script>
 

--- a/frontend/src/components/TerminalPanel.vue
+++ b/frontend/src/components/TerminalPanel.vue
@@ -48,7 +48,7 @@ import { onClickOutside } from '@vueuse/core';
 import logger from '@/utils/logger';
 
 const terminalStore = useTerminalStore();
-const { isOpen } = storeToRefs(terminalStore);
+const { isOpen, launchPath } = storeToRefs(terminalStore);
 const { close } = terminalStore;
 
 const terminaldiv = ref(null);
@@ -111,7 +111,7 @@ const buildTerminalUrl = (token) => {
 
 const connectToBackend = async () => {
   try {
-    const session = await createTerminalSession();
+    const session = await createTerminalSession(launchPath.value || '');
     const token = session?.token;
     if (!token) {
       console.error('Failed to obtain terminal session token');
@@ -210,6 +210,26 @@ const initTerminal = () => {
   connectToBackend();
 };
 
+const teardownTerminal = () => {
+  if (resizeObserver) {
+    resizeObserver.disconnect();
+    resizeObserver = null;
+  }
+
+  if (socket) {
+    socket.close();
+    socket = null;
+  }
+
+  if (term) {
+    term.dispose();
+    term = null;
+  }
+
+  fitAddon = null;
+  pendingResize = null;
+};
+
 watch(isOpen, (newVal) => {
   if (newVal) {
     setTimeout(() => {
@@ -218,6 +238,8 @@ watch(isOpen, (newVal) => {
         fitAddon.fit();
       }
     }, 250);
+  } else {
+    teardownTerminal();
   }
 });
 
@@ -228,15 +250,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-  if (resizeObserver) {
-    resizeObserver.disconnect();
-  }
-  if (socket) {
-    socket.close();
-  }
-  if (term) {
-    term.dispose();
-  }
+  teardownTerminal();
 });
 
 onClickOutside(panelRef, () => {

--- a/frontend/src/stores/terminal.js
+++ b/frontend/src/stores/terminal.js
@@ -3,8 +3,10 @@ import { ref } from 'vue';
 
 export const useTerminalStore = defineStore('terminal', () => {
   const isOpen = ref(false);
+  const launchPath = ref('');
 
-  const open = () => {
+  const open = (cwd = '') => {
+    launchPath.value = typeof cwd === 'string' ? cwd : '';
     isOpen.value = true;
   };
 
@@ -12,12 +14,18 @@ export const useTerminalStore = defineStore('terminal', () => {
     isOpen.value = false;
   };
 
-  const toggle = () => {
-    isOpen.value = !isOpen.value;
+  const toggle = (cwd = '') => {
+    if (isOpen.value) {
+      close();
+      return;
+    }
+
+    open(cwd);
   };
 
   return {
     isOpen,
+    launchPath,
     open,
     close,
     toggle,


### PR DESCRIPTION
## Summary
- Open the integrated terminal in the currently viewed folder instead of the default home directory.
- Pass the logical browser path to the terminal session endpoint and resolve it server-side through existing access checks.
- Recreate the terminal session when the panel is reopened so each launch uses the selected folder.
- Add a focused backend test for terminal session cwd resolution.

## Validation
- npm run test -w backend -- tests/routes/terminal.test.js
- npx prettier --config prettier.config.cjs --check frontend/src/api/terminal.api.js frontend/src/stores/terminal.js frontend/src/components/TerminalMenu.vue frontend/src/components/TerminalPanel.vue backend/src/routes/terminal.js backend/src/services/terminalService.js backend/tests/routes/terminal.test.js

Closes https://github.com/nxzai/NextExplorer/issues/308