### PR TITLE
Prevent accidental UI text selection

### DIFF
--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -29,6 +29,29 @@
     background-color: var(--clr-base);
   }
 
+  body {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  input,
+  textarea,
+  [contenteditable],
+  .select-text,
+  .cm-editor,
+  .cm-editor *,
+  .xterm,
+  .xterm *,
+  .prose,
+  .prose *,
+  pre,
+  code,
+  kbd,
+  samp {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
   *,
   ::after,
   ::before,

--- a/frontend/src/components/ExplorerContextMenu.vue
+++ b/frontend/src/components/ExplorerContextMenu.vue
@@ -134,6 +134,10 @@ const closeMenu = () => {
   isOpen.value = false;
 };
 
+const clearTextSelection = () => {
+  window.getSelection?.()?.removeAllRanges?.();
+};
+
 const getItemKey = (item) => {
   if (!item || !item.name) return '';
   const parent = normalizePath(item.path || '');
@@ -156,6 +160,7 @@ const ensureItemInSelection = (item) => {
 
 const openMenuAt = (event, kind, item = null) => {
   if (!event) return;
+  clearTextSelection();
   const clientX = event.clientX ?? 0;
   const clientY = event.clientY ?? 0;
 


### PR DESCRIPTION
## Summary
- make static application chrome non-selectable by default
- keep text selection enabled for inputs, editable content, CodeMirror, xterm, markdown/prose, and code blocks
- clear any existing text selection when opening the explorer context menu

## User impact
This prevents accidental blue text selections in the file browser, sidebar, toolbar, and context menus while preserving selection where users naturally expect it.

## Validation
- npm run build -w frontend