### PR TITLE
Add direct file links for shared files

### DIFF
--- a/backend/src/routes/files/delete.js
+++ b/backend/src/routes/files/delete.js
@@ -1,7 +1,19 @@
-const { deleteItems } = require('../../services/fileTransferService');
+const { deleteItems, getDeleteImpact } = require('../../services/fileTransferService');
 const asyncHandler = require('../../utils/asyncHandler');
 
 const router = require('express').Router();
+
+router.post(
+  '/files/delete-impact',
+  asyncHandler(async (req, res) => {
+    const { items = [] } = req.body || {};
+    const impact = await getDeleteImpact(items, {
+      user: req.user,
+      guestSession: req.guestSession,
+    });
+    res.json(impact);
+  })
+);
 
 router.delete(
   '/files',

--- a/backend/src/routes/files/utils.js
+++ b/backend/src/routes/files/utils.js
@@ -65,25 +65,28 @@ const collectInputPaths = (...sources) => {
 
 const toPosix = (value = '') => value.replace(/\\/g, '/');
 
-const encodeContentDisposition = (filename) => {
+const encodeContentDisposition = (filename, disposition = 'attachment') => {
+  const safeDisposition = disposition === 'inline' ? 'inline' : 'attachment';
+  const safeFilename = String(filename || 'download').replace(/[\r\n"]/g, '_');
+
   // Check if filename contains non-ASCII characters
   // eslint-disable-next-line no-control-regex
-  const hasNonAscii = /[^\x00-\x7F]/.test(filename);
+  const hasNonAscii = /[^\x00-\x7F]/.test(safeFilename);
 
   if (!hasNonAscii) {
     // Simple case: filename is ASCII-only
-    return `attachment; filename="${filename}"`;
+    return `${safeDisposition}; filename="${safeFilename}"`;
   }
 
   // For non-ASCII filenames, use RFC 5987 encoding
   // Create ASCII fallback (replace non-ASCII with underscores)
   // eslint-disable-next-line no-control-regex
-  const asciiFallback = filename.replace(/[^\x00-\x7F]/g, '_');
+  const asciiFallback = safeFilename.replace(/[^\x00-\x7F]/g, '_');
 
   // Encode filename for filename* parameter (RFC 5987)
-  const encodedFilename = encodeURIComponent(filename);
+  const encodedFilename = encodeURIComponent(safeFilename);
 
-  return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`;
+  return `${safeDisposition}; filename="${asciiFallback}"; filename*=UTF-8''${encodedFilename}`;
 };
 
 const stripBasePath = (relativePath, basePath) => {

--- a/backend/src/routes/shares.js
+++ b/backend/src/routes/shares.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const fs = require('fs/promises');
+const fss = require('fs');
 const path = require('path');
 const asyncHandler = require('../utils/asyncHandler');
 const {
@@ -17,19 +18,115 @@ const {
   updateShare,
   deleteShare,
   verifySharePassword,
+  hasUserPermission,
   isShareExpired,
   trackShareAccess,
   getShareStats,
 } = require('../services/sharesService');
 const { createGuestSession } = require('../services/guestSessionService');
-const { parsePathSpace } = require('../utils/pathUtils');
+const { normalizeRelativePath, parsePathSpace } = require('../utils/pathUtils');
 const { pathExists } = require('../utils/fsUtils');
 const { resolvePathWithAccess } = require('../services/accessManager');
-const { extensions } = require('../config/index');
+const { extensions, mimeTypes } = require('../config/index');
 const { getSettings } = require('../services/settingsService');
 const { listDirectoryItems } = require('../services/directoryListingService');
+const { encodeContentDisposition } = require('./files/utils');
 
 const router = express.Router();
+
+const buildPublicBaseUrl = (req) => {
+  const { public: publicConfig } = require('../config/index');
+  return publicConfig.origin || `${req.protocol}://${req.get('host')}`;
+};
+
+const encodeUrlPath = (value = '') =>
+  String(value).split('/').filter(Boolean).map(encodeURIComponent).join('/');
+
+const buildDirectFilePath = (shareToken, innerPath = '') => {
+  const encodedToken = encodeURIComponent(shareToken);
+  const encodedInnerPath = encodeUrlPath(innerPath);
+  return encodedInnerPath
+    ? `/api/share/${encodedToken}/file/${encodedInnerPath}`
+    : `/api/share/${encodedToken}/file`;
+};
+
+const getSafeRedirectTarget = (target) => {
+  if (typeof target !== 'string' || !target.startsWith('/') || target.startsWith('//')) {
+    return null;
+  }
+  return target;
+};
+
+const redirectToShareAccess = (req, res, shareToken) => {
+  const redirectTarget = getSafeRedirectTarget(req.originalUrl || '');
+  const redirectQuery = redirectTarget ? `?redirect=${encodeURIComponent(redirectTarget)}` : '';
+  res.redirect(302, `/share/${encodeURIComponent(shareToken)}${redirectQuery}`);
+};
+
+const streamResolvedFileInline = async ({ absolutePath, stats, req, res }) => {
+  const filename = path.basename(absolutePath);
+  const extension = path.extname(filename).slice(1).toLowerCase();
+  const mimeType = mimeTypes[extension] || 'application/octet-stream';
+
+  const streamFile = (options = undefined) => {
+    const stream = options
+      ? fss.createReadStream(absolutePath, options)
+      : fss.createReadStream(absolutePath);
+    stream.on('error', (streamError) => {
+      if (!res.headersSent) {
+        res.status(500).end();
+      } else {
+        res.destroy(streamError);
+      }
+    });
+    stream.pipe(res);
+  };
+
+  const baseHeaders = {
+    'Content-Type': mimeType,
+    'Content-Disposition': encodeContentDisposition(filename, 'inline'),
+    'X-Content-Type-Options': 'nosniff',
+    'X-Robots-Tag': 'noindex',
+  };
+
+  const rangeHeader = req.headers.range;
+  if (rangeHeader) {
+    const bytesPrefix = 'bytes=';
+    if (!rangeHeader.startsWith(bytesPrefix)) {
+      res.status(416).send('Malformed Range header');
+      return;
+    }
+
+    const [startString, endString] = rangeHeader.slice(bytesPrefix.length).split('-');
+    let start = Number(startString);
+    let end = endString ? Number(endString) : stats.size - 1;
+
+    if (Number.isNaN(start)) start = 0;
+    if (Number.isNaN(end) || end >= stats.size) end = stats.size - 1;
+
+    if (start > end) {
+      res.status(416).send('Range Not Satisfiable');
+      return;
+    }
+
+    const chunkSize = end - start + 1;
+    res.writeHead(206, {
+      ...baseHeaders,
+      'Content-Range': `bytes ${start}-${end}/${stats.size}`,
+      'Accept-Ranges': 'bytes',
+      'Content-Length': chunkSize,
+    });
+    streamFile({ start, end });
+    return;
+  }
+
+  res.writeHead(200, {
+    ...baseHeaders,
+    'Content-Length': stats.size,
+    'Accept-Ranges': 'bytes',
+  });
+  streamFile();
+};
 
 /**
  * POST /api/shares - Create a new share
@@ -123,13 +220,14 @@ router.post(
     });
 
     // Generate share URL using PUBLIC_URL if configured, otherwise use request host
-    const { public: publicConfig } = require('../config/index');
-    const baseUrl = publicConfig.origin || `${req.protocol}://${req.get('host')}`;
+    const baseUrl = buildPublicBaseUrl(req);
     const shareUrl = `${baseUrl}/share/${share.shareToken}`;
+    const directFileUrl = isDirectory ? null : `${baseUrl}${buildDirectFilePath(share.shareToken)}`;
 
     res.status(201).json({
       ...share,
       shareUrl,
+      directFileUrl,
     });
   })
 );
@@ -475,6 +573,93 @@ router.get(
     });
   })
 );
+
+const handleDirectFileRequest = async (req, res) => {
+  const shareToken = req.params.token;
+  const rawInnerPath = req.params[0] || '';
+  let innerPath = '';
+
+  try {
+    innerPath = rawInnerPath ? normalizeRelativePath(rawInnerPath) : '';
+  } catch (error) {
+    throw new ValidationError('Invalid file path.');
+  }
+
+  const share = await getShareByToken(shareToken);
+  if (!share) {
+    throw new NotFoundError('Share not found');
+  }
+
+  if (isShareExpired(share)) {
+    throw new ForbiddenError('Share has expired');
+  }
+
+  if (!share.isDirectory && innerPath) {
+    throw new NotFoundError('Path not found');
+  }
+
+  if (share.sharingType === 'users') {
+    if (!req.user || !req.user.id) {
+      redirectToShareAccess(req, res, shareToken);
+      return;
+    }
+
+    const permitted = await hasUserPermission(share.id, req.user.id);
+    if (!permitted) {
+      throw new ForbiddenError('Access denied');
+    }
+  }
+
+  let guestSession = req.guestSession || null;
+
+  if (share.sharingType === 'anyone' && !req.user) {
+    if (share.hasPassword) {
+      if (!guestSession || guestSession.shareId !== share.id) {
+        redirectToShareAccess(req, res, shareToken);
+        return;
+      }
+    } else {
+      // Public direct file links should work without first visiting the Web UI.
+      guestSession = guestSession?.shareId === share.id ? guestSession : { shareId: share.id };
+    }
+  }
+
+  const logicalPath = innerPath ? `share/${shareToken}/${innerPath}` : `share/${shareToken}`;
+  const context = { user: req.user, guestSession };
+  const { accessInfo, resolved } = await resolvePathWithAccess(context, logicalPath);
+
+  if (
+    !accessInfo ||
+    !accessInfo.canAccess ||
+    !accessInfo.canRead ||
+    !accessInfo.canDownload ||
+    !resolved
+  ) {
+    throw new ForbiddenError(accessInfo?.denialReason || 'File access not allowed.');
+  }
+
+  if (!(await pathExists(resolved.absolutePath))) {
+    throw new NotFoundError('Path not found');
+  }
+
+  const stats = await fs.stat(resolved.absolutePath);
+  if (stats.isDirectory()) {
+    redirectToShareAccess(req, res, shareToken);
+    return;
+  }
+
+  await trackShareAccess(share.id);
+  await streamResolvedFileInline({ absolutePath: resolved.absolutePath, stats, req, res });
+};
+
+/**
+ * GET /api/share/:token/file/* - Open a shared file directly.
+ *
+ * This keeps the same share rules as the Web UI but streams the target file
+ * itself, letting the browser preview supported formats or download others.
+ */
+router.get('/:token/file', asyncHandler(handleDirectFileRequest));
+router.get('/:token/file/*', asyncHandler(handleDirectFileRequest));
 
 /**
  * GET /api/share/:token/browse/* - Browse share contents

--- a/backend/src/routes/shares.js
+++ b/backend/src/routes/shares.js
@@ -2,6 +2,7 @@ const express = require('express');
 const fs = require('fs/promises');
 const fss = require('fs');
 const path = require('path');
+const archiver = require('archiver');
 const asyncHandler = require('../utils/asyncHandler');
 const {
   ValidationError,
@@ -31,6 +32,7 @@ const { extensions, mimeTypes } = require('../config/index');
 const { getSettings } = require('../services/settingsService');
 const { listDirectoryItems } = require('../services/directoryListingService');
 const { encodeContentDisposition } = require('./files/utils');
+const logger = require('../utils/logger');
 
 const router = express.Router();
 
@@ -42,12 +44,127 @@ const buildPublicBaseUrl = (req) => {
 const encodeUrlPath = (value = '') =>
   String(value).split('/').filter(Boolean).map(encodeURIComponent).join('/');
 
-const buildDirectFilePath = (shareToken, innerPath = '') => {
+const DIRECT_FILE_MODES = new Set(['auto', 'download', 'inline', 'raw', 'view']);
+const TEXT_LIKE_EXTENSIONS = new Set([
+  'bat',
+  'bash',
+  'c',
+  'cfg',
+  'cmd',
+  'conf',
+  'cpp',
+  'cs',
+  'css',
+  'csv',
+  'env',
+  'fish',
+  'go',
+  'h',
+  'hpp',
+  'htm',
+  'html',
+  'ini',
+  'java',
+  'js',
+  'json',
+  'jsx',
+  'less',
+  'log',
+  'mjs',
+  'md',
+  'php',
+  'ps1',
+  'py',
+  'rb',
+  'rs',
+  'scss',
+  'sh',
+  'sql',
+  'svg',
+  'toml',
+  'ts',
+  'tsx',
+  'txt',
+  'vue',
+  'xml',
+  'yaml',
+  'yml',
+  'zsh',
+]);
+const TEXT_LIKE_FILENAMES = new Set(['dockerfile', 'makefile', 'readme', 'license']);
+const FORCE_PLAIN_TEXT_EXTENSIONS = new Set([
+  'bat',
+  'bash',
+  'cmd',
+  'fish',
+  'htm',
+  'html',
+  'js',
+  'jsx',
+  'mjs',
+  'ps1',
+  'sh',
+  'svg',
+  'ts',
+  'tsx',
+  'zsh',
+]);
+const INLINE_MIME_PREFIXES = ['audio/', 'image/', 'text/', 'video/'];
+const INLINE_MIME_TYPES = new Set([
+  'application/json',
+  'application/pdf',
+  'application/xml',
+  'application/javascript',
+  'application/x-javascript',
+]);
+
+const normalizeDirectFileMode = (mode) => {
+  const value = typeof mode === 'string' ? mode.toLowerCase() : 'auto';
+  if (!DIRECT_FILE_MODES.has(value)) return 'auto';
+  return value === 'view' ? 'inline' : value;
+};
+
+const isTextLikeFile = (filename, extension) => {
+  const lowerName = filename.toLowerCase();
+  return TEXT_LIKE_EXTENSIONS.has(extension) || TEXT_LIKE_FILENAMES.has(lowerName);
+};
+
+const getDirectFilePresentation = (filename, requestedMode) => {
+  const mode = normalizeDirectFileMode(requestedMode);
+  const extension = path.extname(filename).slice(1).toLowerCase();
+  const detectedMimeType = mimeTypes[extension] || 'application/octet-stream';
+  const textLike = isTextLikeFile(filename, extension);
+  const inlineMime =
+    INLINE_MIME_PREFIXES.some((prefix) => detectedMimeType.startsWith(prefix)) ||
+    INLINE_MIME_TYPES.has(detectedMimeType);
+  const canInline = textLike || inlineMime;
+  const forceDownload = mode === 'download' || !canInline;
+  const disposition = forceDownload ? 'attachment' : 'inline';
+
+  let contentType = detectedMimeType;
+  if (!forceDownload && textLike) {
+    const shouldUsePlainText =
+      mode === 'inline' ||
+      detectedMimeType === 'application/octet-stream' ||
+      FORCE_PLAIN_TEXT_EXTENSIONS.has(extension);
+    contentType = shouldUsePlainText ? 'text/plain; charset=utf-8' : detectedMimeType;
+  }
+
+  return {
+    contentType,
+    disposition,
+  };
+};
+
+const buildDirectFilePath = (shareToken, innerPath = '', mode = 'auto') => {
   const encodedToken = encodeURIComponent(shareToken);
   const encodedInnerPath = encodeUrlPath(innerPath);
-  return encodedInnerPath
+  const normalizedMode = normalizeDirectFileMode(mode);
+  const query = normalizedMode === 'auto' ? '' : `?mode=${encodeURIComponent(normalizedMode)}`;
+  const pathPart = encodedInnerPath
     ? `/api/share/${encodedToken}/file/${encodedInnerPath}`
     : `/api/share/${encodedToken}/file`;
+  return `${pathPart}${query}`;
 };
 
 const getSafeRedirectTarget = (target) => {
@@ -63,10 +180,9 @@ const redirectToShareAccess = (req, res, shareToken) => {
   res.redirect(302, `/share/${encodeURIComponent(shareToken)}${redirectQuery}`);
 };
 
-const streamResolvedFileInline = async ({ absolutePath, stats, req, res }) => {
+const streamResolvedFile = async ({ absolutePath, stats, mode, req, res }) => {
   const filename = path.basename(absolutePath);
-  const extension = path.extname(filename).slice(1).toLowerCase();
-  const mimeType = mimeTypes[extension] || 'application/octet-stream';
+  const { contentType, disposition } = getDirectFilePresentation(filename, mode);
 
   const streamFile = (options = undefined) => {
     const stream = options
@@ -83,8 +199,8 @@ const streamResolvedFileInline = async ({ absolutePath, stats, req, res }) => {
   };
 
   const baseHeaders = {
-    'Content-Type': mimeType,
-    'Content-Disposition': encodeContentDisposition(filename, 'inline'),
+    'Content-Type': contentType,
+    'Content-Disposition': encodeContentDisposition(filename, disposition),
     'X-Content-Type-Options': 'nosniff',
     'X-Robots-Tag': 'noindex',
   };
@@ -126,6 +242,32 @@ const streamResolvedFileInline = async ({ absolutePath, stats, req, res }) => {
     'Accept-Ranges': 'bytes',
   });
   streamFile();
+};
+
+const streamResolvedDirectoryZip = async ({ absolutePath, archiveName, res }) => {
+  const safeArchiveName = archiveName && archiveName.trim() ? archiveName.trim() : 'download';
+  const filename = safeArchiveName.toLowerCase().endsWith('.zip')
+    ? safeArchiveName
+    : `${safeArchiveName}.zip`;
+
+  res.setHeader('Content-Type', 'application/zip');
+  res.setHeader('Content-Disposition', encodeContentDisposition(filename, 'attachment'));
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Robots-Tag', 'noindex');
+
+  const archive = archiver('zip', { zlib: { level: 1 } });
+  archive.on('error', (archiveError) => {
+    logger.error({ err: archiveError }, 'Direct share archive creation failed');
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Failed to create archive.' });
+    } else {
+      res.end();
+    }
+  });
+
+  archive.pipe(res);
+  archive.directory(absolutePath, path.basename(absolutePath) || safeArchiveName);
+  await archive.finalize();
 };
 
 /**
@@ -222,7 +364,7 @@ router.post(
     // Generate share URL using PUBLIC_URL if configured, otherwise use request host
     const baseUrl = buildPublicBaseUrl(req);
     const shareUrl = `${baseUrl}/share/${share.shareToken}`;
-    const directFileUrl = isDirectory ? null : `${baseUrl}${buildDirectFilePath(share.shareToken)}`;
+    const directFileUrl = `${baseUrl}${buildDirectFilePath(share.shareToken)}`;
 
     res.status(201).json({
       ...share,
@@ -577,6 +719,7 @@ router.get(
 const handleDirectFileRequest = async (req, res) => {
   const shareToken = req.params.token;
   const rawInnerPath = req.params[0] || '';
+  const mode = normalizeDirectFileMode(req.query?.mode);
   let innerPath = '';
 
   try {
@@ -644,12 +787,21 @@ const handleDirectFileRequest = async (req, res) => {
 
   const stats = await fs.stat(resolved.absolutePath);
   if (stats.isDirectory()) {
-    redirectToShareAccess(req, res, shareToken);
+    await trackShareAccess(share.id);
+    await streamResolvedDirectoryZip({
+      absolutePath: resolved.absolutePath,
+      archiveName:
+        path.basename(resolved.absolutePath) ||
+        share.label ||
+        path.basename(share.sourcePath || '') ||
+        'download',
+      res,
+    });
     return;
   }
 
   await trackShareAccess(share.id);
-  await streamResolvedFileInline({ absolutePath: resolved.absolutePath, stats, req, res });
+  await streamResolvedFile({ absolutePath: resolved.absolutePath, stats, mode, req, res });
 };
 
 /**

--- a/backend/src/services/fileTransferService.js
+++ b/backend/src/services/fileTransferService.js
@@ -8,6 +8,7 @@ const {
   findAvailableName,
 } = require('../utils/pathUtils');
 const { ACTIONS, authorizeAndResolve, authorizePath } = require('./authorizationService');
+const { getSharesForSourceTargets, deleteSharesByIds } = require('./sharesService');
 
 const copyEntry = async (sourcePath, destinationPath, isDirectory) => {
   if (isDirectory) {
@@ -134,16 +135,33 @@ const transferItems = async (items, destination, operation, options = {}) => {
   return { destination: destinationRelative, items: results };
 };
 
-const deleteItems = async (items = [], options = {}) => {
+const getShareSourceTarget = (resolved, includeChildren = false) => {
+  if (!resolved) return null;
+
+  if (resolved.userVolume) {
+    const sourcePath = resolved.innerRelativePath
+      ? `${resolved.userVolume.id}/${resolved.innerRelativePath}`
+      : resolved.userVolume.id;
+    return {
+      sourceSpace: 'user_volume',
+      sourcePath,
+      includeChildren,
+    };
+  }
+
+  return {
+    sourceSpace: resolved.space || 'volume',
+    sourcePath: resolved.innerRelativePath || resolved.relativePath || '',
+    includeChildren,
+  };
+};
+
+const resolveDeleteTargets = async (items = [], context) => {
   if (!Array.isArray(items) || items.length === 0) {
     throw new Error('At least one item is required.');
   }
 
-  const results = [];
-  const context = {
-    user: options.user || null,
-    guestSession: options.guestSession || null,
-  };
+  const targets = [];
 
   for (const item of items) {
     const combined = combineRelativePath(item.path || '', item.name);
@@ -157,15 +175,70 @@ const deleteItems = async (items = [], options = {}) => {
     }
 
     const { relativePath, absolutePath } = resolved;
+    const exists = await pathExists(absolutePath);
+    const stats = exists ? await fs.stat(absolutePath) : null;
+    const isDirectory = stats ? stats.isDirectory() : item?.kind === 'directory';
 
-    if (!(await pathExists(absolutePath))) {
+    targets.push({
+      item,
+      relativePath,
+      absolutePath,
+      exists,
+      stats,
+      isDirectory,
+      shareSourceTarget: getShareSourceTarget(resolved, isDirectory),
+    });
+  }
+
+  return targets;
+};
+
+const getDeleteImpact = async (items = [], options = {}) => {
+  const context = {
+    user: options.user || null,
+    guestSession: options.guestSession || null,
+  };
+  const targets = await resolveDeleteTargets(items, context);
+  const shares = await getSharesForSourceTargets(
+    targets.map((target) => target.shareSourceTarget).filter(Boolean)
+  );
+
+  return {
+    shareCount: shares.length,
+    shares,
+  };
+};
+
+const deleteItems = async (items = [], options = {}) => {
+  const results = [];
+  const context = {
+    user: options.user || null,
+    guestSession: options.guestSession || null,
+  };
+  const targets = await resolveDeleteTargets(items, context);
+
+  for (const target of targets) {
+    const { relativePath, absolutePath, exists, stats, isDirectory, shareSourceTarget } = target;
+    const affectedShares = shareSourceTarget
+      ? await getSharesForSourceTargets([shareSourceTarget])
+      : [];
+
+    if (!exists) {
+      const deletedShareCount = await deleteSharesByIds(affectedShares.map((share) => share.id));
       results.push({ path: relativePath, status: 'missing' });
+      if (deletedShareCount > 0) {
+        results[results.length - 1].deletedShareCount = deletedShareCount;
+      }
       continue;
     }
 
-    const stats = await fs.stat(absolutePath);
-    await fs.rm(absolutePath, { recursive: stats.isDirectory(), force: true });
-    results.push({ path: relativePath, status: 'deleted' });
+    await fs.rm(absolutePath, { recursive: isDirectory || stats.isDirectory(), force: true });
+    const deletedShareCount = await deleteSharesByIds(affectedShares.map((share) => share.id));
+    results.push({
+      path: relativePath,
+      status: 'deleted',
+      ...(deletedShareCount > 0 ? { deletedShareCount } : {}),
+    });
   }
 
   return results;
@@ -173,5 +246,6 @@ const deleteItems = async (items = [], options = {}) => {
 
 module.exports = {
   transferItems,
+  getDeleteImpact,
   deleteItems,
 };

--- a/backend/src/services/sharesService.js
+++ b/backend/src/services/sharesService.js
@@ -363,6 +363,70 @@ const deleteShare = async (shareId) => {
   return result.changes > 0;
 };
 
+const normalizeShareSourcePath = (sourcePath = '') =>
+  String(sourcePath || '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+
+const escapeLikePattern = (value = '') => String(value).replace(/[\\%_]/g, '\\$&');
+
+const getSharesForSourceTargets = async (targets = []) => {
+  const normalizedTargets = (Array.isArray(targets) ? targets : [])
+    .map((target) => ({
+      sourceSpace: target?.sourceSpace,
+      sourcePath: normalizeShareSourcePath(target?.sourcePath),
+      includeChildren: Boolean(target?.includeChildren),
+    }))
+    .filter((target) => target.sourceSpace && target.sourcePath);
+
+  if (normalizedTargets.length === 0) {
+    return [];
+  }
+
+  const db = await getDb();
+  const sharesById = new Map();
+
+  const exactQuery = db.prepare('SELECT * FROM shares WHERE source_space = ? AND source_path = ?');
+  const childQuery = db.prepare(
+    "SELECT * FROM shares WHERE source_space = ? AND source_path LIKE ? ESCAPE '\\'"
+  );
+
+  for (const target of normalizedTargets) {
+    const exactRows = exactQuery.all(target.sourceSpace, target.sourcePath);
+    exactRows.forEach((row) => sharesById.set(row.id, row));
+
+    if (target.includeChildren) {
+      const childRows = childQuery.all(
+        target.sourceSpace,
+        `${escapeLikePattern(target.sourcePath)}/%`
+      );
+      childRows.forEach((row) => sharesById.set(row.id, row));
+    }
+  }
+
+  return Array.from(sharesById.values()).map(toClientShare);
+};
+
+const deleteSharesByIds = async (shareIds = []) => {
+  const uniqueIds = [...new Set((Array.isArray(shareIds) ? shareIds : []).filter(Boolean))];
+  if (uniqueIds.length === 0) {
+    return 0;
+  }
+
+  const db = await getDb();
+  const deleteOne = db.prepare('DELETE FROM shares WHERE id = ?');
+  const transaction = db.transaction((ids) => {
+    let changes = 0;
+    ids.forEach((id) => {
+      changes += deleteOne.run(id).changes;
+    });
+    return changes;
+  });
+
+  return transaction(uniqueIds);
+};
+
 /**
  * Verify share password
  */
@@ -494,9 +558,11 @@ module.exports = {
   getShareById,
   getShareByToken,
   getSharesByOwnerId,
+  getSharesForSourceTargets,
   getSharesForUser,
   updateShare,
   deleteShare,
+  deleteSharesByIds,
   verifySharePassword,
   hasUserPermission,
   isShareExpired,

--- a/backend/tests/routes/shares.test.js
+++ b/backend/tests/routes/shares.test.js
@@ -22,6 +22,8 @@ beforeAll(async () => {
       'src/utils/pathUtils',
       'src/middleware/errorHandler',
       'src/routes/shares',
+      'src/routes/files/delete',
+      'src/services/fileTransferService',
     ],
   });
 });
@@ -37,6 +39,7 @@ const buildApp = ({ user } = {}) => {
   clearModuleCache('src/config/index');
 
   const sharesRoutes = envContext.requireFresh('src/routes/shares');
+  const deleteRoutes = envContext.requireFresh('src/routes/files/delete');
   const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
 
   const app = express();
@@ -54,6 +57,7 @@ const buildApp = ({ user } = {}) => {
 
   app.use('/api/shares', sharesRoutes);
   app.use('/api/share', sharesRoutes);
+  app.use('/api', deleteRoutes);
   app.use(errorHandler);
   return app;
 };
@@ -202,6 +206,100 @@ describe('Shares Routes', () => {
       // Browse should be forbidden
       const browse = await request(app).get(`/api/share/${shareToken}/browse/`);
       expect(browse.status).toBe(403);
+    });
+  });
+
+  describe('Delete Cleanup', () => {
+    it('should report and remove linked shares when deleting a shared file', async () => {
+      const usersService = envContext.requireFresh('src/services/users');
+      const userVolumesService = envContext.requireFresh('src/services/userVolumesService');
+
+      const assignedRoot = path.join(envContext.tmpRoot, 'assigned-volume-delete-file');
+      await fs.mkdir(assignedRoot, { recursive: true });
+      await fs.writeFile(path.join(assignedRoot, 'shared.txt'), 'shared file');
+
+      const user = await usersService.createLocalUser({
+        email: 'delete-file@example.com',
+        username: 'delete-file',
+        displayName: 'Delete File',
+        password: 'secret123',
+        roles: ['user'],
+      });
+
+      await userVolumesService.addVolumeToUser({
+        userId: user.id,
+        label: 'DeleteFileVol',
+        volumePath: assignedRoot,
+        accessMode: 'readwrite',
+      });
+
+      const app = buildApp({ user });
+      const create = await request(app).post('/api/shares').send({
+        sourcePath: 'DeleteFileVol/shared.txt',
+        accessMode: 'readonly',
+        sharingType: 'anyone',
+      });
+
+      expect(create.status).toBe(201);
+
+      const items = [{ path: 'DeleteFileVol', name: 'shared.txt', kind: 'txt' }];
+      const impact = await request(app).post('/api/files/delete-impact').send({ items });
+      expect(impact.status).toBe(200);
+      expect(impact.body.shareCount).toBe(1);
+
+      const deleted = await request(app).delete('/api/files').send({ items });
+      expect(deleted.status).toBe(200);
+      expect(deleted.body.items[0].status).toBe('deleted');
+      expect(deleted.body.items[0].deletedShareCount).toBe(1);
+
+      const shareAfterDelete = await request(app).get(`/api/shares/${create.body.id}`);
+      expect(shareAfterDelete.status).toBe(404);
+    });
+
+    it('should remove shares inside a deleted folder tree', async () => {
+      const usersService = envContext.requireFresh('src/services/users');
+      const userVolumesService = envContext.requireFresh('src/services/userVolumesService');
+
+      const assignedRoot = path.join(envContext.tmpRoot, 'assigned-volume-delete-folder');
+      await fs.mkdir(path.join(assignedRoot, 'folder'), { recursive: true });
+      await fs.writeFile(path.join(assignedRoot, 'folder', 'nested.txt'), 'nested file');
+
+      const user = await usersService.createLocalUser({
+        email: 'delete-folder@example.com',
+        username: 'delete-folder',
+        displayName: 'Delete Folder',
+        password: 'secret123',
+        roles: ['user'],
+      });
+
+      await userVolumesService.addVolumeToUser({
+        userId: user.id,
+        label: 'DeleteFolderVol',
+        volumePath: assignedRoot,
+        accessMode: 'readwrite',
+      });
+
+      const app = buildApp({ user });
+      const create = await request(app).post('/api/shares').send({
+        sourcePath: 'DeleteFolderVol/folder/nested.txt',
+        accessMode: 'readonly',
+        sharingType: 'anyone',
+      });
+
+      expect(create.status).toBe(201);
+
+      const items = [{ path: 'DeleteFolderVol', name: 'folder', kind: 'directory' }];
+      const impact = await request(app).post('/api/files/delete-impact').send({ items });
+      expect(impact.status).toBe(200);
+      expect(impact.body.shareCount).toBe(1);
+
+      const deleted = await request(app).delete('/api/files').send({ items });
+      expect(deleted.status).toBe(200);
+      expect(deleted.body.items[0].status).toBe('deleted');
+      expect(deleted.body.items[0].deletedShareCount).toBe(1);
+
+      const shareAfterDelete = await request(app).get(`/api/shares/${create.body.id}`);
+      expect(shareAfterDelete.status).toBe(404);
     });
   });
 

--- a/backend/tests/routes/shares.test.js
+++ b/backend/tests/routes/shares.test.js
@@ -245,7 +245,15 @@ describe('Shares Routes', () => {
       expect(direct.status).toBe(200);
       expect(direct.headers['content-disposition']).toContain('inline');
       expect(direct.headers['content-disposition']).toContain('hello.txt');
-      expect(Buffer.from(direct.body).toString()).toBe('hello direct link');
+      expect(direct.text).toBe('hello direct link');
+
+      const download = await request(publicApp).get(
+        `/api/share/${create.body.shareToken}/file?mode=download`
+      );
+
+      expect(download.status).toBe(200);
+      expect(download.headers['content-disposition']).toContain('attachment');
+      expect(download.headers['content-disposition']).toContain('hello.txt');
     });
 
     it('should redirect a password-protected direct file until the password is verified', async () => {
@@ -301,15 +309,16 @@ describe('Shares Routes', () => {
         .set('X-Guest-Session', verify.body.guestSessionId);
 
       expect(directAfterPassword.status).toBe(200);
-      expect(Buffer.from(directAfterPassword.body).toString()).toBe('protected direct link');
+      expect(directAfterPassword.text).toBe('protected direct link');
     });
 
-    it('should redirect direct links that resolve to directories back to the share flow', async () => {
+    it('should stream direct directory links as ZIP downloads', async () => {
       const usersService = envContext.requireFresh('src/services/users');
       const userVolumesService = envContext.requireFresh('src/services/userVolumesService');
 
       const assignedRoot = path.join(envContext.tmpRoot, 'assigned-volume-direct-folder');
       await fs.mkdir(path.join(assignedRoot, 'folder'), { recursive: true });
+      await fs.writeFile(path.join(assignedRoot, 'folder', 'nested.txt'), 'nested file');
 
       const user = await usersService.createLocalUser({
         email: 'direct-folder@example.com',
@@ -334,13 +343,55 @@ describe('Shares Routes', () => {
       });
 
       expect(create.status).toBe(201);
-      expect(create.body.directFileUrl).toBeNull();
+      expect(create.body.directFileUrl).toContain(`/api/share/${create.body.shareToken}/file`);
 
       const publicApp = buildApp();
       const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}/file`);
 
-      expect(direct.status).toBe(302);
-      expect(direct.headers.location).toContain(`/share/${create.body.shareToken}`);
+      expect(direct.status).toBe(200);
+      expect(direct.headers['content-type']).toContain('application/zip');
+      expect(direct.headers['content-disposition']).toContain('attachment');
+      expect(direct.headers['content-disposition']).toContain('folder.zip');
+    });
+
+    it('should force binary direct links to download in automatic mode', async () => {
+      const usersService = envContext.requireFresh('src/services/users');
+      const userVolumesService = envContext.requireFresh('src/services/userVolumesService');
+
+      const assignedRoot = path.join(envContext.tmpRoot, 'assigned-volume-direct-binary');
+      await fs.mkdir(assignedRoot, { recursive: true });
+      await fs.writeFile(path.join(assignedRoot, 'archive.zip'), Buffer.from('fake zip payload'));
+
+      const user = await usersService.createLocalUser({
+        email: 'direct-binary@example.com',
+        username: 'direct-binary',
+        displayName: 'Direct Binary',
+        password: 'secret123',
+        roles: ['user'],
+      });
+
+      await userVolumesService.addVolumeToUser({
+        userId: user.id,
+        label: 'DirectBinaryVol',
+        volumePath: assignedRoot,
+        accessMode: 'readwrite',
+      });
+
+      const ownerApp = buildApp({ user });
+      const create = await request(ownerApp).post('/api/shares').send({
+        sourcePath: 'DirectBinaryVol/archive.zip',
+        accessMode: 'readonly',
+        sharingType: 'anyone',
+      });
+
+      expect(create.status).toBe(201);
+
+      const publicApp = buildApp();
+      const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}/file`);
+
+      expect(direct.status).toBe(200);
+      expect(direct.headers['content-disposition']).toContain('attachment');
+      expect(direct.headers['content-disposition']).toContain('archive.zip');
     });
 
     it('should reject direct file access for expired shares', async () => {

--- a/backend/tests/routes/shares.test.js
+++ b/backend/tests/routes/shares.test.js
@@ -18,6 +18,7 @@ beforeAll(async () => {
       'src/services/users',
       'src/services/userVolumesService',
       'src/services/sharesService',
+      'src/services/guestSessionService',
       'src/utils/pathUtils',
       'src/middleware/errorHandler',
       'src/routes/shares',
@@ -41,8 +42,13 @@ const buildApp = ({ user } = {}) => {
   const app = express();
   app.use(express.json());
 
-  app.use((req, _res, next) => {
+  app.use(async (req, _res, next) => {
     if (user) req.user = user;
+    const guestSessionId = req.headers['x-guest-session'];
+    if (guestSessionId) {
+      const { getGuestSession } = envContext.requireFresh('src/services/guestSessionService');
+      req.guestSession = await getGuestSession(guestSessionId);
+    }
     next();
   });
 
@@ -82,13 +88,11 @@ describe('Shares Routes', () => {
 
       const app = buildApp({ user });
 
-      const create = await request(app)
-        .post('/api/shares')
-        .send({
-          sourcePath: 'MyVol/myfolder',
-          accessMode: 'readonly',
-          sharingType: 'anyone',
-        });
+      const create = await request(app).post('/api/shares').send({
+        sourcePath: 'MyVol/myfolder',
+        accessMode: 'readonly',
+        sharingType: 'anyone',
+      });
 
       expect(create.status).toBe(201);
       expect(create.body.shareToken).toBeDefined();
@@ -198,6 +202,191 @@ describe('Shares Routes', () => {
       // Browse should be forbidden
       const browse = await request(app).get(`/api/share/${shareToken}/browse/`);
       expect(browse.status).toBe(403);
+    });
+  });
+
+  describe('Direct File Links', () => {
+    it('should stream an anyone-with-link file share without a prior guest session', async () => {
+      const usersService = envContext.requireFresh('src/services/users');
+      const userVolumesService = envContext.requireFresh('src/services/userVolumesService');
+
+      const assignedRoot = path.join(envContext.tmpRoot, 'assigned-volume-direct-public');
+      await fs.mkdir(assignedRoot, { recursive: true });
+      await fs.writeFile(path.join(assignedRoot, 'hello.txt'), 'hello direct link');
+
+      const user = await usersService.createLocalUser({
+        email: 'direct-public@example.com',
+        username: 'direct-public',
+        displayName: 'Direct Public',
+        password: 'secret123',
+        roles: ['user'],
+      });
+
+      await userVolumesService.addVolumeToUser({
+        userId: user.id,
+        label: 'DirectPublicVol',
+        volumePath: assignedRoot,
+        accessMode: 'readwrite',
+      });
+
+      const ownerApp = buildApp({ user });
+      const create = await request(ownerApp).post('/api/shares').send({
+        sourcePath: 'DirectPublicVol/hello.txt',
+        accessMode: 'readonly',
+        sharingType: 'anyone',
+      });
+
+      expect(create.status).toBe(201);
+      expect(create.body.directFileUrl).toContain(`/api/share/${create.body.shareToken}/file`);
+
+      const publicApp = buildApp();
+      const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}/file`);
+
+      expect(direct.status).toBe(200);
+      expect(direct.headers['content-disposition']).toContain('inline');
+      expect(direct.headers['content-disposition']).toContain('hello.txt');
+      expect(Buffer.from(direct.body).toString()).toBe('hello direct link');
+    });
+
+    it('should redirect a password-protected direct file until the password is verified', async () => {
+      const usersService = envContext.requireFresh('src/services/users');
+      const userVolumesService = envContext.requireFresh('src/services/userVolumesService');
+
+      const assignedRoot = path.join(envContext.tmpRoot, 'assigned-volume-direct-password');
+      await fs.mkdir(assignedRoot, { recursive: true });
+      await fs.writeFile(path.join(assignedRoot, 'secret.txt'), 'protected direct link');
+
+      const user = await usersService.createLocalUser({
+        email: 'direct-password@example.com',
+        username: 'direct-password',
+        displayName: 'Direct Password',
+        password: 'secret123',
+        roles: ['user'],
+      });
+
+      await userVolumesService.addVolumeToUser({
+        userId: user.id,
+        label: 'DirectPasswordVol',
+        volumePath: assignedRoot,
+        accessMode: 'readwrite',
+      });
+
+      const ownerApp = buildApp({ user });
+      const create = await request(ownerApp).post('/api/shares').send({
+        sourcePath: 'DirectPasswordVol/secret.txt',
+        accessMode: 'readonly',
+        sharingType: 'anyone',
+        password: 'open-sesame',
+      });
+
+      expect(create.status).toBe(201);
+
+      const publicApp = buildApp();
+      const directBeforePassword = await request(publicApp).get(
+        `/api/share/${create.body.shareToken}/file`
+      );
+      expect(directBeforePassword.status).toBe(302);
+      expect(directBeforePassword.headers.location).toContain(`/share/${create.body.shareToken}`);
+      expect(directBeforePassword.headers.location).toContain('redirect=');
+
+      const verify = await request(publicApp)
+        .post(`/api/share/${create.body.shareToken}/verify`)
+        .send({ password: 'open-sesame' });
+
+      expect(verify.status).toBe(200);
+      expect(verify.body.guestSessionId).toBeDefined();
+
+      const directAfterPassword = await request(publicApp)
+        .get(`/api/share/${create.body.shareToken}/file`)
+        .set('X-Guest-Session', verify.body.guestSessionId);
+
+      expect(directAfterPassword.status).toBe(200);
+      expect(Buffer.from(directAfterPassword.body).toString()).toBe('protected direct link');
+    });
+
+    it('should redirect direct links that resolve to directories back to the share flow', async () => {
+      const usersService = envContext.requireFresh('src/services/users');
+      const userVolumesService = envContext.requireFresh('src/services/userVolumesService');
+
+      const assignedRoot = path.join(envContext.tmpRoot, 'assigned-volume-direct-folder');
+      await fs.mkdir(path.join(assignedRoot, 'folder'), { recursive: true });
+
+      const user = await usersService.createLocalUser({
+        email: 'direct-folder@example.com',
+        username: 'direct-folder',
+        displayName: 'Direct Folder',
+        password: 'secret123',
+        roles: ['user'],
+      });
+
+      await userVolumesService.addVolumeToUser({
+        userId: user.id,
+        label: 'DirectFolderVol',
+        volumePath: assignedRoot,
+        accessMode: 'readwrite',
+      });
+
+      const ownerApp = buildApp({ user });
+      const create = await request(ownerApp).post('/api/shares').send({
+        sourcePath: 'DirectFolderVol/folder',
+        accessMode: 'readonly',
+        sharingType: 'anyone',
+      });
+
+      expect(create.status).toBe(201);
+      expect(create.body.directFileUrl).toBeNull();
+
+      const publicApp = buildApp();
+      const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}/file`);
+
+      expect(direct.status).toBe(302);
+      expect(direct.headers.location).toContain(`/share/${create.body.shareToken}`);
+    });
+
+    it('should reject direct file access for expired shares', async () => {
+      const usersService = envContext.requireFresh('src/services/users');
+      const userVolumesService = envContext.requireFresh('src/services/userVolumesService');
+
+      const assignedRoot = path.join(envContext.tmpRoot, 'assigned-volume-direct-expired');
+      await fs.mkdir(assignedRoot, { recursive: true });
+      await fs.writeFile(path.join(assignedRoot, 'expired.txt'), 'expired direct link');
+
+      const user = await usersService.createLocalUser({
+        email: 'direct-expired@example.com',
+        username: 'direct-expired',
+        displayName: 'Direct Expired',
+        password: 'secret123',
+        roles: ['user'],
+      });
+
+      await userVolumesService.addVolumeToUser({
+        userId: user.id,
+        label: 'DirectExpiredVol',
+        volumePath: assignedRoot,
+        accessMode: 'readwrite',
+      });
+
+      const app = buildApp({ user });
+      const create = await request(app)
+        .post('/api/shares')
+        .send({
+          sourcePath: 'DirectExpiredVol/expired.txt',
+          accessMode: 'readonly',
+          sharingType: 'anyone',
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        });
+
+      expect(create.status).toBe(201);
+
+      const updateResponse = await request(app)
+        .put(`/api/shares/${create.body.id}`)
+        .send({ expiresAt: '2000-01-01T00:00:00.000Z' });
+      expect(updateResponse.status).toBe(200);
+
+      const publicApp = buildApp();
+      const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}/file`);
+
+      expect(direct.status).toBe(403);
     });
   });
 });

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -38,6 +38,13 @@ async function deleteItems(items) {
   });
 }
 
+async function getDeleteImpact(items) {
+  return requestJson('/api/files/delete-impact', {
+    method: 'POST',
+    body: JSON.stringify({ items }),
+  });
+}
+
 async function createFolder(destination, name) {
   const normalizedDestination = normalizePath(destination || '');
   const payload = { path: normalizedDestination };
@@ -214,6 +221,7 @@ export {
   copyItems,
   moveItems,
   deleteItems,
+  getDeleteImpact,
   createFolder,
   renameItem,
   fetchFileContent,

--- a/frontend/src/api/shares.api.js
+++ b/frontend/src/api/shares.api.js
@@ -139,26 +139,50 @@ function getShareUrl(shareToken) {
 }
 
 /**
+ * Generate direct shared file URL for a token and optional inner path
+ */
+function getDirectShareFileUrl(shareToken, innerPath = '') {
+  const baseUrl = window.location.origin;
+  const encodedToken = encodeURIComponent(shareToken);
+  const normalizedInnerPath = normalizePath(innerPath);
+  const encodedInnerPath = encodePath(normalizedInnerPath);
+  return encodedInnerPath
+    ? `${baseUrl}/api/share/${encodedToken}/file/${encodedInnerPath}`
+    : `${baseUrl}/api/share/${encodedToken}/file`;
+}
+
+const writeToClipboard = async (value) => {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    await navigator.clipboard.writeText(value);
+    return true;
+  }
+
+  // Fallback for older browsers
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const success = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  return success;
+};
+
+/**
  * Copy share URL to clipboard
  */
 async function copyShareUrl(shareToken) {
   const url = getShareUrl(shareToken);
+  return writeToClipboard(url);
+}
 
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    await navigator.clipboard.writeText(url);
-    return true;
-  } else {
-    // Fallback for older browsers
-    const textarea = document.createElement('textarea');
-    textarea.value = url;
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
-    textarea.select();
-    const success = document.execCommand('copy');
-    document.body.removeChild(textarea);
-    return success;
-  }
+/**
+ * Copy direct shared file URL to clipboard
+ */
+async function copyDirectShareFileUrl(shareToken, innerPath = '') {
+  const url = getDirectShareFileUrl(shareToken, innerPath);
+  return writeToClipboard(url);
 }
 
 export {
@@ -176,5 +200,7 @@ export {
   getGuestSession,
   clearGuestSession,
   getShareUrl,
+  getDirectShareFileUrl,
   copyShareUrl,
+  copyDirectShareFileUrl,
 };

--- a/frontend/src/api/shares.api.js
+++ b/frontend/src/api/shares.api.js
@@ -138,17 +138,31 @@ function getShareUrl(shareToken) {
   return `${baseUrl}/share/${shareToken}`;
 }
 
+const DIRECT_SHARE_FILE_MODES = [
+  { value: 'auto', labelKey: 'share.directLinkModes.auto', fallback: 'Auto' },
+  { value: 'inline', labelKey: 'share.directLinkModes.inline', fallback: 'View' },
+  { value: 'raw', labelKey: 'share.directLinkModes.raw', fallback: 'Raw' },
+  { value: 'download', labelKey: 'share.directLinkModes.download', fallback: 'Download' },
+];
+
+function normalizeDirectShareFileMode(mode) {
+  const value = typeof mode === 'string' ? mode.toLowerCase() : 'auto';
+  return DIRECT_SHARE_FILE_MODES.some((item) => item.value === value) ? value : 'auto';
+}
+
 /**
  * Generate direct shared file URL for a token and optional inner path
  */
-function getDirectShareFileUrl(shareToken, innerPath = '') {
+function getDirectShareFileUrl(shareToken, innerPath = '', mode = 'auto') {
   const baseUrl = window.location.origin;
   const encodedToken = encodeURIComponent(shareToken);
   const normalizedInnerPath = normalizePath(innerPath);
   const encodedInnerPath = encodePath(normalizedInnerPath);
-  return encodedInnerPath
+  const url = encodedInnerPath
     ? `${baseUrl}/api/share/${encodedToken}/file/${encodedInnerPath}`
     : `${baseUrl}/api/share/${encodedToken}/file`;
+  const normalizedMode = normalizeDirectShareFileMode(mode);
+  return normalizedMode === 'auto' ? url : `${url}?mode=${encodeURIComponent(normalizedMode)}`;
 }
 
 const writeToClipboard = async (value) => {
@@ -180,8 +194,8 @@ async function copyShareUrl(shareToken) {
 /**
  * Copy direct shared file URL to clipboard
  */
-async function copyDirectShareFileUrl(shareToken, innerPath = '') {
-  const url = getDirectShareFileUrl(shareToken, innerPath);
+async function copyDirectShareFileUrl(shareToken, innerPath = '', mode = 'auto') {
+  const url = getDirectShareFileUrl(shareToken, innerPath, mode);
   return writeToClipboard(url);
 }
 
@@ -200,6 +214,7 @@ export {
   getGuestSession,
   clearGuestSession,
   getShareUrl,
+  DIRECT_SHARE_FILE_MODES,
   getDirectShareFileUrl,
   copyShareUrl,
   copyDirectShareFileUrl,

--- a/frontend/src/components/ExplorerContextMenu.vue
+++ b/frontend/src/components/ExplorerContextMenu.vue
@@ -128,7 +128,21 @@ const deleteDialogMessage = computed(() => {
   return t('context.deleteMessage.generic');
 });
 
-const { isDeleteConfirmOpen, isDeleting, requestDelete, confirmDelete } = useDeleteConfirm();
+const {
+  isDeleteConfirmOpen,
+  isDeleting,
+  isLoadingDeleteImpact,
+  deleteImpact,
+  deleteImpactError,
+  requestDelete,
+  confirmDelete,
+} = useDeleteConfirm();
+
+const deleteShareImpactMessage = computed(() => {
+  const count = Number(deleteImpact.value?.shareCount || 0);
+  if (count <= 0) return '';
+  return t('context.deleteLinkedShares', { count });
+});
 
 const closeMenu = () => {
   isOpen.value = false;
@@ -586,6 +600,18 @@ provide(explorerContextMenuSymbol, {
     <template #title>{{ deleteDialogTitle }}</template>
     <p class="mb-6 text-base text-zinc-700 dark:text-zinc-200">
       {{ deleteDialogMessage }}
+    </p>
+    <p v-if="isLoadingDeleteImpact" class="-mt-3 mb-6 text-sm text-zinc-500 dark:text-zinc-400">
+      {{ $t('context.checkingDeleteImpact') }}
+    </p>
+    <p
+      v-else-if="deleteShareImpactMessage"
+      class="-mt-3 mb-6 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700/60 dark:bg-amber-900/20 dark:text-amber-100"
+    >
+      {{ deleteShareImpactMessage }}
+    </p>
+    <p v-else-if="deleteImpactError" class="-mt-3 mb-6 text-sm text-amber-700 dark:text-amber-300">
+      {{ $t('context.deleteImpactUnavailable') }}
     </p>
     <div class="flex justify-end gap-3">
       <button

--- a/frontend/src/components/ShareDialog.vue
+++ b/frontend/src/components/ShareDialog.vue
@@ -4,7 +4,7 @@ import { useI18n } from 'vue-i18n';
 import { useAppSettings } from '@/stores/appSettings';
 import { calculateExpirationDate } from '@/utils/datetime';
 import ModalDialog from '@/components/ModalDialog.vue';
-import { createShare, copyShareUrl } from '@/api/shares.api';
+import { createShare, copyDirectShareFileUrl, copyShareUrl } from '@/api/shares.api';
 import { fetchShareableUsers } from '@/api/users.api';
 import flatpickr from 'flatpickr';
 import 'flatpickr/dist/flatpickr.min.css';
@@ -48,6 +48,7 @@ const isCreating = ref(false);
 const error = ref('');
 const shareResult = ref(null);
 const linkCopied = ref(false);
+const directLinkCopied = ref(false);
 const availableUsers = ref([]);
 const loadingUsers = ref(false);
 const expiresAtInputRef = ref(null);
@@ -106,6 +107,7 @@ function resetForm() {
   error.value = '';
   shareResult.value = null;
   linkCopied.value = false;
+  directLinkCopied.value = false;
 }
 
 function destroyExpiresPicker() {
@@ -245,6 +247,20 @@ async function copyLink() {
   }
 }
 
+async function copyDirectLink() {
+  if (!shareResult.value?.shareToken || shareResult.value?.isDirectory) return;
+
+  try {
+    await copyDirectShareFileUrl(shareResult.value.shareToken);
+    directLinkCopied.value = true;
+    setTimeout(() => {
+      directLinkCopied.value = false;
+    }, 2000);
+  } catch (err) {
+    console.error('Failed to copy direct file link:', err);
+  }
+}
+
 function closeDialog() {
   isOpen.value = false;
 }
@@ -281,6 +297,28 @@ function closeDialog() {
             :class="linkCopied ? 'bg-green-600' : 'bg-blue-600 hover:bg-blue-700'"
           >
             <ClipboardDocumentIcon v-if="!linkCopied" class="w-5 h-5" />
+            <CheckIcon v-else class="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+
+      <div v-if="!shareResult.isDirectory">
+        <label class="block mb-2 text-sm font-medium">
+          {{ t('share.directFileLink', 'Direct file link') }}
+        </label>
+        <div class="flex gap-2">
+          <input
+            type="text"
+            :value="shareResult.directFileUrl"
+            readonly
+            class="flex-1 px-3 py-2 text-sm border rounded-lg bg-gray-50 dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button
+            @click="copyDirectLink"
+            class="px-4 py-2 text-sm font-medium text-white transition rounded-lg"
+            :class="directLinkCopied ? 'bg-green-600' : 'bg-blue-600 hover:bg-blue-700'"
+          >
+            <ClipboardDocumentIcon v-if="!directLinkCopied" class="w-5 h-5" />
             <CheckIcon v-else class="w-5 h-5" />
           </button>
         </div>

--- a/frontend/src/components/ShareDialog.vue
+++ b/frontend/src/components/ShareDialog.vue
@@ -4,7 +4,13 @@ import { useI18n } from 'vue-i18n';
 import { useAppSettings } from '@/stores/appSettings';
 import { calculateExpirationDate } from '@/utils/datetime';
 import ModalDialog from '@/components/ModalDialog.vue';
-import { createShare, copyDirectShareFileUrl, copyShareUrl } from '@/api/shares.api';
+import {
+  createShare,
+  copyDirectShareFileUrl,
+  copyShareUrl,
+  DIRECT_SHARE_FILE_MODES,
+  getDirectShareFileUrl,
+} from '@/api/shares.api';
 import { fetchShareableUsers } from '@/api/users.api';
 import flatpickr from 'flatpickr';
 import 'flatpickr/dist/flatpickr.min.css';
@@ -49,6 +55,7 @@ const error = ref('');
 const shareResult = ref(null);
 const linkCopied = ref(false);
 const directLinkCopied = ref(false);
+const directLinkMode = ref('auto');
 const availableUsers = ref([]);
 const loadingUsers = ref(false);
 const expiresAtInputRef = ref(null);
@@ -60,6 +67,16 @@ const sourcePath = computed(() => {
   if (!props.item) return '';
   const parentPath = props.item.path || '';
   return parentPath ? `${parentPath}/${props.item.name}` : props.item.name;
+});
+const directLinkModeOptions = computed(() =>
+  DIRECT_SHARE_FILE_MODES.map((mode) => ({
+    ...mode,
+    label: t(mode.labelKey, mode.fallback),
+  }))
+);
+const directShareUrl = computed(() => {
+  if (!shareResult.value?.shareToken) return '';
+  return getDirectShareFileUrl(shareResult.value.shareToken, '', directLinkMode.value);
 });
 
 // Reset form when dialog opens/closes
@@ -108,6 +125,7 @@ function resetForm() {
   shareResult.value = null;
   linkCopied.value = false;
   directLinkCopied.value = false;
+  directLinkMode.value = 'auto';
 }
 
 function destroyExpiresPicker() {
@@ -248,10 +266,10 @@ async function copyLink() {
 }
 
 async function copyDirectLink() {
-  if (!shareResult.value?.shareToken || shareResult.value?.isDirectory) return;
+  if (!shareResult.value?.shareToken) return;
 
   try {
-    await copyDirectShareFileUrl(shareResult.value.shareToken);
+    await copyDirectShareFileUrl(shareResult.value.shareToken, '', directLinkMode.value);
     directLinkCopied.value = true;
     setTimeout(() => {
       directLinkCopied.value = false;
@@ -302,14 +320,29 @@ function closeDialog() {
         </div>
       </div>
 
-      <div v-if="!shareResult.isDirectory">
-        <label class="block mb-2 text-sm font-medium">
-          {{ t('share.directFileLink', 'Direct file link') }}
-        </label>
+      <div>
+        <div class="flex items-center justify-between gap-3 mb-2">
+          <label class="block text-sm font-medium">
+            {{
+              shareResult.isDirectory
+                ? t('share.directFolderLink', 'Direct folder ZIP link')
+                : t('share.directFileLink', 'Direct file link')
+            }}
+          </label>
+          <select
+            v-model="directLinkMode"
+            class="px-2 py-1 text-xs border rounded-md bg-white dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            :title="t('share.directLinkMode', 'Direct link mode')"
+          >
+            <option v-for="mode in directLinkModeOptions" :key="mode.value" :value="mode.value">
+              {{ mode.label }}
+            </option>
+          </select>
+        </div>
         <div class="flex gap-2">
           <input
             type="text"
-            :value="shareResult.directFileUrl"
+            :value="directShareUrl"
             readonly
             class="flex-1 px-3 py-2 text-sm border rounded-lg bg-gray-50 dark:bg-zinc-800 border-zinc-300 dark:border-zinc-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />

--- a/frontend/src/composables/useDeleteConfirm.js
+++ b/frontend/src/composables/useDeleteConfirm.js
@@ -1,5 +1,6 @@
 import { ref } from 'vue';
 import { useFileActions } from '@/composables/fileActions';
+import { getDeleteImpact, normalizePath } from '@/api';
 
 // Singleton instance so multiple callers share the same modal state
 let instance = null;
@@ -11,10 +12,41 @@ export function useDeleteConfirm() {
 
   const isDeleteConfirmOpen = ref(false);
   const isDeleting = ref(false);
+  const isLoadingDeleteImpact = ref(false);
+  const deleteImpact = ref({ shareCount: 0, shares: [] });
+  const deleteImpactError = ref('');
+
+  const serializeSelectedItems = () =>
+    actions.selectedItems.value
+      .filter((item) => item && item.name && item.kind !== 'volume')
+      .map((item) => ({
+        name: item.name,
+        path: normalizePath(item.path || ''),
+        kind: item.kind,
+      }));
+
+  const loadDeleteImpact = async () => {
+    deleteImpact.value = { shareCount: 0, shares: [] };
+    deleteImpactError.value = '';
+
+    const payload = serializeSelectedItems();
+    if (payload.length === 0) return;
+
+    isLoadingDeleteImpact.value = true;
+    try {
+      deleteImpact.value = await getDeleteImpact(payload);
+    } catch (err) {
+      console.error('Failed to load delete impact', err);
+      deleteImpactError.value = err?.message || 'Failed to check linked shares.';
+    } finally {
+      isLoadingDeleteImpact.value = false;
+    }
+  };
 
   const openDeleteConfirm = () => {
     if (!actions.canDelete.value) return;
     isDeleteConfirmOpen.value = true;
+    loadDeleteImpact();
   };
 
   const closeDeleteConfirm = () => {
@@ -31,6 +63,7 @@ export function useDeleteConfirm() {
     try {
       await actions.deleteNow();
       isDeleteConfirmOpen.value = false;
+      deleteImpact.value = { shareCount: 0, shares: [] };
     } catch (err) {
       console.error('Delete operation failed', err);
     } finally {
@@ -41,6 +74,9 @@ export function useDeleteConfirm() {
   instance = {
     isDeleteConfirmOpen,
     isDeleting,
+    isLoadingDeleteImpact,
+    deleteImpact,
+    deleteImpactError,
     openDeleteConfirm,
     closeDeleteConfirm,
     requestDelete,

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -540,6 +540,7 @@
     "shareLink": "Share Link",
     "directFileLink": "Direct file link",
     "directFolderLink": "Direct folder ZIP link",
+    "copyShareLink": "Copy share link",
     "directLinkMode": "Direct link mode",
     "copyDirectFileLink": "Copy direct file link",
     "copyDirectFolderLink": "Copy direct folder ZIP link",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -72,8 +72,8 @@
     "readwrite": "Read/Write"
   },
   "editor": {
-    "editing":"Editing",
-    "unsavedChanges":"Unsaved changes",
+    "editing": "Editing",
+    "unsavedChanges": "Unsaved changes",
     "theme": "Theme",
     "editorSettings": "Editor settings",
     "wrapLines": "Wrap Lines",
@@ -535,6 +535,17 @@
     "shareCreated": "Share Created",
     "createShareLink": "Create Share Link",
     "shareLink": "Share Link",
+    "directFileLink": "Direct file link",
+    "directFolderLink": "Direct folder ZIP link",
+    "directLinkMode": "Direct link mode",
+    "copyDirectFileLink": "Copy direct file link",
+    "copyDirectFolderLink": "Copy direct folder ZIP link",
+    "directLinkModes": {
+      "auto": "Auto",
+      "inline": "View",
+      "raw": "Raw",
+      "download": "Download"
+    },
     "shareLinkCreatedSuccess": "Share link created successfully!",
     "access": "Access Mode",
     "type": "Target",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -226,7 +226,10 @@
       "single": "Are you sure you want to delete \"{name}\"? This action cannot be undone.",
       "multiple": "Are you sure you want to delete these {count} items? This action cannot be undone.",
       "generic": "No items selected."
-    }
+    },
+    "checkingDeleteImpact": "Checking linked shares...",
+    "deleteImpactUnavailable": "Unable to check linked shares. Deletion will still be enforced by the server.",
+    "deleteLinkedShares": "This content has {count} linked share that will be removed with it. | This content has {count} linked shares that will be removed with it."
   },
   "folder": {
     "kind": "Kind",
@@ -593,6 +596,8 @@
     "noMySharesDescription": "Create a share from any file or folder to see it listed here.",
     "mySharesCount": "{count} active share links",
     "confirmDeleteShare": "Remove this share? People with the link will no longer have access.",
+    "deleteShareTitle": "Remove share?",
+    "deleteShareMessage": "People with this link will no longer be able to access the shared item.",
     "removeShare": "Remove share",
     "sharedWithAnyone": "Shared with anyone",
     "sharedWithUsers": "{count} user | {count} users"

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -226,7 +226,10 @@
       "single": "Voulez-vous vraiment supprimer \"{name}\" ? Cette action est irréversible.",
       "multiple": "Voulez-vous vraiment supprimer ces {count} éléments ? Cette action est irréversible.",
       "generic": "Aucun élément sélectionné."
-    }
+    },
+    "checkingDeleteImpact": "Vérification des partages associés...",
+    "deleteImpactUnavailable": "Impossible de vérifier les partages associés. La suppression restera contrôlée côté serveur.",
+    "deleteLinkedShares": "Ce contenu possède {count} lien de partage associé qui sera supprimé avec lui. | Ce contenu possède {count} liens de partage associés qui seront supprimés avec lui."
   },
   "folder": {
     "kind": "Type",
@@ -593,6 +596,8 @@
     "noMySharesDescription": "Créez un partage à partir de n'importe quel fichier ou dossier pour le voir apparaître ici.",
     "mySharesCount": "{count} liens de partage actifs",
     "confirmDeleteShare": "Supprimer ce partage ? Les personnes disposant du lien n'y auront plus accès.",
+    "deleteShareTitle": "Supprimer le partage ?",
+    "deleteShareMessage": "Les personnes disposant de ce lien ne pourront plus accéder à l’élément partagé.",
     "removeShare": "Supprimer le partage",
     "sharedWithAnyone": "Partagé avec tout le monde",
     "sharedWithUsers": "{count} utilisateur | {count} utilisateurs"

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -72,8 +72,8 @@
     "readwrite": "Lecture/Écriture"
   },
   "editor": {
-    "editing":"Editing",
-    "unsavedChanges":"Unsaved changes",
+    "editing": "Editing",
+    "unsavedChanges": "Unsaved changes",
     "theme": "Theme",
     "editorSettings": "Editor settings",
     "wrapLines": "Wrap Lines",
@@ -535,6 +535,17 @@
     "shareCreated": "Partage créé",
     "createShareLink": "Créer un lien de partage",
     "shareLink": "Lien de partage",
+    "directFileLink": "Lien direct du fichier",
+    "directFolderLink": "Lien direct ZIP du dossier",
+    "directLinkMode": "Mode du lien direct",
+    "copyDirectFileLink": "Copier le lien direct du fichier",
+    "copyDirectFolderLink": "Copier le lien direct ZIP du dossier",
+    "directLinkModes": {
+      "auto": "Auto",
+      "inline": "Visualiser",
+      "raw": "Raw",
+      "download": "Télécharger"
+    },
     "shareLinkCreatedSuccess": "Lien de partage créé avec succès !",
     "access": "Access Mode",
     "type": "Target",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -540,6 +540,7 @@
     "shareLink": "Lien de partage",
     "directFileLink": "Lien direct du fichier",
     "directFolderLink": "Lien direct ZIP du dossier",
+    "copyShareLink": "Copier le lien de partage",
     "directLinkMode": "Mode du lien direct",
     "copyDirectFileLink": "Copier le lien direct du fichier",
     "copyDirectFolderLink": "Copier le lien direct ZIP du dossier",

--- a/frontend/src/views/ShareLoginView.vue
+++ b/frontend/src/views/ShareLoginView.vue
@@ -35,6 +35,14 @@ const isExpired = computed(() => shareInfo.value?.isExpired || false);
 const requiresPassword = computed(() =>
   Boolean(shareInfo.value?.hasPassword && shareInfo.value?.sharingType === 'anyone')
 );
+const redirectTarget = computed(() => {
+  const value = route.query.redirect;
+  const target = Array.isArray(value) ? value[0] : value;
+  if (typeof target !== 'string' || !target.startsWith('/') || target.startsWith('//')) {
+    return null;
+  }
+  return target;
+});
 const expiryDate = computed(() => {
   if (!shareInfo.value?.expiresAt) return null;
   return new Date(shareInfo.value.expiresAt);
@@ -85,14 +93,23 @@ async function loadShareInfo() {
 async function handleUserAccess() {
   try {
     await accessShare(shareToken.value);
-    router.push({
-      name: 'FolderView',
-      params: { path: `share/${shareToken.value}` },
-    });
+    navigateAfterShareAccess();
   } catch (err) {
     logger.error({ err }, 'User access failed');
     error.value = err.message || 'Failed to access share';
   }
+}
+
+function navigateAfterShareAccess() {
+  if (redirectTarget.value) {
+    window.location.assign(redirectTarget.value);
+    return;
+  }
+
+  router.push({
+    name: 'FolderView',
+    params: { path: `share/${shareToken.value}` },
+  });
 }
 
 async function handleAutoAccess() {
@@ -107,14 +124,7 @@ async function handleAutoAccess() {
       setGuestSession(result.guestSessionId);
     }
 
-    const targetPath = `share/${shareToken.value}`;
-    logger.debug('Redirecting to FolderView with path', targetPath);
-
-    // Redirect to browse the share
-    router.push({
-      name: 'FolderView',
-      params: { path: targetPath },
-    });
+    navigateAfterShareAccess();
   } catch (err) {
     logger.error({ err }, 'Auto-access failed');
     error.value = err.message || 'Failed to access share';
@@ -142,20 +152,13 @@ async function handlePasswordSubmit() {
         setGuestSession(result.guestSessionId);
       }
 
-      const targetPath = `share/${shareToken.value}`;
-      logger.debug('Redirecting to FolderView with path', targetPath);
-
-      // Redirect to browse the share
-      router.push({
-        name: 'FolderView',
-        params: { path: targetPath },
-      });
+      navigateAfterShareAccess();
     } else if (result.requiresAuth) {
       // User-specific share with password - redirect to login
       logger.debug('Redirecting to login (requires auth)');
       router.push({
         name: 'auth-login',
-        query: { redirect: `/share/${shareToken.value}` },
+        query: { redirect: route.fullPath },
       });
     }
   } catch (err) {
@@ -302,7 +305,7 @@ async function handlePasswordSubmit() {
             @click="
               router.push({
                 name: 'auth-login',
-                query: { redirect: `/share/${shareToken}` },
+                query: { redirect: route.fullPath },
               })
             "
             class="w-full px-6 py-3 font-medium text-white transition bg-blue-600 rounded-lg hover:bg-blue-700"

--- a/frontend/src/views/SharedByMeView.vue
+++ b/frontend/src/views/SharedByMeView.vue
@@ -433,12 +433,13 @@ onMounted(async () => {
             </div>
 
             <!-- Actions -->
-            <div class="flex items-center justify-end gap-1">
+            <div class="flex items-center justify-end gap-1.5">
+              <!-- Copy the standard share-page link -->
               <button
                 @click.stop="handleCopyLink(share)"
                 :disabled="copyingId === share.id"
                 class="p-1.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
-                :title="t('actions.copy')"
+                :title="t('share.copyShareLink', 'Copy share link')"
               >
                 <component
                   :is="copiedId === share.id ? CheckIcon : ClipboardDocumentIcon"
@@ -446,12 +447,22 @@ onMounted(async () => {
                   :class="{ 'text-green-500': copiedId === share.id }"
                 />
               </button>
-              <div class="flex items-center gap-1">
+              <!--
+                Direct link control. The mode selector and the copy button are one
+                control (pick a mode, then copy the direct link in that mode), so
+                they live in a single segmented box with a shared border to signal
+                they belong together — instead of reading as two unrelated icons
+                next to the copy/delete buttons (issue #265).
+              -->
+              <div
+                class="flex items-center rounded-md border border-neutral-200 dark:border-neutral-700 overflow-hidden bg-white dark:bg-neutral-900 focus-within:ring-2 focus-within:ring-blue-500/40"
+              >
                 <select
                   v-model="directLinkModes[share.id]"
                   @click.stop
-                  class="w-20 px-1.5 py-1 text-xs rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-600 dark:text-neutral-300"
+                  class="w-[4.25rem] px-1.5 py-1 text-xs bg-transparent text-neutral-600 dark:text-neutral-300 border-0 focus:outline-none focus:ring-0 cursor-pointer"
                   :title="t('share.directLinkMode', 'Direct link mode')"
+                  :aria-label="t('share.directLinkMode', 'Direct link mode')"
                 >
                   <option
                     v-for="mode in directLinkModeOptions"
@@ -461,10 +472,14 @@ onMounted(async () => {
                     {{ mode.label }}
                   </option>
                 </select>
+                <span
+                  class="w-px self-stretch bg-neutral-200 dark:bg-neutral-700"
+                  aria-hidden="true"
+                ></span>
                 <button
                   @click.stop="handleCopyDirectFileLink(share)"
                   :disabled="directCopyingId === share.id"
-                  class="p-1.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
+                  class="p-1.5 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
                   :title="
                     share.isDirectory
                       ? t('share.copyDirectFolderLink', 'Copy direct folder ZIP link')

--- a/frontend/src/views/SharedByMeView.vue
+++ b/frontend/src/views/SharedByMeView.vue
@@ -455,12 +455,12 @@ onMounted(async () => {
                 next to the copy/delete buttons (issue #265).
               -->
               <div
-                class="flex items-center rounded-md border border-neutral-200 dark:border-neutral-700 overflow-hidden bg-white dark:bg-neutral-900 focus-within:ring-2 focus-within:ring-blue-500/40"
+                class="flex min-w-0 items-center rounded-md border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 focus-within:ring-2 focus-within:ring-blue-500/40"
               >
                 <select
                   v-model="directLinkModes[share.id]"
                   @click.stop
-                  class="w-[4.25rem] px-1.5 py-1 text-xs bg-transparent text-neutral-600 dark:text-neutral-300 border-0 focus:outline-none focus:ring-0 cursor-pointer"
+                  class="min-w-0 rounded-l-md border-0 bg-transparent py-1 pl-1.5 pr-0.5 text-xs text-neutral-600 dark:text-neutral-300 focus:outline-none focus:ring-0 cursor-pointer"
                   :title="t('share.directLinkMode', 'Direct link mode')"
                   :aria-label="t('share.directLinkMode', 'Direct link mode')"
                 >
@@ -473,13 +473,13 @@ onMounted(async () => {
                   </option>
                 </select>
                 <span
-                  class="w-px self-stretch bg-neutral-200 dark:bg-neutral-700"
+                  class="w-px self-stretch bg-neutral-200 dark:bg-neutral-700 shrink-0"
                   aria-hidden="true"
                 ></span>
                 <button
                   @click.stop="handleCopyDirectFileLink(share)"
                   :disabled="directCopyingId === share.id"
-                  class="p-1.5 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
+                  class="shrink-0 rounded-r-md p-1.5 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
                   :title="
                     share.isDirectory
                       ? t('share.copyDirectFolderLink', 'Copy direct folder ZIP link')

--- a/frontend/src/views/SharedByMeView.vue
+++ b/frontend/src/views/SharedByMeView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { getMyShares, deleteShare, copyShareUrl } from '@/api/shares.api';
+import { getMyShares, deleteShare, copyDirectShareFileUrl, copyShareUrl } from '@/api/shares.api';
 import { fetchShareableUsers } from '@/api/users.api';
 import {
   ShareIcon,
@@ -13,6 +13,7 @@ import {
   UsersIcon,
   ClipboardDocumentIcon,
   CheckIcon,
+  LinkIcon,
   MagnifyingGlassIcon,
   ArrowsUpDownIcon,
 } from '@heroicons/vue/24/outline';
@@ -27,6 +28,8 @@ const error = ref('');
 const deletingId = ref(null);
 const copyingId = ref(null);
 const copiedId = ref(null);
+const directCopyingId = ref(null);
+const directCopiedId = ref(null);
 const searchQuery = ref('');
 const filterMode = ref('active'); // 'active' | 'expired' | 'all'
 const sortMode = ref('recent'); // 'recent' | 'label'
@@ -190,6 +193,25 @@ const handleCopyLink = async (share) => {
     console.error('Failed to copy link:', err);
   } finally {
     copyingId.value = null;
+  }
+};
+
+const handleCopyDirectFileLink = async (share) => {
+  if (!share?.id || !share?.shareToken || share.isDirectory) return;
+
+  try {
+    directCopyingId.value = share.id;
+    await copyDirectShareFileUrl(share.shareToken);
+    directCopiedId.value = share.id;
+    setTimeout(() => {
+      if (directCopiedId.value === share.id) {
+        directCopiedId.value = null;
+      }
+    }, 2000);
+  } catch (err) {
+    console.error('Failed to copy direct file link:', err);
+  } finally {
+    directCopyingId.value = null;
   }
 };
 
@@ -380,6 +402,7 @@ onMounted(async () => {
             <div class="flex items-center justify-end gap-1">
               <button
                 @click.stop="handleCopyLink(share)"
+                :disabled="copyingId === share.id"
                 class="p-1.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
                 :title="t('actions.copy')"
               >
@@ -387,6 +410,19 @@ onMounted(async () => {
                   :is="copiedId === share.id ? CheckIcon : ClipboardDocumentIcon"
                   class="w-4 h-4"
                   :class="{ 'text-green-500': copiedId === share.id }"
+                />
+              </button>
+              <button
+                v-if="!share.isDirectory"
+                @click.stop="handleCopyDirectFileLink(share)"
+                :disabled="directCopyingId === share.id"
+                class="p-1.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
+                :title="t('share.copyDirectFileLink', 'Copy direct file link')"
+              >
+                <component
+                  :is="directCopiedId === share.id ? CheckIcon : LinkIcon"
+                  class="w-4 h-4"
+                  :class="{ 'text-green-500': directCopiedId === share.id }"
                 />
               </button>
               <button

--- a/frontend/src/views/SharedByMeView.vue
+++ b/frontend/src/views/SharedByMeView.vue
@@ -1,7 +1,13 @@
 <script setup>
 import { ref, onMounted, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { getMyShares, deleteShare, copyDirectShareFileUrl, copyShareUrl } from '@/api/shares.api';
+import {
+  getMyShares,
+  deleteShare,
+  copyDirectShareFileUrl,
+  copyShareUrl,
+  DIRECT_SHARE_FILE_MODES,
+} from '@/api/shares.api';
 import { fetchShareableUsers } from '@/api/users.api';
 import {
   ShareIcon,
@@ -30,12 +36,13 @@ const copyingId = ref(null);
 const copiedId = ref(null);
 const directCopyingId = ref(null);
 const directCopiedId = ref(null);
+const directLinkModes = ref({});
 const searchQuery = ref('');
 const filterMode = ref('active'); // 'active' | 'expired' | 'all'
 const sortMode = ref('recent'); // 'recent' | 'label'
 
 // Grid columns configuration
-const GRID_COLS = 'grid-cols-[30px_minmax(0,3fr)_1.5fr_1fr_1.5fr_100px]';
+const GRID_COLS = 'grid-cols-[30px_minmax(0,3fr)_1.5fr_1fr_1.5fr_170px]';
 
 // Create a map of userId -> user for quick lookup
 const usersMap = computed(() => {
@@ -56,6 +63,11 @@ const loadShares = async () => {
       fetchShareableUsers().catch(() => ({ users: [] })),
     ]);
     shares.value = sharesResponse?.shares || [];
+    shares.value.forEach((share) => {
+      if (share?.id && !directLinkModes.value[share.id]) {
+        directLinkModes.value[share.id] = 'auto';
+      }
+    });
     users.value = usersResponse?.users || [];
   } catch (err) {
     console.error('Failed to load my shares:', err);
@@ -131,6 +143,13 @@ const visibleShares = computed(() => {
   return list;
 });
 
+const directLinkModeOptions = computed(() =>
+  DIRECT_SHARE_FILE_MODES.map((mode) => ({
+    ...mode,
+    label: t(mode.labelKey, mode.fallback),
+  }))
+);
+
 const getShareLabel = (share) => {
   if (share.label) return share.label;
   if (share.sourcePath) {
@@ -197,11 +216,11 @@ const handleCopyLink = async (share) => {
 };
 
 const handleCopyDirectFileLink = async (share) => {
-  if (!share?.id || !share?.shareToken || share.isDirectory) return;
+  if (!share?.id || !share?.shareToken) return;
 
   try {
     directCopyingId.value = share.id;
-    await copyDirectShareFileUrl(share.shareToken);
+    await copyDirectShareFileUrl(share.shareToken, '', directLinkModes.value[share.id] || 'auto');
     directCopiedId.value = share.id;
     setTimeout(() => {
       if (directCopiedId.value === share.id) {
@@ -412,19 +431,38 @@ onMounted(async () => {
                   :class="{ 'text-green-500': copiedId === share.id }"
                 />
               </button>
-              <button
-                v-if="!share.isDirectory"
-                @click.stop="handleCopyDirectFileLink(share)"
-                :disabled="directCopyingId === share.id"
-                class="p-1.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
-                :title="t('share.copyDirectFileLink', 'Copy direct file link')"
-              >
-                <component
-                  :is="directCopiedId === share.id ? CheckIcon : LinkIcon"
-                  class="w-4 h-4"
-                  :class="{ 'text-green-500': directCopiedId === share.id }"
-                />
-              </button>
+              <div class="flex items-center gap-1">
+                <select
+                  v-model="directLinkModes[share.id]"
+                  @click.stop
+                  class="w-20 px-1.5 py-1 text-xs rounded border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-600 dark:text-neutral-300"
+                  :title="t('share.directLinkMode', 'Direct link mode')"
+                >
+                  <option
+                    v-for="mode in directLinkModeOptions"
+                    :key="mode.value"
+                    :value="mode.value"
+                  >
+                    {{ mode.label }}
+                  </option>
+                </select>
+                <button
+                  @click.stop="handleCopyDirectFileLink(share)"
+                  :disabled="directCopyingId === share.id"
+                  class="p-1.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400"
+                  :title="
+                    share.isDirectory
+                      ? t('share.copyDirectFolderLink', 'Copy direct folder ZIP link')
+                      : t('share.copyDirectFileLink', 'Copy direct file link')
+                  "
+                >
+                  <component
+                    :is="directCopiedId === share.id ? CheckIcon : LinkIcon"
+                    class="w-4 h-4"
+                    :class="{ 'text-green-500': directCopiedId === share.id }"
+                  />
+                </button>
+              </div>
               <button
                 @click.stop="handleDeleteShare(share)"
                 class="p-1.5 rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-neutral-500 hover:text-red-600 dark:text-neutral-400 dark:hover:text-red-400"

--- a/frontend/src/views/SharedByMeView.vue
+++ b/frontend/src/views/SharedByMeView.vue
@@ -9,6 +9,7 @@ import {
   DIRECT_SHARE_FILE_MODES,
 } from '@/api/shares.api';
 import { fetchShareableUsers } from '@/api/users.api';
+import ModalDialog from '@/components/ModalDialog.vue';
 import {
   ShareIcon,
   ClockIcon,
@@ -37,6 +38,8 @@ const copiedId = ref(null);
 const directCopyingId = ref(null);
 const directCopiedId = ref(null);
 const directLinkModes = ref({});
+const sharePendingDelete = ref(null);
+const isDeleteShareDialogOpen = ref(false);
 const searchQuery = ref('');
 const filterMode = ref('active'); // 'active' | 'expired' | 'all'
 const sortMode = ref('recent'); // 'recent' | 'label'
@@ -180,20 +183,32 @@ const getIconItem = (share) => {
 
 const handleDeleteShare = async (share) => {
   if (!share?.id) return;
+  sharePendingDelete.value = share;
+  isDeleteShareDialogOpen.value = true;
+};
 
-  const confirmed = window.confirm(t('share.confirmDeleteShare'));
-  if (!confirmed) return;
+const confirmDeleteShare = async () => {
+  const share = sharePendingDelete.value;
+  if (!share?.id) return;
 
   deletingId.value = share.id;
   try {
     await deleteShare(share.id);
     shares.value = shares.value.filter((s) => s.id !== share.id);
+    isDeleteShareDialogOpen.value = false;
+    sharePendingDelete.value = null;
   } catch (err) {
     console.error('Failed to delete share:', err);
     error.value = err.message || t('errors.deleteShare');
   } finally {
     deletingId.value = null;
   }
+};
+
+const closeDeleteShareDialog = () => {
+  if (deletingId.value) return;
+  isDeleteShareDialogOpen.value = false;
+  sharePendingDelete.value = null;
 };
 
 const handleCopyLink = async (share) => {
@@ -475,5 +490,38 @@ onMounted(async () => {
         </div>
       </div>
     </div>
+
+    <ModalDialog v-model="isDeleteShareDialogOpen">
+      <template #title>
+        {{ t('share.deleteShareTitle', 'Remove share?') }}
+      </template>
+      <p class="mb-6 text-base text-zinc-700 dark:text-zinc-200">
+        {{
+          t(
+            'share.deleteShareMessage',
+            'People with this link will no longer be able to access the shared item.'
+          )
+        }}
+      </p>
+      <div class="flex justify-end gap-3">
+        <button
+          type="button"
+          class="rounded-md border border-zinc-300 px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-100 active:bg-zinc-200 disabled:cursor-not-allowed disabled:opacity-60 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-700 dark:active:bg-zinc-600"
+          :disabled="Boolean(deletingId)"
+          @click="closeDeleteShareDialog"
+        >
+          {{ t('common.cancel') }}
+        </button>
+        <button
+          type="button"
+          class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-500 active:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-red-500 dark:hover:bg-red-400"
+          :disabled="Boolean(deletingId)"
+          @click="confirmDeleteShare"
+        >
+          <span v-if="deletingId">{{ t('common.deleting') }}</span>
+          <span v-else>{{ t('common.delete') }}</span>
+        </button>
+      </div>
+    </ModalDialog>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add direct share URLs that can be copied when creating a share and from the existing shares list
- support direct-link modes for normal users: automatic handling, browser view, raw content, or forced download
- stream browser-friendly files inline while forcing binary files to download
- stream shared folders as ZIP downloads through the direct link flow
- preserve share authentication rules for anonymous, password-protected, user-restricted, and expired shares
- replace the native browser confirmation when deleting shares with the application modal
- clean up linked shares when the shared file or folder is deleted, with a warning in the delete confirmation dialog

## Validation
- `npm run test -w backend -- shares.test.js`
- `npm run build -w frontend`
- live validation from the fork package image: `ghcr.io/cerede2000/explorer:direct-share-file-links`

Closes https://github.com/nxzai/NextExplorer/issues/186
Closes https://github.com/nxzai/NextExplorer/issues/284
Closes https://github.com/nxzai/NextExplorer/issues/297
Closes https://github.com/nxzai/NextExplorer/issues/265
