### PR TITLE
Add shared folder download action

### DIFF
--- a/backend/src/routes/browse.js
+++ b/backend/src/routes/browse.js
@@ -58,6 +58,9 @@ router.get(
         canShare: accessInfo.canShare,
         canDownload: accessInfo.canDownload,
       },
+      current: {
+        isDirectory: true,
+      },
       path: relativePath,
     };
 

--- a/backend/src/routes/files/download.js
+++ b/backend/src/routes/files/download.js
@@ -6,9 +6,25 @@ const { resolvePathWithAccess } = require('../../services/accessManager');
 const asyncHandler = require('../../utils/asyncHandler');
 const { ValidationError, ForbiddenError } = require('../../errors/AppError');
 const logger = require('../../utils/logger');
-const { collectInputPaths, encodeContentDisposition, stripBasePath } = require('./utils');
+const { collectInputPaths, encodeContentDisposition, stripBasePath, toPosix } = require('./utils');
 
 const router = require('express').Router();
+
+const getLogicalSegments = (relativePath = '') => toPosix(relativePath).split('/').filter(Boolean);
+
+const isShareRootPath = (relativePath = '') => {
+  const segments = getLogicalSegments(relativePath);
+  return segments.length === 2 && segments[0] === 'share';
+};
+
+const getDownloadBaseName = ({ relativePath, absolutePath }) => {
+  if (isShareRootPath(relativePath)) {
+    return path.basename(absolutePath);
+  }
+
+  const segments = getLogicalSegments(relativePath);
+  return segments[segments.length - 1] || path.basename(absolutePath);
+};
 
 const handleDownloadRequest = async (paths, req, res, basePath = '') => {
   if (!Array.isArray(paths) || paths.length === 0) {
@@ -74,13 +90,7 @@ const handleDownloadRequest = async (paths, req, res, basePath = '') => {
 
   const archiveName = (() => {
     if (targets.length === 1) {
-      const segments = targets[0].relativePath
-        ? targets[0].relativePath.split(path.sep).filter(Boolean)
-        : [];
-      const baseName =
-        segments.length > 0
-          ? segments[segments.length - 1]
-          : path.basename(targets[0].absolutePath);
+      const baseName = getDownloadBaseName(targets[0]);
       return `${baseName || 'download'}.zip`;
     }
 
@@ -111,7 +121,9 @@ const handleDownloadRequest = async (paths, req, res, basePath = '') => {
   archive.pipe(res);
 
   targets.forEach(({ relativePath, absolutePath, stats }) => {
-    const entryNameRaw = stripBasePath(relativePath, baseNormalized);
+    const entryNameRaw = isShareRootPath(relativePath)
+      ? getDownloadBaseName({ relativePath, absolutePath })
+      : stripBasePath(relativePath, baseNormalized);
     const entryName = entryNameRaw
       ? entryNameRaw.replace(/\\/g, '/').replace(/^\/+/, '')
       : path.basename(absolutePath);

--- a/backend/src/routes/shares.js
+++ b/backend/src/routes/shares.js
@@ -553,6 +553,9 @@ router.get(
           canShare: false,
           canDownload: accessInfo.canDownload,
         },
+        current: {
+          isDirectory: true,
+        },
         path: resolved.relativePath,
       };
 
@@ -607,6 +610,9 @@ router.get(
         canDelete: accessInfo.canDelete,
         canShare: false,
         canDownload: accessInfo.canDownload,
+      },
+      current: {
+        isDirectory: false,
       },
       path: resolved.relativePath,
     };

--- a/frontend/src/components/FolderViewToolbar.vue
+++ b/frontend/src/components/FolderViewToolbar.vue
@@ -10,11 +10,12 @@ import NotificationBell from '@/components/NotificationBell.vue';
 import SearchBar from '@/components/SearchBar.vue';
 import MenuShare from '@/components/MenuShare.vue';
 import CreateNew from '@/components/CreateNew.vue';
+import { useFileActions } from '@/composables/fileActions';
 import { useSettingsStore } from '@/stores/settings';
 import { useAuthStore } from '@/stores/auth';
 import { useFileStore } from '@/stores/fileStore';
 import { useRoute, useRouter } from 'vue-router';
-import { Bars3Icon, HomeIcon } from '@heroicons/vue/24/outline';
+import { ArrowDownTrayIcon, Bars3Icon, HomeIcon } from '@heroicons/vue/24/outline';
 import { useInputMode } from '@/composables/useInputMode';
 
 const settings = useSettingsStore();
@@ -23,6 +24,7 @@ const fileStore = useFileStore();
 const route = useRoute();
 const router = useRouter();
 const { isTouchDevice } = useInputMode();
+const actions = useFileActions();
 
 defineEmits(['toggle-sidebar']);
 
@@ -60,6 +62,10 @@ const goHome = async () => {
 
 const toggleSelectionMode = () => {
   fileStore.toggleSelectionMode({ clearOnDisable: true });
+};
+
+const downloadCurrentFolder = () => {
+  actions.runDownloadCurrentFolder();
 };
 </script>
 
@@ -109,6 +115,16 @@ const toggleSelectionMode = () => {
 
       <div class="flex items-center ml-auto">
         <template v-if="!isVolumesView">
+          <button
+            v-if="actions.canDownloadCurrentFolder.value"
+            type="button"
+            class="p-[6px] rounded-md transition-colors hover:bg-[rgb(239,239,240)] active:bg-zinc-200 dark:hover:bg-zinc-700 dark:active:bg-zinc-600"
+            :title="$t('actions.downloadFolder')"
+            :aria-label="$t('actions.downloadFolder')"
+            @click="downloadCurrentFolder"
+          >
+            <ArrowDownTrayIcon class="w-6" />
+          </button>
           <MenuItemInfo class="ml-auto" />
           <MenuShare />
           <div class="h-8 w-px mx-1 md:mx-3 bg-neutral-200 dark:bg-neutral-700"></div>

--- a/frontend/src/composables/fileActions.js
+++ b/frontend/src/composables/fileActions.js
@@ -1,6 +1,6 @@
 import { computed } from 'vue';
 import { useFileStore } from '@/stores/fileStore';
-import { normalizePath } from '@/api';
+import { buildUrl, normalizePath } from '@/api';
 
 function isEditableElement(el) {
   if (!el) return false;
@@ -28,6 +28,10 @@ export function useFileActions() {
   const locationCanWrite = computed(() => fileStore.currentPathData?.canWrite ?? true);
   const locationCanUpload = computed(() => fileStore.currentPathData?.canUpload ?? true);
   const locationCanDelete = computed(() => fileStore.currentPathData?.canDelete ?? true);
+  const locationCanDownload = computed(() => fileStore.currentPathData?.canDownload ?? true);
+  const currentDirectoryPath = computed(() => normalizePath(fileStore.getCurrentPath || ''));
+  const currentPathIsDirectory = computed(() => fileStore.currentPathData?.isDirectory === true);
+  const isSharePath = computed(() => currentDirectoryPath.value.startsWith('share/'));
 
   const isZipSelected = computed(() => {
     if (!isSingleItemSelected.value || !primaryItem.value) return false;
@@ -70,6 +74,13 @@ export function useFileActions() {
       selectionHasUniformParent.value &&
       selectedItems.value.every((item) => item?.kind !== 'volume')
   );
+  const canDownloadCurrentFolder = computed(
+    () =>
+      isSharePath.value &&
+      locationCanDownload.value &&
+      currentPathIsDirectory.value &&
+      Boolean(currentDirectoryPath.value)
+  );
 
   const isCutActive = computed(() => fileStore.cutItems.length > 0);
   const isCopyActive = computed(() => fileStore.copiedItems.length > 0);
@@ -109,26 +120,16 @@ export function useFileActions() {
     await fileStore.del();
   };
 
-  const runDownload = () => {
-    if (!hasSelection.value) return;
-
-    const paths = selectedItems.value
-      .map((item) => {
-        const parent = normalizePath(item.path || '');
-        const combined = parent ? `${parent}/${item.name}` : item.name;
-        return normalizePath(combined);
-      })
-      .filter(Boolean);
-
+  const submitDownloadRequest = (paths, basePath = '') => {
     if (!paths.length) return;
 
-    const currentPath = normalizePath(fileStore.getCurrentPath || '');
+    const currentPath = normalizePath(basePath || '');
 
     // Create a hidden form to submit the download request
     // This triggers the browser's native download with progress bar
     const form = document.createElement('form');
     form.method = 'POST';
-    form.action = '/api/download';
+    form.action = buildUrl('/api/download');
     form.style.display = 'none';
 
     // Add each path as a separate 'paths' field (form arrays)
@@ -152,6 +153,18 @@ export function useFileActions() {
     document.body.removeChild(form);
   };
 
+  const runDownload = () => {
+    if (!hasSelection.value) return;
+
+    const paths = selectedItems.value.map(resolveItemPath).filter(Boolean);
+    submitDownloadRequest(paths, currentDirectoryPath.value);
+  };
+
+  const runDownloadCurrentFolder = () => {
+    if (!canDownloadCurrentFolder.value) return;
+    submitDownloadRequest([currentDirectoryPath.value], currentDirectoryPath.value);
+  };
+
   return {
     // state
     selectedItems,
@@ -162,6 +175,7 @@ export function useFileActions() {
     locationCanWrite,
     locationCanUpload,
     locationCanDelete,
+    locationCanDownload,
     canCut,
     canCopy,
     canPaste,
@@ -169,6 +183,7 @@ export function useFileActions() {
     canRename,
     canExtractZip,
     canCompressToZip,
+    canDownloadCurrentFolder,
     isCutActive,
     isCopyActive,
     // helpers
@@ -184,5 +199,6 @@ export function useFileActions() {
     runCompressToZip,
     deleteNow,
     runDownload,
+    runDownloadCurrentFolder,
   };
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -95,6 +95,7 @@
     "paste": "Einfügen",
     "rename": "Umbenennen",
     "download": "Herunterladen",
+    "downloadFolder": "Ordner herunterladen",
     "extractZip": "ZIP entpacken",
     "compressToZip": "In ZIP komprimieren",
     "search": "Suchen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -95,6 +95,7 @@
     "paste": "Paste",
     "rename": "Rename",
     "download": "Download",
+    "downloadFolder": "Download folder",
     "extractZip": "Extract ZIP",
     "compressToZip": "Compress to ZIP",
     "search": "Search",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -95,6 +95,7 @@
     "paste": "Pegar",
     "rename": "Renombrar",
     "download": "Descargar",
+    "downloadFolder": "Descargar carpeta",
     "extractZip": "Extraer ZIP",
     "compressToZip": "Comprimir a ZIP",
     "search": "Buscar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -95,6 +95,7 @@
     "paste": "Coller",
     "rename": "Renommer",
     "download": "Télécharger",
+    "downloadFolder": "Télécharger le dossier",
     "extractZip": "Extraire ZIP",
     "compressToZip": "Compresser en ZIP",
     "search": "Rechercher",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -95,6 +95,7 @@
     "paste": "पेस्ट",
     "rename": "नाम बदलें",
     "download": "डाउनलोड",
+    "downloadFolder": "फ़ोल्डर डाउनलोड करें",
     "extractZip": "ZIP निकालें",
     "compressToZip": "ZIP में संपीड़ित करें",
     "search": "खोजें",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -95,6 +95,7 @@
     "paste": "Incolla",
     "rename": "Rinomina",
     "download": "Scarica",
+    "downloadFolder": "Scarica cartella",
     "extractZip": "Estrai ZIP",
     "compressToZip": "Comprimi in ZIP",
     "search": "Cerca",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -95,6 +95,7 @@
     "paste": "붙여넣기",
     "rename": "이름 바꾸기",
     "download": "다운로드",
+    "downloadFolder": "폴더 다운로드",
     "extractZip": "ZIP 파일 추출",
     "compressToZip": "ZIP 파일로 압축",
     "search": "검색",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -95,6 +95,7 @@
     "paste": "Wklej",
     "rename": "Zmień nazwę",
     "download": "Pobierz",
+    "downloadFolder": "Pobierz folder",
     "extractZip": "Wypakuj ZIP",
     "compressToZip": "Spakuj do ZIP",
     "search": "Szukaj",

--- a/frontend/src/i18n/locales/ro.json
+++ b/frontend/src/i18n/locales/ro.json
@@ -95,6 +95,7 @@
     "paste": "Lipește",
     "rename": "Redenumește",
     "download": "Descarcă",
+    "downloadFolder": "Descarcă dosarul",
     "extractZip": "Extrage ZIP",
     "compressToZip": "Comprimă în ZIP",
     "search": "Caută",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -95,6 +95,7 @@
     "paste": "Вставить",
     "rename": "Переименовать",
     "download": "Скачать",
+    "downloadFolder": "Скачать папку",
     "extractZip": "Распаковать ZIP",
     "compressToZip": "Сжать в ZIP",
     "search": "Поиск",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -95,6 +95,7 @@
     "paste": "Klistra in",
     "rename": "Byt namn",
     "download": "Ladda ner",
+    "downloadFolder": "Ladda ner mapp",
     "extractZip": "Extrahera ZIP",
     "compressToZip": "Komprimera till ZIP",
     "search": "Sök",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -95,6 +95,7 @@
     "paste": "粘贴",
     "rename": "重命名",
     "download": "下载",
+    "downloadFolder": "下载文件夹",
     "extractZip": "解压 ZIP",
     "compressToZip": "压缩为 ZIP",
     "search": "搜索",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -95,6 +95,7 @@
     "paste": "貼上",
     "rename": "重新命名",
     "download": "下載",
+    "downloadFolder": "下載資料夾",
     "extractZip": "解壓縮 ZIP",
     "compressToZip": "壓縮為 ZIP",
     "search": "搜尋",

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -487,6 +487,7 @@ export const useFileStore = defineStore('fileStore', () => {
         canDelete: access?.canDelete ?? true,
         canShare: access?.canShare ?? true,
         canDownload: access?.canDownload ?? true,
+        isDirectory: response.current?.isDirectory ?? null,
         // Include share metadata if present
         shareInfo: response.shareInfo || null,
       };


### PR DESCRIPTION
## Summary
- add a toolbar action to download the current shared folder as a ZIP
- reuse the existing /api/download authorization path for authenticated and guest share access
- keep the ZIP name based on the shared source folder instead of the share token

Closes https://github.com/nxzai/NextExplorer/issues/289

## Validation
- node --check backend/src/routes/files/download.js backend/src/routes/browse.js backend/src/routes/shares.js
- npm run build -w frontend
- backend share route tests passed