### PR TITLE
Stabilize thumbnail queue and cache handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN npm run -w frontend build -- --sourcemap false
 # ---------------------------------------------------------------------------
 FROM base AS runtime
 ENV NODE_ENV=production
+# Enlarge the libuv thread pool so directory-listing fs.stat calls are not
+# starved by concurrent thumbnail-generation fs operations (keeps navigation
+# responsive while a large media folder is being processed). Tunable at runtime.
+ENV UV_THREADPOOL_SIZE=16
 
 # Create the baseline app user; UID/GID may be mutated at runtime via entrypoint.sh.
 # Alpine uses busybox addgroup/adduser instead of Debian's groupadd/useradd.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ services:
       # THUMBNAIL_VIDEO_SEEK_PERCENT: "" # Optional 0-1 value to seek by duration percentage; enables ffprobe per video.
       # THUMBNAIL_VIDEO_THREADS: "1" # ffmpeg thread limit for video thumbnail extraction.
       # THUMBNAIL_VIDEO_SCALE_FLAGS: "fast_bilinear" # ffmpeg scale flags; use lanczos for sharper but heavier thumbnails.
+      # THUMBNAIL_BACKGROUND_QUEUE_LIMIT: "8" # Max pending/in-flight thumbnail jobs accepted before clients retry later.
       # THUMBNAIL_DIAGNOSTICS_ENABLED: "false" # Enable detailed thumbnail queue/memory/process logs.
       # THUMBNAIL_DIAGNOSTICS_INTERVAL_MS: "30000" # Interval for thumbnail diagnostics logs.
       # THUMBNAIL_SLOW_JOB_MS: "10000" # Log thumbnail jobs/processes slower than this threshold.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ services:
       # THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE: "500" # Max thumbnail cache files deleted per cleanup pass.
       # THUMBNAIL_SHARP_CACHE_MEMORY_MB: "0" # Sharp/libvips thumbnail cache memory budget.
       # THUMBNAIL_VIDEO_CONCURRENCY: "1" # Max concurrent ffmpeg thumbnail jobs.
+      # THUMBNAIL_VIDEO_SEEK_SECONDS: "5" # Timestamp used for video thumbnails; avoids probing every video by default.
+      # THUMBNAIL_VIDEO_SEEK_PERCENT: "" # Optional 0-1 value to seek by duration percentage; enables ffprobe per video.
+      # THUMBNAIL_VIDEO_THREADS: "1" # ffmpeg thread limit for video thumbnail extraction.
+      # THUMBNAIL_VIDEO_SCALE_FLAGS: "fast_bilinear" # ffmpeg scale flags; use lanczos for sharper but heavier thumbnails.
       # THUMBNAIL_DIAGNOSTICS_ENABLED: "false" # Enable detailed thumbnail queue/memory/process logs.
       # THUMBNAIL_DIAGNOSTICS_INTERVAL_MS: "30000" # Interval for thumbnail diagnostics logs.
       # THUMBNAIL_SLOW_JOB_MS: "10000" # Log thumbnail jobs/processes slower than this threshold.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ services:
       # THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE: "500" # Max thumbnail cache files deleted per cleanup pass.
       # THUMBNAIL_SHARP_CACHE_MEMORY_MB: "0" # Sharp/libvips thumbnail cache memory budget.
       # THUMBNAIL_VIDEO_CONCURRENCY: "1" # Max concurrent ffmpeg thumbnail jobs.
+      # THUMBNAIL_DIAGNOSTICS_ENABLED: "false" # Enable detailed thumbnail queue/memory/process logs.
+      # THUMBNAIL_DIAGNOSTICS_INTERVAL_MS: "30000" # Interval for thumbnail diagnostics logs.
+      # THUMBNAIL_SLOW_JOB_MS: "10000" # Log thumbnail jobs/processes slower than this threshold.
 
       # Container user mapping (optional)
       # PUID: "1000" # Map container processes to host UID so created files have consistent ownership.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ services:
       # FFMPEG_PATH: "" # Point to a custom ffmpeg binary (defaults to bundled binary).
       # FFPROBE_PATH: "" # Point to a custom ffprobe binary (defaults to bundled binary).
       # THUMBNAIL_CACHE_MAX_FILES: "3000" # Max files kept in /cache/thumbnails; set 0 to disable cleanup.
+      # THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE: "500" # Max thumbnail cache files deleted per cleanup pass.
 
       # Container user mapping (optional)
       # PUID: "1000" # Map container processes to host UID so created files have consistent ownership.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ services:
       # THUMBNAIL_CACHE_MAX_FILES: "3000" # Max files kept in /cache/thumbnails; set 0 to disable cleanup.
       # THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE: "500" # Max thumbnail cache files deleted per cleanup pass.
       # THUMBNAIL_SHARP_CACHE_MEMORY_MB: "0" # Sharp/libvips thumbnail cache memory budget.
+      # THUMBNAIL_VIDEO_CONCURRENCY: "1" # Max concurrent ffmpeg thumbnail jobs.
 
       # Container user mapping (optional)
       # PUID: "1000" # Map container processes to host UID so created files have consistent ownership.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ services:
       # ONLYOFFICE_FILE_EXTENSIONS: "" # Extra file extensions to surface to the Document Server.
       # FFMPEG_PATH: "" # Point to a custom ffmpeg binary (defaults to bundled binary).
       # FFPROBE_PATH: "" # Point to a custom ffprobe binary (defaults to bundled binary).
+      # THUMBNAIL_CACHE_MAX_FILES: "3000" # Max files kept in /cache/thumbnails; set 0 to disable cleanup.
 
       # Container user mapping (optional)
       # PUID: "1000" # Map container processes to host UID so created files have consistent ownership.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ services:
       # FFPROBE_PATH: "" # Point to a custom ffprobe binary (defaults to bundled binary).
       # THUMBNAIL_CACHE_MAX_FILES: "3000" # Max files kept in /cache/thumbnails; set 0 to disable cleanup.
       # THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE: "500" # Max thumbnail cache files deleted per cleanup pass.
+      # THUMBNAIL_SHARP_CACHE_MEMORY_MB: "32" # Sharp/libvips thumbnail cache memory budget.
 
       # Container user mapping (optional)
       # PUID: "1000" # Map container processes to host UID so created files have consistent ownership.

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ services:
       # ONLYOFFICE_FILE_EXTENSIONS: "" # Extra file extensions to surface to the Document Server.
       # FFMPEG_PATH: "" # Point to a custom ffmpeg binary (defaults to bundled binary).
       # FFPROBE_PATH: "" # Point to a custom ffprobe binary (defaults to bundled binary).
+      # THUMBNAILS_ENABLED: "true" # Set to "false" to disable thumbnail generation globally.
       # THUMBNAIL_CACHE_MAX_FILES: "3000" # Max files kept in /cache/thumbnails; set 0 to disable cleanup.
       # THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE: "500" # Max thumbnail cache files deleted per cleanup pass.
-      # THUMBNAIL_SHARP_CACHE_MEMORY_MB: "32" # Sharp/libvips thumbnail cache memory budget.
+      # THUMBNAIL_SHARP_CACHE_MEMORY_MB: "0" # Sharp/libvips thumbnail cache memory budget.
 
       # Container user mapping (optional)
       # PUID: "1000" # Map container processes to host UID so created files have consistent ownership.

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -141,6 +141,10 @@ module.exports = {
       : 30000,
   THUMBNAIL_SLOW_JOB_MS:
     process.env.THUMBNAIL_SLOW_JOB_MS != null ? Number(process.env.THUMBNAIL_SLOW_JOB_MS) : 10000,
+  // Niceness applied to child ffmpeg/convert processes (0 = disabled, 1-19 lowers
+  // their CPU priority so the Node event loop stays responsive during generation).
+  THUMBNAIL_PROCESS_NICE:
+    process.env.THUMBNAIL_PROCESS_NICE != null ? Number(process.env.THUMBNAIL_PROCESS_NICE) : 10,
 
   // Favorites
   FAVORITES_DEFAULT_ICON: process.env.FAVORITES_DEFAULT_ICON || 'outline:StarIcon',

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -115,7 +115,7 @@ module.exports = {
   THUMBNAIL_VIDEO_CONCURRENCY:
     process.env.THUMBNAIL_VIDEO_CONCURRENCY != null
       ? Number(process.env.THUMBNAIL_VIDEO_CONCURRENCY)
-      : 2,
+      : 3,
   THUMBNAIL_VIDEO_SEEK_SECONDS:
     process.env.THUMBNAIL_VIDEO_SEEK_SECONDS != null
       ? Number(process.env.THUMBNAIL_VIDEO_SEEK_SECONDS)
@@ -132,7 +132,7 @@ module.exports = {
   THUMBNAIL_BACKGROUND_QUEUE_LIMIT:
     process.env.THUMBNAIL_BACKGROUND_QUEUE_LIMIT != null
       ? Number(process.env.THUMBNAIL_BACKGROUND_QUEUE_LIMIT)
-      : 8,
+      : 16,
   THUMBNAIL_DIAGNOSTICS_ENABLED:
     normalizeBoolean(process.env.THUMBNAIL_DIAGNOSTICS_ENABLED) ?? false,
   THUMBNAIL_DIAGNOSTICS_INTERVAL_MS:

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -115,7 +115,7 @@ module.exports = {
   THUMBNAIL_VIDEO_CONCURRENCY:
     process.env.THUMBNAIL_VIDEO_CONCURRENCY != null
       ? Number(process.env.THUMBNAIL_VIDEO_CONCURRENCY)
-      : 1,
+      : 2,
   THUMBNAIL_VIDEO_SEEK_SECONDS:
     process.env.THUMBNAIL_VIDEO_SEEK_SECONDS != null
       ? Number(process.env.THUMBNAIL_VIDEO_SEEK_SECONDS)
@@ -126,7 +126,7 @@ module.exports = {
       ? Number(process.env.THUMBNAIL_VIDEO_SEEK_PERCENT)
       : null,
   THUMBNAIL_VIDEO_THREADS:
-    process.env.THUMBNAIL_VIDEO_THREADS != null ? Number(process.env.THUMBNAIL_VIDEO_THREADS) : 1,
+    process.env.THUMBNAIL_VIDEO_THREADS != null ? Number(process.env.THUMBNAIL_VIDEO_THREADS) : 2,
   THUMBNAIL_VIDEO_SCALE_FLAGS:
     process.env.THUMBNAIL_VIDEO_SCALE_FLAGS?.trim() || 'fast_bilinear',
   THUMBNAIL_BACKGROUND_QUEUE_LIMIT:

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -95,6 +95,7 @@ module.exports = {
   FFMPEG_HWACCEL: process.env.FFMPEG_HWACCEL?.trim() || null,
   FFMPEG_HWACCEL_DEVICE: process.env.FFMPEG_HWACCEL_DEVICE?.trim() || null,
   FFMPEG_HWACCEL_OUTPUT_FORMAT: process.env.FFMPEG_HWACCEL_OUTPUT_FORMAT?.trim() || null,
+  THUMBNAILS_ENABLED: normalizeBoolean(process.env.THUMBNAILS_ENABLED) ?? true,
   THUMBNAIL_CACHE_MAX_FILES:
     process.env.THUMBNAIL_CACHE_MAX_FILES != null
       ? Number(process.env.THUMBNAIL_CACHE_MAX_FILES)
@@ -110,7 +111,7 @@ module.exports = {
   THUMBNAIL_SHARP_CACHE_MEMORY_MB:
     process.env.THUMBNAIL_SHARP_CACHE_MEMORY_MB != null
       ? Number(process.env.THUMBNAIL_SHARP_CACHE_MEMORY_MB)
-      : 32,
+      : 0,
 
   // Favorites
   FAVORITES_DEFAULT_ICON: process.env.FAVORITES_DEFAULT_ICON || 'outline:StarIcon',

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -116,6 +116,19 @@ module.exports = {
     process.env.THUMBNAIL_VIDEO_CONCURRENCY != null
       ? Number(process.env.THUMBNAIL_VIDEO_CONCURRENCY)
       : 1,
+  THUMBNAIL_VIDEO_SEEK_SECONDS:
+    process.env.THUMBNAIL_VIDEO_SEEK_SECONDS != null
+      ? Number(process.env.THUMBNAIL_VIDEO_SEEK_SECONDS)
+      : 5,
+  THUMBNAIL_VIDEO_SEEK_PERCENT:
+    process.env.THUMBNAIL_VIDEO_SEEK_PERCENT != null &&
+    process.env.THUMBNAIL_VIDEO_SEEK_PERCENT.trim() !== ''
+      ? Number(process.env.THUMBNAIL_VIDEO_SEEK_PERCENT)
+      : null,
+  THUMBNAIL_VIDEO_THREADS:
+    process.env.THUMBNAIL_VIDEO_THREADS != null ? Number(process.env.THUMBNAIL_VIDEO_THREADS) : 1,
+  THUMBNAIL_VIDEO_SCALE_FLAGS:
+    process.env.THUMBNAIL_VIDEO_SCALE_FLAGS?.trim() || 'fast_bilinear',
   THUMBNAIL_DIAGNOSTICS_ENABLED:
     normalizeBoolean(process.env.THUMBNAIL_DIAGNOSTICS_ENABLED) ?? false,
   THUMBNAIL_DIAGNOSTICS_INTERVAL_MS:

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -116,6 +116,14 @@ module.exports = {
     process.env.THUMBNAIL_VIDEO_CONCURRENCY != null
       ? Number(process.env.THUMBNAIL_VIDEO_CONCURRENCY)
       : 1,
+  THUMBNAIL_DIAGNOSTICS_ENABLED:
+    normalizeBoolean(process.env.THUMBNAIL_DIAGNOSTICS_ENABLED) ?? false,
+  THUMBNAIL_DIAGNOSTICS_INTERVAL_MS:
+    process.env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS != null
+      ? Number(process.env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS)
+      : 30000,
+  THUMBNAIL_SLOW_JOB_MS:
+    process.env.THUMBNAIL_SLOW_JOB_MS != null ? Number(process.env.THUMBNAIL_SLOW_JOB_MS) : 10000,
 
   // Favorites
   FAVORITES_DEFAULT_ICON: process.env.FAVORITES_DEFAULT_ICON || 'outline:StarIcon',

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -103,6 +103,10 @@ module.exports = {
     process.env.THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS != null
       ? Number(process.env.THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS)
       : 60 * 60 * 1000,
+  THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE:
+    process.env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE != null
+      ? Number(process.env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE)
+      : 500,
 
   // Favorites
   FAVORITES_DEFAULT_ICON: process.env.FAVORITES_DEFAULT_ICON || 'outline:StarIcon',

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -95,6 +95,14 @@ module.exports = {
   FFMPEG_HWACCEL: process.env.FFMPEG_HWACCEL?.trim() || null,
   FFMPEG_HWACCEL_DEVICE: process.env.FFMPEG_HWACCEL_DEVICE?.trim() || null,
   FFMPEG_HWACCEL_OUTPUT_FORMAT: process.env.FFMPEG_HWACCEL_OUTPUT_FORMAT?.trim() || null,
+  THUMBNAIL_CACHE_MAX_FILES:
+    process.env.THUMBNAIL_CACHE_MAX_FILES != null
+      ? Number(process.env.THUMBNAIL_CACHE_MAX_FILES)
+      : 3000,
+  THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS:
+    process.env.THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS != null
+      ? Number(process.env.THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS)
+      : 60 * 60 * 1000,
 
   // Favorites
   FAVORITES_DEFAULT_ICON: process.env.FAVORITES_DEFAULT_ICON || 'outline:StarIcon',

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -112,6 +112,10 @@ module.exports = {
     process.env.THUMBNAIL_SHARP_CACHE_MEMORY_MB != null
       ? Number(process.env.THUMBNAIL_SHARP_CACHE_MEMORY_MB)
       : 0,
+  THUMBNAIL_VIDEO_CONCURRENCY:
+    process.env.THUMBNAIL_VIDEO_CONCURRENCY != null
+      ? Number(process.env.THUMBNAIL_VIDEO_CONCURRENCY)
+      : 1,
 
   // Favorites
   FAVORITES_DEFAULT_ICON: process.env.FAVORITES_DEFAULT_ICON || 'outline:StarIcon',

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -129,6 +129,10 @@ module.exports = {
     process.env.THUMBNAIL_VIDEO_THREADS != null ? Number(process.env.THUMBNAIL_VIDEO_THREADS) : 1,
   THUMBNAIL_VIDEO_SCALE_FLAGS:
     process.env.THUMBNAIL_VIDEO_SCALE_FLAGS?.trim() || 'fast_bilinear',
+  THUMBNAIL_BACKGROUND_QUEUE_LIMIT:
+    process.env.THUMBNAIL_BACKGROUND_QUEUE_LIMIT != null
+      ? Number(process.env.THUMBNAIL_BACKGROUND_QUEUE_LIMIT)
+      : 8,
   THUMBNAIL_DIAGNOSTICS_ENABLED:
     normalizeBoolean(process.env.THUMBNAIL_DIAGNOSTICS_ENABLED) ?? false,
   THUMBNAIL_DIAGNOSTICS_INTERVAL_MS:

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -107,6 +107,10 @@ module.exports = {
     process.env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE != null
       ? Number(process.env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE)
       : 500,
+  THUMBNAIL_SHARP_CACHE_MEMORY_MB:
+    process.env.THUMBNAIL_SHARP_CACHE_MEMORY_MB != null
+      ? Number(process.env.THUMBNAIL_SHARP_CACHE_MEMORY_MB)
+      : 32,
 
   // Favorites
   FAVORITES_DEFAULT_ICON: process.env.FAVORITES_DEFAULT_ICON || 'outline:StarIcon',

--- a/backend/src/routes/browse.js
+++ b/backend/src/routes/browse.js
@@ -2,6 +2,7 @@ const express = require('express');
 
 const { normalizeRelativePath } = require('../utils/pathUtils');
 const { pathExists } = require('../utils/fsUtils');
+const env = require('../config/env');
 const { getSettings } = require('../services/settingsService');
 const logger = require('../utils/logger');
 const asyncHandler = require('../utils/asyncHandler');
@@ -15,7 +16,8 @@ router.get(
   '/browse/*',
   asyncHandler(async (req, res) => {
     const settings = await getSettings();
-    const thumbsEnabled = settings?.thumbnails?.enabled !== false;
+    const thumbsEnabled =
+      env.THUMBNAILS_ENABLED !== false && settings?.thumbnails?.enabled !== false;
     const rawPath = req.params[0] || '';
     const inputRelativePath = normalizeRelativePath(rawPath);
 

--- a/backend/src/routes/shares.js
+++ b/backend/src/routes/shares.js
@@ -26,6 +26,7 @@ const { parsePathSpace } = require('../utils/pathUtils');
 const { pathExists } = require('../utils/fsUtils');
 const { resolvePathWithAccess } = require('../services/accessManager');
 const { extensions } = require('../config/index');
+const env = require('../config/env');
 const { getSettings } = require('../services/settingsService');
 const { listDirectoryItems } = require('../services/directoryListingService');
 
@@ -513,7 +514,8 @@ router.get(
 
     // Determine thumbnail settings
     const settings = await getSettings();
-    const thumbsEnabled = settings?.thumbnails?.enabled !== false;
+    const thumbsEnabled =
+      env.THUMBNAILS_ENABLED !== false && settings?.thumbnails?.enabled !== false;
 
     // Directory share or navigating inside a directory share
     if (stats.isDirectory()) {

--- a/backend/src/routes/thumbnails.js
+++ b/backend/src/routes/thumbnails.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const { normalizeRelativePath } = require('../utils/pathUtils');
 const { extensions } = require('../config/index');
+const env = require('../config/env');
 const { getThumbnail } = require('../services/thumbnailService');
 const { resolvePathWithAccess } = require('../services/accessManager');
 const logger = require('../utils/logger');
@@ -29,7 +30,8 @@ router.get(
   '/thumbnails/*',
   asyncHandler(async (req, res) => {
     const settings = await getSettings();
-    const thumbsEnabled = settings?.thumbnails?.enabled !== false;
+    const thumbsEnabled =
+      env.THUMBNAILS_ENABLED !== false && settings?.thumbnails?.enabled !== false;
     if (!thumbsEnabled) {
       return res.json({ thumbnail: '' });
     }

--- a/backend/src/routes/thumbnails.js
+++ b/backend/src/routes/thumbnails.js
@@ -5,7 +5,10 @@ const path = require('path');
 const { normalizeRelativePath } = require('../utils/pathUtils');
 const { extensions } = require('../config/index');
 const env = require('../config/env');
-const { getThumbnail } = require('../services/thumbnailService');
+const {
+  getThumbnailPathIfExists,
+  queueThumbnailGeneration,
+} = require('../services/thumbnailService');
 const { resolvePathWithAccess } = require('../services/accessManager');
 const logger = require('../utils/logger');
 const asyncHandler = require('../utils/asyncHandler');
@@ -79,26 +82,28 @@ router.get(
       throw new ValidationError('Thumbnails are not available for this file type.');
     }
 
-    let thumbnail = '';
     try {
-      thumbnail = await getThumbnail(absolutePath);
+      const cachedThumbnail = await getThumbnailPathIfExists(absolutePath, stats);
+      if (cachedThumbnail) {
+        return res.json({ thumbnail: cachedThumbnail, pending: false });
+      }
+
+      const result = await queueThumbnailGeneration(absolutePath);
+      return res.status(result.pending ? 202 : 200).json(result);
     } catch (error) {
       logger.warn(
         { absolutePath, err: error },
-        'Thumbnail generation failed, falling back to original file'
+        'Thumbnail generation scheduling failed, falling back to original file'
       );
     }
 
-    // If thumbnail generation failed or produced no result, fall back to the original file
-    if (
-      !thumbnail &&
-      (extensions.images.includes(extension) || (extensions.rawImages || []).includes(extension))
-    ) {
+    // If thumbnail scheduling failed unexpectedly, fall back to the original file for images.
+    if (extensions.images.includes(extension) || (extensions.rawImages || []).includes(extension)) {
       const previewUrl = `/api/preview?path=${encodeURIComponent(logicalPath)}`;
       return res.json({ thumbnail: previewUrl });
     }
 
-    res.json({ thumbnail: thumbnail || '' });
+    res.json({ thumbnail: '', pending: false });
   })
 );
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,6 +3,17 @@
  * This file is responsible for starting the server and should NOT be imported in tests.
  * Tests should import the app directly from ./app.js
  */
+
+// Size the libuv thread pool up front, before any async filesystem work runs.
+// Directory listings do one fs.stat per entry through this pool; with the Node
+// default of 4 threads those stats queue behind concurrent thumbnail-generation
+// fs operations (realpath/stat/rename), which makes folder navigation stall
+// while a large media folder is being processed. Overridable via the env var
+// (also set in the Docker image); this default only applies when unset.
+if (!process.env.UV_THREADPOOL_SIZE) {
+  process.env.UV_THREADPOOL_SIZE = '16';
+}
+
 const { createApp } = require('./app');
 const { port, http, features, address } = require('./config/index');
 const logger = require('./utils/logger');

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -112,7 +112,7 @@ const THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE = Number.isFinite(env.THUMBNAIL_CACHE_C
   : 500;
 const THUMBNAIL_VIDEO_CONCURRENCY = Number.isFinite(env.THUMBNAIL_VIDEO_CONCURRENCY)
   ? Math.max(1, Math.min(8, Math.floor(env.THUMBNAIL_VIDEO_CONCURRENCY)))
-  : 2;
+  : 3;
 const THUMBNAIL_VIDEO_SEEK_SECONDS = Number.isFinite(env.THUMBNAIL_VIDEO_SEEK_SECONDS)
   ? Math.max(0, Math.floor(env.THUMBNAIL_VIDEO_SEEK_SECONDS))
   : 5;
@@ -127,7 +127,7 @@ const THUMBNAIL_VIDEO_SCALE_FLAGS = /^[a-z0-9_+.-]+$/i.test(env.THUMBNAIL_VIDEO_
   : 'fast_bilinear';
 const THUMBNAIL_BACKGROUND_QUEUE_LIMIT = Number.isFinite(env.THUMBNAIL_BACKGROUND_QUEUE_LIMIT)
   ? Math.max(1, Math.min(100, Math.floor(env.THUMBNAIL_BACKGROUND_QUEUE_LIMIT)))
-  : 8;
+  : 16;
 const THUMBNAIL_DIAGNOSTICS_ENABLED = env.THUMBNAIL_DIAGNOSTICS_ENABLED === true;
 const THUMBNAIL_DIAGNOSTICS_INTERVAL_MS = Number.isFinite(env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS)
   ? Math.max(5000, Math.floor(env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS))
@@ -545,7 +545,7 @@ const makeImageThumb = async (srcPath, destPath) => {
       withoutEnlargement: true,
       fastShrinkOnLoad: true,
     })
-    .webp({ quality, effort: 4 });
+    .webp({ quality, effort: 3 });
 
   await atomicWriteSharpFile(destPath, pipeline);
 };
@@ -713,7 +713,7 @@ const makeHeicThumb = async (srcPath, destPath) => {
     });
 
     let settled = false;
-    const pipeline = sharp().webp({ quality, effort: 4 });
+    const pipeline = sharp().webp({ quality, effort: 3 });
     convert.stdout.pipe(pipeline);
 
     const cleanup = ({ killProcess = false } = {}) => {

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -23,7 +23,21 @@ const getThumbOptions = async () => {
 
 const currentConcurrency = sharp.concurrency();
 sharp.concurrency(Math.max(1, Math.min(8, currentConcurrency)));
-sharp.cache({ memory: 256, files: 0 });
+const SHARP_CACHE_MEMORY_MB = Number.isFinite(env.THUMBNAIL_SHARP_CACHE_MEMORY_MB)
+  ? Math.max(0, Math.min(256, Math.floor(env.THUMBNAIL_SHARP_CACHE_MEMORY_MB)))
+  : 32;
+const configureSharpCache = () => {
+  sharp.cache({
+    memory: SHARP_CACHE_MEMORY_MB,
+    files: 0,
+    items: 100,
+  });
+};
+const trimSharpCache = () => {
+  sharp.cache(false);
+  configureSharpCache();
+};
+configureSharpCache();
 
 const EXECUTABLE_CANDIDATES = {
   ffmpeg: [env.FFMPEG_PATH, '/usr/local/bin/ffmpeg', '/usr/bin/ffmpeg', '/opt/homebrew/bin/ffmpeg'],
@@ -108,9 +122,31 @@ const thumbnailQueue = new PQueue({
 let queueConcurrencyRefreshPromise = null;
 let lastQueueConcurrencyRefreshAt = 0;
 let lastQueueConcurrency = thumbnailQueue.concurrency;
+let sharpCacheTrimTimer = null;
 let thumbnailCacheCleanupPromise = null;
 let thumbnailCacheCleanupTimer = null;
 let lastThumbnailCacheCleanupAt = 0;
+
+const scheduleSharpCacheTrim = ({ delayMs = 10 * 1000 } = {}) => {
+  if (sharpCacheTrimTimer) {
+    clearTimeout(sharpCacheTrimTimer);
+  }
+
+  sharpCacheTrimTimer = setTimeout(() => {
+    sharpCacheTrimTimer = null;
+    if (thumbnailQueue.size === 0 && thumbnailQueue.pending === 0) {
+      trimSharpCache();
+      logger.debug({ memoryMb: SHARP_CACHE_MEMORY_MB }, 'Sharp thumbnail cache trimmed');
+      return;
+    }
+
+    scheduleSharpCacheTrim({ delayMs });
+  }, delayMs);
+
+  if (typeof sharpCacheTrimTimer.unref === 'function') {
+    sharpCacheTrimTimer.unref();
+  }
+};
 
 // Update queue concurrency from settings
 const updateQueueConcurrency = async ({ force = false } = {}) => {
@@ -243,26 +279,52 @@ const makeVideoThumb = async (srcPath, destPath) => {
       inputOptions.push('-hwaccel_output_format', env.FFMPEG_HWACCEL_OUTPUT_FORMAT);
     }
 
+    let stream = null;
+    let pipeline = null;
+    let settled = false;
+
+    const cleanup = () => {
+      if (stream && !stream.destroyed) {
+        stream.destroy();
+      }
+      if (pipeline && !pipeline.destroyed) {
+        pipeline.destroy();
+      }
+    };
+
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
     const command = ffmpeg(srcPath)
       .inputOptions(inputOptions)
       .seekInput(seconds)
       .outputOptions(['-frames:v', '1', '-vf', `scale=${size}:-1:flags=lanczos`, '-vcodec', 'png'])
       .format('image2pipe')
-      .on('error', reject);
+      .on('error', fail);
 
-    const stream = command.pipe();
-    stream.on('error', reject);
+    stream = command.pipe();
+    stream.on('error', fail);
 
     (async () => {
       const { quality } = await getThumbOptions();
-      const pipeline = sharp().webp({ quality, effort: 4 });
+      pipeline = sharp().webp({ quality, effort: 4 });
       stream.pipe(pipeline);
       pipeline
         .toBuffer()
         .then((buffer) => atomicWrite(destPath, buffer))
-        .then(resolve)
-        .catch(reject);
-    })().catch(reject);
+        .then(done)
+        .catch(fail);
+    })().catch(fail);
   });
 };
 
@@ -286,24 +348,49 @@ const makeHeicThumb = async (srcPath, destPath) => {
       stderr += data.toString();
     });
 
+    let pipeline = null;
+    let settled = false;
+
+    const cleanup = () => {
+      if (pipeline && !pipeline.destroyed) {
+        pipeline.destroy();
+      }
+      if (!convert.killed) {
+        convert.kill('SIGKILL');
+      }
+    };
+
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
     convert.on('error', (err) => {
-      reject(new Error(`Failed to spawn ImageMagick convert: ${err.message}`));
+      fail(new Error(`Failed to spawn ImageMagick convert: ${err.message}`));
     });
 
     convert.on('exit', (code) => {
       if (code !== 0 && code !== null) {
-        reject(new Error(`ImageMagick convert exited with code ${code}: ${stderr}`));
+        fail(new Error(`ImageMagick convert exited with code ${code}: ${stderr}`));
       }
     });
 
-    const pipeline = sharp().webp({ quality, effort: 4 });
+    pipeline = sharp().webp({ quality, effort: 4 });
     convert.stdout.pipe(pipeline);
 
     pipeline
       .toBuffer()
       .then((buffer) => atomicWrite(destPath, buffer))
-      .then(resolve)
-      .catch(reject);
+      .then(done)
+      .catch(fail);
   });
 };
 
@@ -550,6 +637,7 @@ const getThumbnail = async (filePath) => {
       .finally(() => {
         // Clean up inflight map when done
         inflight.delete(thumbPath);
+        scheduleSharpCacheTrim();
       });
 
     inflight.set(thumbPath, pending);

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -74,14 +74,15 @@ const configureFfmpegBinaries = () => {
     logger.warn('FFmpeg binary not found. Video thumbnails will be skipped.');
   }
 
+  const ffprobeRequired = env.THUMBNAIL_VIDEO_SEEK_PERCENT != null;
   const ffprobePath = resolveExecutable(EXECUTABLE_CANDIDATES.ffprobe);
   if (ffprobePath) {
     ffmpeg.setFfprobePath(ffprobePath);
-  } else {
+  } else if (ffprobeRequired) {
     logger.warn('ffprobe binary not found. Video thumbnails will be skipped.');
   }
 
-  canProcessVideoThumbnails = Boolean(ffmpegPath && ffprobePath);
+  canProcessVideoThumbnails = Boolean(ffmpegPath && (!ffprobeRequired || ffprobePath));
 };
 
 configureFfmpegBinaries();
@@ -111,6 +112,18 @@ const THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE = Number.isFinite(env.THUMBNAIL_CACHE_C
 const THUMBNAIL_VIDEO_CONCURRENCY = Number.isFinite(env.THUMBNAIL_VIDEO_CONCURRENCY)
   ? Math.max(1, Math.min(4, Math.floor(env.THUMBNAIL_VIDEO_CONCURRENCY)))
   : 1;
+const THUMBNAIL_VIDEO_SEEK_SECONDS = Number.isFinite(env.THUMBNAIL_VIDEO_SEEK_SECONDS)
+  ? Math.max(0, Math.floor(env.THUMBNAIL_VIDEO_SEEK_SECONDS))
+  : 5;
+const THUMBNAIL_VIDEO_SEEK_PERCENT = Number.isFinite(env.THUMBNAIL_VIDEO_SEEK_PERCENT)
+  ? Math.max(0, Math.min(1, Number(env.THUMBNAIL_VIDEO_SEEK_PERCENT)))
+  : null;
+const THUMBNAIL_VIDEO_THREADS = Number.isFinite(env.THUMBNAIL_VIDEO_THREADS)
+  ? Math.max(1, Math.min(8, Math.floor(env.THUMBNAIL_VIDEO_THREADS)))
+  : 1;
+const THUMBNAIL_VIDEO_SCALE_FLAGS = /^[a-z0-9_+.-]+$/i.test(env.THUMBNAIL_VIDEO_SCALE_FLAGS || '')
+  ? env.THUMBNAIL_VIDEO_SCALE_FLAGS
+  : 'fast_bilinear';
 const THUMBNAIL_DIAGNOSTICS_ENABLED = env.THUMBNAIL_DIAGNOSTICS_ENABLED === true;
 const THUMBNAIL_DIAGNOSTICS_INTERVAL_MS = Number.isFinite(env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS)
   ? Math.max(5000, Math.floor(env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS))
@@ -258,6 +271,10 @@ const startThumbnailDiagnostics = () => {
       cacheMaxFiles: THUMBNAIL_CACHE_MAX_FILES,
       sharpCacheMemoryMb: SHARP_CACHE_MEMORY_MB,
       videoConcurrency: THUMBNAIL_VIDEO_CONCURRENCY,
+      videoSeekSeconds: THUMBNAIL_VIDEO_SEEK_SECONDS,
+      videoSeekPercent: THUMBNAIL_VIDEO_SEEK_PERCENT,
+      videoThreads: THUMBNAIL_VIDEO_THREADS,
+      videoScaleFlags: THUMBNAIL_VIDEO_SCALE_FLAGS,
     },
     'Thumbnail diagnostics enabled'
   );
@@ -518,19 +535,33 @@ const probeDuration = (filePath) =>
     });
   });
 
+const resolveVideoSeekSeconds = async (filePath) => {
+  if (THUMBNAIL_VIDEO_SEEK_PERCENT == null) {
+    return THUMBNAIL_VIDEO_SEEK_SECONDS;
+  }
+
+  const duration = await probeDuration(filePath);
+  if (!duration || !Number.isFinite(duration)) {
+    return THUMBNAIL_VIDEO_SEEK_SECONDS;
+  }
+
+  return Math.max(0, Math.floor(duration * THUMBNAIL_VIDEO_SEEK_PERCENT));
+};
+
 const makeVideoThumb = async (srcPath, destPath) => {
   if (!canProcessVideoThumbnails) {
     logger.warn({ srcPath }, 'Skipping video thumbnail (no ffmpeg/ffprobe)');
     return;
   }
 
-  const duration = await probeDuration(srcPath);
-  const seconds =
-    duration && Number.isFinite(duration) ? Math.max(1, Math.floor(duration * 0.05)) : 1;
+  const seconds = await resolveVideoSeekSeconds(srcPath);
   const { size, quality } = await getThumbOptions();
 
   await new Promise((resolve, reject) => {
     const inputOptions = ['-hide_banner', '-loglevel', 'error'];
+    if (THUMBNAIL_VIDEO_THREADS > 0) {
+      inputOptions.push('-threads', String(THUMBNAIL_VIDEO_THREADS));
+    }
 
     if (env.FFMPEG_HWACCEL) {
       inputOptions.push('-hwaccel', env.FFMPEG_HWACCEL);
@@ -585,7 +616,23 @@ const makeVideoThumb = async (srcPath, destPath) => {
     command = ffmpeg(srcPath)
       .inputOptions(inputOptions)
       .seekInput(seconds)
-      .outputOptions(['-frames:v', '1', '-vf', `scale=${size}:-1:flags=lanczos`, '-vcodec', 'png'])
+      .outputOptions([
+        '-map',
+        '0:v:0',
+        '-an',
+        '-sn',
+        '-dn',
+        '-frames:v',
+        '1',
+        '-vf',
+        `scale=${size}:-1:flags=${THUMBNAIL_VIDEO_SCALE_FLAGS}`,
+        '-threads',
+        String(THUMBNAIL_VIDEO_THREADS),
+        '-vcodec',
+        'mjpeg',
+        '-q:v',
+        '4',
+      ])
       .format('image2pipe')
       .on('start', () => {
         externalProcessId = registerExternalProcess('ffmpeg', srcPath, command?.ffmpegProc?.pid, {
@@ -602,7 +649,7 @@ const makeVideoThumb = async (srcPath, destPath) => {
     stream.on('error', fail);
 
     (async () => {
-      pipeline = sharp().webp({ quality, effort: 4 });
+      pipeline = sharp().webp({ quality, effort: 3 });
       stream.pipe(pipeline);
       atomicWriteSharpFile(destPath, pipeline).then(done).catch(fail);
     })().catch(fail);

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -79,8 +79,19 @@ const isPdf = (ext) => ext === 'pdf';
 const isHeic = (ext) => ext === 'heic';
 
 const inflight = new Map();
+const failedThumbnails = new Map();
 
 const THUMBNAIL_CACHE_VERSION = 2;
+const QUEUE_CONCURRENCY_REFRESH_INTERVAL_MS = 30 * 1000;
+const FAILED_THUMBNAIL_TTL_MS = 10 * 60 * 1000;
+const FAILED_THUMBNAIL_MAX_ENTRIES = 1000;
+const THUMBNAIL_CACHE_MAX_FILES = Number.isFinite(env.THUMBNAIL_CACHE_MAX_FILES)
+  ? Math.max(0, Math.floor(env.THUMBNAIL_CACHE_MAX_FILES))
+  : 3000;
+const THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS = Number.isFinite(env.THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS)
+  ? Math.max(60 * 1000, Math.floor(env.THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS))
+  : 60 * 60 * 1000;
+const THUMBNAIL_CACHE_TARGET_RATIO = 0.9;
 
 // Create thumbnail generation queue with concurrency limit
 // This prevents overwhelming the system with too many concurrent sharp/ffmpeg operations
@@ -91,20 +102,49 @@ const thumbnailQueue = new PQueue({
   throwOnTimeout: false,
 });
 
+let queueConcurrencyRefreshPromise = null;
+let lastQueueConcurrencyRefreshAt = 0;
+let lastQueueConcurrency = thumbnailQueue.concurrency;
+let thumbnailCacheCleanupPromise = null;
+let thumbnailCacheCleanupTimer = null;
+let lastThumbnailCacheCleanupAt = 0;
+
 // Update queue concurrency from settings
-const updateQueueConcurrency = async () => {
-  try {
-    const settings = await getSettings();
-    const concurrency = settings?.thumbnails?.concurrency || 10;
-    thumbnailQueue.concurrency = concurrency;
-    logger.info({ concurrency }, 'Thumbnail queue concurrency set');
-  } catch (error) {
-    logger.warn({ err: error }, 'Failed to update thumbnail queue concurrency');
+const updateQueueConcurrency = async ({ force = false } = {}) => {
+  const now = Date.now();
+  if (!force && now - lastQueueConcurrencyRefreshAt < QUEUE_CONCURRENCY_REFRESH_INTERVAL_MS) {
+    return;
   }
+
+  if (queueConcurrencyRefreshPromise) {
+    return queueConcurrencyRefreshPromise;
+  }
+
+  queueConcurrencyRefreshPromise = (async () => {
+    lastQueueConcurrencyRefreshAt = Date.now();
+
+    try {
+      const settings = await getSettings();
+      const rawConcurrency = Number(settings?.thumbnails?.concurrency) || 10;
+      const concurrency = Math.max(1, Math.min(50, Math.floor(rawConcurrency)));
+
+      if (concurrency !== lastQueueConcurrency) {
+        thumbnailQueue.concurrency = concurrency;
+        lastQueueConcurrency = concurrency;
+        logger.info({ concurrency }, 'Thumbnail queue concurrency set');
+      }
+    } catch (error) {
+      logger.warn({ err: error }, 'Failed to update thumbnail queue concurrency');
+    } finally {
+      queueConcurrencyRefreshPromise = null;
+    }
+  })();
+
+  return queueConcurrencyRefreshPromise;
 };
 
 // Initialize concurrency from settings
-updateQueueConcurrency();
+updateQueueConcurrency({ force: true });
 
 // Log queue stats periodically for monitoring
 thumbnailQueue.on('active', () => {
@@ -301,6 +341,129 @@ const buildThumbnailPaths = async (filePath, stats = null) => {
   return { thumbFile, thumbPath };
 };
 
+const getFailedThumbnail = (thumbPath) => {
+  const failedAt = failedThumbnails.get(thumbPath);
+  if (!failedAt) {
+    return false;
+  }
+
+  if (Date.now() - failedAt > FAILED_THUMBNAIL_TTL_MS) {
+    failedThumbnails.delete(thumbPath);
+    return false;
+  }
+
+  return true;
+};
+
+const markFailedThumbnail = (thumbPath) => {
+  if (failedThumbnails.size >= FAILED_THUMBNAIL_MAX_ENTRIES) {
+    const oldestKey = failedThumbnails.keys().next().value;
+    if (oldestKey) {
+      failedThumbnails.delete(oldestKey);
+    }
+  }
+
+  failedThumbnails.set(thumbPath, Date.now());
+};
+
+const cleanupThumbnailCache = async () => {
+  if (THUMBNAIL_CACHE_MAX_FILES <= 0) {
+    return;
+  }
+
+  if (thumbnailCacheCleanupPromise) {
+    return thumbnailCacheCleanupPromise;
+  }
+
+  thumbnailCacheCleanupPromise = (async () => {
+    lastThumbnailCacheCleanupAt = Date.now();
+
+    try {
+      await ensureDir(directories.thumbnails);
+      const dirents = await fsPromises.readdir(directories.thumbnails, { withFileTypes: true });
+      const fileNames = dirents.filter((entry) => entry.isFile()).map((entry) => entry.name);
+
+      if (fileNames.length <= THUMBNAIL_CACHE_MAX_FILES) {
+        return;
+      }
+
+      const files = [];
+      for (const name of fileNames) {
+        const filePath = path.join(directories.thumbnails, name);
+        try {
+          const stats = await fsPromises.stat(filePath);
+          files.push({ filePath, mtimeMs: stats.mtimeMs });
+        } catch (_) {
+          // File may have been removed by another request.
+        }
+      }
+
+      if (files.length <= THUMBNAIL_CACHE_MAX_FILES) {
+        return;
+      }
+
+      files.sort((a, b) => a.mtimeMs - b.mtimeMs);
+      const targetCount = Math.max(
+        0,
+        Math.floor(THUMBNAIL_CACHE_MAX_FILES * THUMBNAIL_CACHE_TARGET_RATIO)
+      );
+      const deleteCount = Math.max(0, files.length - targetCount);
+      const toDelete = files.slice(0, deleteCount);
+
+      let deleted = 0;
+      for (const file of toDelete) {
+        try {
+          await fsPromises.rm(file.filePath, { force: true });
+          deleted += 1;
+        } catch (_) {
+          // Best-effort cache cleanup.
+        }
+      }
+
+      logger.info(
+        {
+          deleted,
+          before: files.length,
+          target: targetCount,
+          max: THUMBNAIL_CACHE_MAX_FILES,
+        },
+        'Thumbnail cache cleanup completed'
+      );
+    } catch (error) {
+      logger.warn({ err: error }, 'Thumbnail cache cleanup failed');
+    } finally {
+      thumbnailCacheCleanupPromise = null;
+    }
+  })();
+
+  return thumbnailCacheCleanupPromise;
+};
+
+const scheduleThumbnailCacheCleanup = ({ force = false, delayMs = 5000 } = {}) => {
+  if (THUMBNAIL_CACHE_MAX_FILES <= 0) {
+    return;
+  }
+
+  const now = Date.now();
+  if (!force && now - lastThumbnailCacheCleanupAt < THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS) {
+    return;
+  }
+
+  if (thumbnailCacheCleanupTimer || thumbnailCacheCleanupPromise) {
+    return;
+  }
+
+  thumbnailCacheCleanupTimer = setTimeout(() => {
+    thumbnailCacheCleanupTimer = null;
+    cleanupThumbnailCache().catch(() => {});
+  }, delayMs);
+  if (typeof thumbnailCacheCleanupTimer.unref === 'function') {
+    thumbnailCacheCleanupTimer.unref();
+  }
+};
+
+scheduleThumbnailCacheCleanup({ force: true, delayMs: 30 * 1000 });
+
 const getThumbnailPathIfExists = async (filePath, stats = null) => {
   if (filePath.includes(directories.thumbnails)) {
     return '';
@@ -336,9 +499,14 @@ const getThumbnail = async (filePath) => {
   // Check if thumbnail already exists (fast path)
   try {
     await fsPromises.access(thumbPath, fs.constants.F_OK);
+    failedThumbnails.delete(thumbPath);
     return `/static/thumbnails/${thumbFile}`;
   } catch (error) {
     // Thumbnail doesn't exist, need to generate
+  }
+
+  if (getFailedThumbnail(thumbPath)) {
+    return '';
   }
 
   // Update queue concurrency from settings (non-blocking)
@@ -361,6 +529,7 @@ const getThumbnail = async (filePath) => {
 
           logger.debug({ filePath, thumbPath }, 'Generating thumbnail');
           await generateThumbnail(filePath, thumbPath);
+          scheduleThumbnailCacheCleanup();
 
           // Verify generation succeeded
           try {
@@ -375,6 +544,7 @@ const getThumbnail = async (filePath) => {
             return '';
           }
         } catch (error) {
+          markFailedThumbnail(thumbPath);
           logger.error({ filePath, err: error }, 'Thumbnail generation failed');
           throw error;
         }

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -111,8 +111,8 @@ const THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE = Number.isFinite(env.THUMBNAIL_CACHE_C
   ? Math.max(1, Math.floor(env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE))
   : 500;
 const THUMBNAIL_VIDEO_CONCURRENCY = Number.isFinite(env.THUMBNAIL_VIDEO_CONCURRENCY)
-  ? Math.max(1, Math.min(4, Math.floor(env.THUMBNAIL_VIDEO_CONCURRENCY)))
-  : 1;
+  ? Math.max(1, Math.min(8, Math.floor(env.THUMBNAIL_VIDEO_CONCURRENCY)))
+  : 2;
 const THUMBNAIL_VIDEO_SEEK_SECONDS = Number.isFinite(env.THUMBNAIL_VIDEO_SEEK_SECONDS)
   ? Math.max(0, Math.floor(env.THUMBNAIL_VIDEO_SEEK_SECONDS))
   : 5;
@@ -121,7 +121,7 @@ const THUMBNAIL_VIDEO_SEEK_PERCENT = Number.isFinite(env.THUMBNAIL_VIDEO_SEEK_PE
   : null;
 const THUMBNAIL_VIDEO_THREADS = Number.isFinite(env.THUMBNAIL_VIDEO_THREADS)
   ? Math.max(1, Math.min(8, Math.floor(env.THUMBNAIL_VIDEO_THREADS)))
-  : 1;
+  : 2;
 const THUMBNAIL_VIDEO_SCALE_FLAGS = /^[a-z0-9_+.-]+$/i.test(env.THUMBNAIL_VIDEO_SCALE_FLAGS || '')
   ? env.THUMBNAIL_VIDEO_SCALE_FLAGS
   : 'fast_bilinear';
@@ -183,6 +183,32 @@ let thumbnailDiagnosticsTimer = null;
 
 const toMb = (bytes) => Math.round((Number(bytes) || 0) / 1024 / 1024);
 
+// Cheap snapshots used on hot paths (per job/process). Avoid building the full
+// getDiagnosticsSnapshot() object when only memory or queue depth is needed.
+const currentMemoryMb = () => {
+  const memory = process.memoryUsage();
+  return {
+    rss: toMb(memory.rss),
+    heapUsed: toMb(memory.heapUsed),
+    heapTotal: toMb(memory.heapTotal),
+    external: toMb(memory.external),
+    arrayBuffers: toMb(memory.arrayBuffers),
+  };
+};
+
+const queuesSnapshot = () => ({
+  thumbnail: {
+    size: thumbnailQueue.size,
+    pending: thumbnailQueue.pending,
+    concurrency: thumbnailQueue.concurrency,
+  },
+  video: {
+    size: videoThumbnailQueue.size,
+    pending: videoThumbnailQueue.pending,
+    concurrency: videoThumbnailQueue.concurrency,
+  },
+});
+
 const summarizeActiveMap = (map, { now = Date.now(), limit = 5 } = {}) =>
   Array.from(map.values())
     .map((item) => ({
@@ -216,30 +242,12 @@ const safeSharpDiagnostics = () => {
 
 const getDiagnosticsSnapshot = () => {
   const now = Date.now();
-  const memory = process.memoryUsage();
   const activeJobs = Array.from(activeThumbnailJobs.values());
   const activeProcesses = Array.from(activeExternalProcesses.values());
 
   return {
-    memoryMb: {
-      rss: toMb(memory.rss),
-      heapUsed: toMb(memory.heapUsed),
-      heapTotal: toMb(memory.heapTotal),
-      external: toMb(memory.external),
-      arrayBuffers: toMb(memory.arrayBuffers),
-    },
-    queues: {
-      thumbnail: {
-        size: thumbnailQueue.size,
-        pending: thumbnailQueue.pending,
-        concurrency: thumbnailQueue.concurrency,
-      },
-      video: {
-        size: videoThumbnailQueue.size,
-        pending: videoThumbnailQueue.pending,
-        concurrency: videoThumbnailQueue.concurrency,
-      },
-    },
+    memoryMb: currentMemoryMb(),
+    queues: queuesSnapshot(),
     counts: {
       inflight: inflight.size,
       failedCache: failedThumbnails.size,
@@ -322,7 +330,7 @@ const startThumbnailJob = (filePath, thumbPath) => {
 
   activeThumbnailJobs.set(id, job);
   if (THUMBNAIL_DIAGNOSTICS_ENABLED) {
-    logger.info({ job, queues: getDiagnosticsSnapshot().queues }, 'Thumbnail job started');
+    logger.info({ job, queues: queuesSnapshot() }, 'Thumbnail job started');
   }
   return id;
 };
@@ -333,17 +341,20 @@ const finishThumbnailJob = (id, status, error = null) => {
 
   activeThumbnailJobs.delete(id);
   const durationMs = Date.now() - job.startedAt;
-  const payload = {
-    job,
-    status,
-    durationMs,
-    memoryMb: getDiagnosticsSnapshot().memoryMb,
-    error: error ? error.message : undefined,
-  };
-
-  if (THUMBNAIL_DIAGNOSTICS_ENABLED || durationMs >= THUMBNAIL_SLOW_JOB_MS) {
-    logger.info(payload, 'Thumbnail job finished');
+  if (!THUMBNAIL_DIAGNOSTICS_ENABLED && durationMs < THUMBNAIL_SLOW_JOB_MS) {
+    return;
   }
+
+  logger.info(
+    {
+      job,
+      status,
+      durationMs,
+      memoryMb: currentMemoryMb(),
+      error: error ? error.message : undefined,
+    },
+    'Thumbnail job finished'
+  );
 };
 
 // Lower the CPU scheduling priority of a spawned child (ffmpeg/convert) so the
@@ -380,7 +391,7 @@ const registerExternalProcess = (type, filePath, pid, extra = {}) => {
 
   if (THUMBNAIL_DIAGNOSTICS_ENABLED) {
     logger.info(
-      { process: item, memoryMb: getDiagnosticsSnapshot().memoryMb },
+      { process: item, memoryMb: currentMemoryMb() },
       'Thumbnail external process started'
     );
   }
@@ -402,7 +413,7 @@ const unregisterExternalProcess = (id, status, error = null) => {
         status,
         durationMs,
         error: error ? error.message : undefined,
-        memoryMb: getDiagnosticsSnapshot().memoryMb,
+        memoryMb: currentMemoryMb(),
       },
       'Thumbnail external process finished'
     );
@@ -491,18 +502,6 @@ const updateQueueConcurrency = async ({ force = false } = {}) => {
 
 // Initialize concurrency from settings
 updateQueueConcurrency({ force: true });
-
-// Log queue stats periodically for monitoring
-thumbnailQueue.on('active', () => {
-  logger.debug(
-    {
-      size: thumbnailQueue.size,
-      pending: thumbnailQueue.pending,
-      concurrency: thumbnailQueue.concurrency,
-    },
-    'Thumbnail queue status'
-  );
-});
 
 const resolveThumbnailSourceIdentity = async (filePath) => {
   try {
@@ -1021,14 +1020,12 @@ const getThumbnail = async (filePath) => {
             // Still doesn't exist, generate it
           }
 
-          logger.debug({ filePath, thumbPath }, 'Generating thumbnail');
           await generateThumbnail(filePath, thumbPath);
           scheduleThumbnailCacheCleanup();
 
           // Verify generation succeeded
           try {
             await fsPromises.access(thumbPath, fs.constants.F_OK);
-            logger.debug({ filePath, thumbPath }, 'Thumbnail generated successfully');
             thumbnailStats.generated += 1;
             finishThumbnailJob(jobId, 'generated');
             return `/static/thumbnails/${thumbFile}`;

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -108,6 +108,9 @@ const THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS = Number.isFinite(env.THUMBNAIL_CACHE_
 const THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE = Number.isFinite(env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE)
   ? Math.max(1, Math.floor(env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE))
   : 500;
+const THUMBNAIL_VIDEO_CONCURRENCY = Number.isFinite(env.THUMBNAIL_VIDEO_CONCURRENCY)
+  ? Math.max(1, Math.min(4, Math.floor(env.THUMBNAIL_VIDEO_CONCURRENCY)))
+  : 1;
 const THUMBNAIL_CACHE_CONTINUE_DELAY_MS = 30 * 1000;
 const THUMBNAIL_CACHE_DIR = path.resolve(directories.thumbnails);
 const THUMBNAIL_CACHE_FILE_PATTERN = /^v\d+-(?:[a-f0-9]{40}|[a-f0-9]{64})\.webp$/i;
@@ -119,6 +122,12 @@ const THUMBNAILS_ENABLED = env.THUMBNAILS_ENABLED !== false;
 const thumbnailQueue = new PQueue({
   concurrency: 10, // Default: 10 concurrent thumbnail generations (updated from settings)
   timeout: 30000, // 30 second timeout per thumbnail
+  throwOnTimeout: false,
+});
+
+const videoThumbnailQueue = new PQueue({
+  concurrency: THUMBNAIL_VIDEO_CONCURRENCY,
+  timeout: 30000,
   throwOnTimeout: false,
 });
 
@@ -232,7 +241,8 @@ const hashForFile = async (filePath, stats = null) => {
   return hash.digest('hex');
 };
 
-const buildTempThumbnailPath = (finalPath) => `${finalPath}.tmp-${process.pid}-${Date.now()}`;
+const buildTempThumbnailPath = (finalPath) =>
+  `${finalPath}.tmp-${process.pid}-${Date.now()}-${crypto.randomUUID()}`;
 
 const atomicWriteSharpFile = async (finalPath, pipeline) => {
   await ensureDir(path.dirname(finalPath));
@@ -289,15 +299,9 @@ const makeVideoThumb = async (srcPath, destPath) => {
   const duration = await probeDuration(srcPath);
   const seconds =
     duration && Number.isFinite(duration) ? Math.max(1, Math.floor(duration * 0.05)) : 1;
+  const { size, quality } = await getThumbOptions();
 
   await new Promise((resolve, reject) => {
-    // Size is dynamic; capture inside ffmpeg filter
-    let size = 200;
-    getThumbOptions()
-      .then(({ size: sz }) => {
-        size = sz;
-      })
-      .catch(() => {});
     const inputOptions = ['-hide_banner', '-loglevel', 'error'];
 
     if (env.FFMPEG_HWACCEL) {
@@ -314,9 +318,17 @@ const makeVideoThumb = async (srcPath, destPath) => {
 
     let stream = null;
     let pipeline = null;
+    let command = null;
     let settled = false;
 
-    const cleanup = () => {
+    const cleanup = ({ killProcess = false } = {}) => {
+      if (killProcess) {
+        try {
+          command?.kill('SIGKILL');
+        } catch (_) {
+          // noop
+        }
+      }
       if (stream && !stream.destroyed) {
         stream.destroy();
       }
@@ -328,7 +340,7 @@ const makeVideoThumb = async (srcPath, destPath) => {
     const fail = (error) => {
       if (settled) return;
       settled = true;
-      cleanup();
+      cleanup({ killProcess: true });
       reject(error);
     };
 
@@ -339,7 +351,7 @@ const makeVideoThumb = async (srcPath, destPath) => {
       resolve();
     };
 
-    const command = ffmpeg(srcPath)
+    command = ffmpeg(srcPath)
       .inputOptions(inputOptions)
       .seekInput(seconds)
       .outputOptions(['-frames:v', '1', '-vf', `scale=${size}:-1:flags=lanczos`, '-vcodec', 'png'])
@@ -350,7 +362,6 @@ const makeVideoThumb = async (srcPath, destPath) => {
     stream.on('error', fail);
 
     (async () => {
-      const { quality } = await getThumbOptions();
       pipeline = sharp().webp({ quality, effort: 4 });
       stream.pipe(pipeline);
       atomicWriteSharpFile(destPath, pipeline).then(done).catch(fail);
@@ -378,14 +389,15 @@ const makeHeicThumb = async (srcPath, destPath) => {
       stderr += data.toString();
     });
 
-    let pipeline = null;
     let settled = false;
+    const pipeline = sharp().webp({ quality, effort: 4 });
+    convert.stdout.pipe(pipeline);
 
-    const cleanup = () => {
+    const cleanup = ({ killProcess = false } = {}) => {
       if (pipeline && !pipeline.destroyed) {
         pipeline.destroy();
       }
-      if (!convert.killed) {
+      if (killProcess && !convert.killed) {
         convert.kill('SIGKILL');
       }
     };
@@ -393,31 +405,31 @@ const makeHeicThumb = async (srcPath, destPath) => {
     const fail = (error) => {
       if (settled) return;
       settled = true;
-      cleanup();
+      cleanup({ killProcess: true });
       reject(error);
-    };
-
-    const done = () => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve();
     };
 
     convert.on('error', (err) => {
       fail(new Error(`Failed to spawn ImageMagick convert: ${err.message}`));
     });
 
-    convert.on('exit', (code) => {
-      if (code !== 0 && code !== null) {
-        fail(new Error(`ImageMagick convert exited with code ${code}: ${stderr}`));
-      }
+    const convertDone = new Promise((resolveConvert, rejectConvert) => {
+      convert.on('close', (code) => {
+        if (code !== 0 && code !== null) {
+          rejectConvert(new Error(`ImageMagick convert exited with code ${code}: ${stderr}`));
+          return;
+        }
+        resolveConvert();
+      });
     });
 
-    pipeline = sharp().webp({ quality, effort: 4 });
-    convert.stdout.pipe(pipeline);
-
-    atomicWriteSharpFile(destPath, pipeline).then(done).catch(fail);
+    Promise.all([atomicWriteSharpFile(destPath, pipeline), convertDone])
+      .then(() => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      })
+      .catch(fail);
   });
 };
 
@@ -444,7 +456,7 @@ const generateThumbnail = async (filePath, thumbPath) => {
   }
 
   if (isVideo(extension)) {
-    await makeVideoThumb(filePath, thumbPath);
+    await videoThumbnailQueue.add(() => makeVideoThumb(filePath, thumbPath));
     return;
   }
 

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -96,7 +96,7 @@ const isHeic = (ext) => ext === 'heic';
 const inflight = new Map();
 const failedThumbnails = new Map();
 
-const THUMBNAIL_CACHE_VERSION = 2;
+const THUMBNAIL_CACHE_VERSION = 3;
 const QUEUE_CONCURRENCY_REFRESH_INTERVAL_MS = 30 * 1000;
 const FAILED_THUMBNAIL_TTL_MS = 10 * 60 * 1000;
 const FAILED_THUMBNAIL_MAX_ENTRIES = 1000;
@@ -477,12 +477,18 @@ thumbnailQueue.on('active', () => {
   );
 });
 
-const hashForFile = async (filePath, stats = null) => {
-  const info = stats || (await fsPromises.stat(filePath));
+const resolveThumbnailSourceIdentity = async (filePath) => {
+  try {
+    return await fsPromises.realpath(filePath);
+  } catch (_) {
+    return path.resolve(filePath);
+  }
+};
+
+const hashForFile = async (filePath) => {
+  const sourceIdentity = await resolveThumbnailSourceIdentity(filePath);
   const hash = crypto.createHash('sha1');
-  hash.update(filePath);
-  hash.update(String(info.size));
-  hash.update(String(Math.floor(info.mtimeMs)));
+  hash.update(sourceIdentity);
   return hash.digest('hex');
 };
 
@@ -753,11 +759,24 @@ const generateThumbnail = async (filePath, thumbPath) => {
   throw new Error(`Unsupported file type: .${extension}`);
 };
 
-const buildThumbnailPaths = async (filePath, stats = null) => {
-  const key = await hashForFile(filePath, stats);
+const buildThumbnailPaths = async (filePath) => {
+  const key = await hashForFile(filePath);
   const thumbFile = `v${THUMBNAIL_CACHE_VERSION}-${key}.webp`;
   const thumbPath = path.join(directories.thumbnails, thumbFile);
   return { thumbFile, thumbPath };
+};
+
+const isThumbnailFresh = async (thumbPath, sourceStats = null, filePath = null) => {
+  try {
+    const [thumbStats, currentSourceStats] = await Promise.all([
+      fsPromises.stat(thumbPath),
+      sourceStats ? Promise.resolve(sourceStats) : fsPromises.stat(filePath),
+    ]);
+
+    return thumbStats.mtimeMs >= currentSourceStats.mtimeMs;
+  } catch (_) {
+    return false;
+  }
 };
 
 const getFailedThumbnail = (thumbPath) => {
@@ -803,15 +822,24 @@ const cleanupThumbnailCache = async () => {
       const dirents = await fsPromises.readdir(directories.thumbnails, { withFileTypes: true });
       const fileNames = dirents.filter((entry) => entry.isFile()).map((entry) => entry.name);
 
-      if (fileNames.length <= THUMBNAIL_CACHE_MAX_FILES) {
+      const currentVersionPrefix = `v${THUMBNAIL_CACHE_VERSION}-`;
+      const oldVersionNames = fileNames.filter(
+        (name) => THUMBNAIL_CACHE_FILE_PATTERN.test(name) && !name.startsWith(currentVersionPrefix)
+      );
+      const oversizedCount = Math.max(0, fileNames.length - THUMBNAIL_CACHE_MAX_FILES);
+      const deleteCount = Math.min(
+        Math.max(oldVersionNames.length, oversizedCount),
+        THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE
+      );
+
+      if (deleteCount <= 0) {
         return;
       }
 
-      const deleteCount = Math.min(
-        fileNames.length - THUMBNAIL_CACHE_MAX_FILES,
-        THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE
-      );
-      const toDelete = fileNames.slice(0, deleteCount);
+      const toDelete = [
+        ...oldVersionNames,
+        ...fileNames.filter((name) => !oldVersionNames.includes(name)),
+      ].slice(0, deleteCount);
 
       let deleted = 0;
       for (const name of toDelete) {
@@ -830,13 +858,17 @@ const cleanupThumbnailCache = async () => {
           remainingEstimate: Math.max(0, fileNames.length - deleted),
           max: THUMBNAIL_CACHE_MAX_FILES,
           batchSize: THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE,
+          oldVersionCandidates: oldVersionNames.length,
         },
         'Thumbnail cache cleanup batch completed'
       );
       thumbnailStats.cacheCleanupDeleted += deleted;
       logThumbnailDiagnostics('cache-cleanup', { cleanupDeleted: deleted });
 
-      if (fileNames.length - deleted > THUMBNAIL_CACHE_MAX_FILES) {
+      if (
+        oldVersionNames.length > deleted ||
+        fileNames.length - deleted > THUMBNAIL_CACHE_MAX_FILES
+      ) {
         shouldContinueCleanup = true;
       }
     } catch (error) {
@@ -890,10 +922,12 @@ const getThumbnailPathIfExists = async (filePath, stats = null) => {
     return '';
   }
 
-  const { thumbFile, thumbPath } = await buildThumbnailPaths(filePath, stats);
+  const { thumbFile, thumbPath } = await buildThumbnailPaths(filePath);
 
   try {
-    await fsPromises.access(thumbPath, fs.constants.F_OK);
+    if (!(await isThumbnailFresh(thumbPath, stats, filePath))) {
+      return '';
+    }
     return `/static/thumbnails/${thumbFile}`;
   } catch (error) {
     return '';
@@ -911,16 +945,14 @@ const getThumbnail = async (filePath) => {
     return '';
   }
 
+  const sourceStats = await fsPromises.stat(filePath);
   const { thumbFile, thumbPath } = await buildThumbnailPaths(filePath);
 
   // Check if thumbnail already exists (fast path)
-  try {
-    await fsPromises.access(thumbPath, fs.constants.F_OK);
+  if (await isThumbnailFresh(thumbPath, sourceStats, filePath)) {
     failedThumbnails.delete(thumbPath);
     thumbnailStats.cacheHits += 1;
     return `/static/thumbnails/${thumbFile}`;
-  } catch (error) {
-    // Thumbnail doesn't exist, need to generate
   }
 
   if (getFailedThumbnail(thumbPath)) {
@@ -942,7 +974,9 @@ const getThumbnail = async (filePath) => {
         try {
           // Double-check if another request created it while we were queued
           try {
-            await fsPromises.access(thumbPath, fs.constants.F_OK);
+            if (!(await isThumbnailFresh(thumbPath, sourceStats, filePath))) {
+              throw new Error('Stale or missing thumbnail');
+            }
             thumbnailStats.cacheHits += 1;
             finishThumbnailJob(jobId, 'cache-hit');
             return `/static/thumbnails/${thumbFile}`;

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -91,7 +91,10 @@ const THUMBNAIL_CACHE_MAX_FILES = Number.isFinite(env.THUMBNAIL_CACHE_MAX_FILES)
 const THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS = Number.isFinite(env.THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS)
   ? Math.max(60 * 1000, Math.floor(env.THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS))
   : 60 * 60 * 1000;
-const THUMBNAIL_CACHE_TARGET_RATIO = 0.9;
+const THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE = Number.isFinite(env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE)
+  ? Math.max(1, Math.floor(env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE))
+  : 500;
+const THUMBNAIL_CACHE_CONTINUE_DELAY_MS = 30 * 1000;
 
 // Create thumbnail generation queue with concurrency limit
 // This prevents overwhelming the system with too many concurrent sharp/ffmpeg operations
@@ -377,6 +380,7 @@ const cleanupThumbnailCache = async () => {
 
   thumbnailCacheCleanupPromise = (async () => {
     lastThumbnailCacheCleanupAt = Date.now();
+    let shouldContinueCleanup = false;
 
     try {
       await ensureDir(directories.thumbnails);
@@ -387,33 +391,16 @@ const cleanupThumbnailCache = async () => {
         return;
       }
 
-      const files = [];
-      for (const name of fileNames) {
-        const filePath = path.join(directories.thumbnails, name);
-        try {
-          const stats = await fsPromises.stat(filePath);
-          files.push({ filePath, mtimeMs: stats.mtimeMs });
-        } catch (_) {
-          // File may have been removed by another request.
-        }
-      }
-
-      if (files.length <= THUMBNAIL_CACHE_MAX_FILES) {
-        return;
-      }
-
-      files.sort((a, b) => a.mtimeMs - b.mtimeMs);
-      const targetCount = Math.max(
-        0,
-        Math.floor(THUMBNAIL_CACHE_MAX_FILES * THUMBNAIL_CACHE_TARGET_RATIO)
+      const deleteCount = Math.min(
+        fileNames.length - THUMBNAIL_CACHE_MAX_FILES,
+        THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE
       );
-      const deleteCount = Math.max(0, files.length - targetCount);
-      const toDelete = files.slice(0, deleteCount);
+      const toDelete = fileNames.slice(0, deleteCount);
 
       let deleted = 0;
-      for (const file of toDelete) {
+      for (const name of toDelete) {
         try {
-          await fsPromises.rm(file.filePath, { force: true });
+          await fsPromises.rm(path.join(directories.thumbnails, name), { force: true });
           deleted += 1;
         } catch (_) {
           // Best-effort cache cleanup.
@@ -423,16 +410,27 @@ const cleanupThumbnailCache = async () => {
       logger.info(
         {
           deleted,
-          before: files.length,
-          target: targetCount,
+          before: fileNames.length,
+          remainingEstimate: Math.max(0, fileNames.length - deleted),
           max: THUMBNAIL_CACHE_MAX_FILES,
+          batchSize: THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE,
         },
-        'Thumbnail cache cleanup completed'
+        'Thumbnail cache cleanup batch completed'
       );
+
+      if (fileNames.length - deleted > THUMBNAIL_CACHE_MAX_FILES) {
+        shouldContinueCleanup = true;
+      }
     } catch (error) {
       logger.warn({ err: error }, 'Thumbnail cache cleanup failed');
     } finally {
       thumbnailCacheCleanupPromise = null;
+      if (shouldContinueCleanup) {
+        scheduleThumbnailCacheCleanup({
+          force: true,
+          delayMs: THUMBNAIL_CACHE_CONTINUE_DELAY_MS,
+        });
+      }
     }
   })();
 
@@ -462,7 +460,7 @@ const scheduleThumbnailCacheCleanup = ({ force = false, delayMs = 5000 } = {}) =
   }
 };
 
-scheduleThumbnailCacheCleanup({ force: true, delayMs: 30 * 1000 });
+scheduleThumbnailCacheCleanup({ force: true, delayMs: 2 * 60 * 1000 });
 
 const getThumbnailPathIfExists = async (filePath, stats = null) => {
   if (filePath.includes(directories.thumbnails)) {

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -111,10 +111,30 @@ const THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE = Number.isFinite(env.THUMBNAIL_CACHE_C
 const THUMBNAIL_VIDEO_CONCURRENCY = Number.isFinite(env.THUMBNAIL_VIDEO_CONCURRENCY)
   ? Math.max(1, Math.min(4, Math.floor(env.THUMBNAIL_VIDEO_CONCURRENCY)))
   : 1;
+const THUMBNAIL_DIAGNOSTICS_ENABLED = env.THUMBNAIL_DIAGNOSTICS_ENABLED === true;
+const THUMBNAIL_DIAGNOSTICS_INTERVAL_MS = Number.isFinite(env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS)
+  ? Math.max(5000, Math.floor(env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS))
+  : 30000;
+const THUMBNAIL_SLOW_JOB_MS = Number.isFinite(env.THUMBNAIL_SLOW_JOB_MS)
+  ? Math.max(1000, Math.floor(env.THUMBNAIL_SLOW_JOB_MS))
+  : 10000;
 const THUMBNAIL_CACHE_CONTINUE_DELAY_MS = 30 * 1000;
 const THUMBNAIL_CACHE_DIR = path.resolve(directories.thumbnails);
 const THUMBNAIL_CACHE_FILE_PATTERN = /^v\d+-(?:[a-f0-9]{40}|[a-f0-9]{64})\.webp$/i;
 const THUMBNAILS_ENABLED = env.THUMBNAILS_ENABLED !== false;
+const activeThumbnailJobs = new Map();
+const activeExternalProcesses = new Map();
+const thumbnailStats = {
+  requests: 0,
+  cacheHits: 0,
+  queued: 0,
+  generated: 0,
+  failed: 0,
+  failedTtlSkips: 0,
+  cacheCleanupDeleted: 0,
+  ffmpegStarted: 0,
+  convertStarted: 0,
+};
 
 // Create thumbnail generation queue with concurrency limit
 // This prevents overwhelming the system with too many concurrent sharp/ffmpeg operations
@@ -138,6 +158,214 @@ let sharpCacheTrimTimer = null;
 let thumbnailCacheCleanupPromise = null;
 let thumbnailCacheCleanupTimer = null;
 let lastThumbnailCacheCleanupAt = 0;
+let thumbnailDiagnosticsTimer = null;
+
+const toMb = (bytes) => Math.round((Number(bytes) || 0) / 1024 / 1024);
+
+const summarizeActiveMap = (map, { now = Date.now(), limit = 5 } = {}) =>
+  Array.from(map.values())
+    .map((item) => ({
+      id: item.id,
+      type: item.type,
+      ext: item.ext,
+      fileName: item.fileName,
+      pid: item.pid,
+      ageMs: now - item.startedAt,
+    }))
+    .sort((a, b) => b.ageMs - a.ageMs)
+    .slice(0, limit);
+
+const countBy = (items, key) =>
+  items.reduce((acc, item) => {
+    const value = item[key] || 'unknown';
+    acc[value] = (acc[value] || 0) + 1;
+    return acc;
+  }, {});
+
+const safeSharpDiagnostics = () => {
+  try {
+    return {
+      cache: sharp.cache(),
+      counters: sharp.counters(),
+    };
+  } catch (error) {
+    return { error: error.message };
+  }
+};
+
+const getDiagnosticsSnapshot = () => {
+  const now = Date.now();
+  const memory = process.memoryUsage();
+  const activeJobs = Array.from(activeThumbnailJobs.values());
+  const activeProcesses = Array.from(activeExternalProcesses.values());
+
+  return {
+    memoryMb: {
+      rss: toMb(memory.rss),
+      heapUsed: toMb(memory.heapUsed),
+      heapTotal: toMb(memory.heapTotal),
+      external: toMb(memory.external),
+      arrayBuffers: toMb(memory.arrayBuffers),
+    },
+    queues: {
+      thumbnail: {
+        size: thumbnailQueue.size,
+        pending: thumbnailQueue.pending,
+        concurrency: thumbnailQueue.concurrency,
+      },
+      video: {
+        size: videoThumbnailQueue.size,
+        pending: videoThumbnailQueue.pending,
+        concurrency: videoThumbnailQueue.concurrency,
+      },
+    },
+    counts: {
+      inflight: inflight.size,
+      failedCache: failedThumbnails.size,
+      activeJobs: activeJobs.length,
+      activeExternalProcesses: activeProcesses.length,
+    },
+    activeByType: countBy(activeJobs, 'type'),
+    activeByExt: countBy(activeJobs, 'ext'),
+    activeExternalByType: countBy(activeProcesses, 'type'),
+    oldestJobs: summarizeActiveMap(activeThumbnailJobs, { now }),
+    oldestExternalProcesses: summarizeActiveMap(activeExternalProcesses, { now }),
+    stats: { ...thumbnailStats },
+    sharp: safeSharpDiagnostics(),
+    cleanup: {
+      cacheMaxFiles: THUMBNAIL_CACHE_MAX_FILES,
+      cleanupInProgress: Boolean(thumbnailCacheCleanupPromise),
+      cleanupTimerScheduled: Boolean(thumbnailCacheCleanupTimer),
+      lastCleanupAgeMs: lastThumbnailCacheCleanupAt ? now - lastThumbnailCacheCleanupAt : null,
+    },
+  };
+};
+
+const logThumbnailDiagnostics = (reason, extra = {}) => {
+  if (!THUMBNAIL_DIAGNOSTICS_ENABLED) return;
+  logger.info({ reason, ...getDiagnosticsSnapshot(), ...extra }, 'Thumbnail diagnostics');
+};
+
+const startThumbnailDiagnostics = () => {
+  if (!THUMBNAIL_DIAGNOSTICS_ENABLED || thumbnailDiagnosticsTimer) {
+    return;
+  }
+
+  logger.info(
+    {
+      intervalMs: THUMBNAIL_DIAGNOSTICS_INTERVAL_MS,
+      slowJobMs: THUMBNAIL_SLOW_JOB_MS,
+      cacheMaxFiles: THUMBNAIL_CACHE_MAX_FILES,
+      sharpCacheMemoryMb: SHARP_CACHE_MEMORY_MB,
+      videoConcurrency: THUMBNAIL_VIDEO_CONCURRENCY,
+    },
+    'Thumbnail diagnostics enabled'
+  );
+
+  thumbnailDiagnosticsTimer = setInterval(() => {
+    logThumbnailDiagnostics('interval');
+  }, THUMBNAIL_DIAGNOSTICS_INTERVAL_MS);
+
+  if (typeof thumbnailDiagnosticsTimer.unref === 'function') {
+    thumbnailDiagnosticsTimer.unref();
+  }
+};
+
+const startThumbnailJob = (filePath, thumbPath) => {
+  const id = crypto.randomUUID();
+  const ext = path.extname(filePath).toLowerCase().slice(1) || 'unknown';
+  const type = isVideo(ext)
+    ? 'video'
+    : isHeic(ext)
+      ? 'heic'
+      : isRawImage(ext)
+        ? 'raw'
+        : isImage(ext)
+          ? 'image'
+          : ext;
+  const job = {
+    id,
+    type,
+    ext,
+    fileName: path.basename(filePath),
+    thumbFile: path.basename(thumbPath),
+    startedAt: Date.now(),
+  };
+
+  activeThumbnailJobs.set(id, job);
+  if (THUMBNAIL_DIAGNOSTICS_ENABLED) {
+    logger.info({ job, queues: getDiagnosticsSnapshot().queues }, 'Thumbnail job started');
+  }
+  return id;
+};
+
+const finishThumbnailJob = (id, status, error = null) => {
+  const job = activeThumbnailJobs.get(id);
+  if (!job) return;
+
+  activeThumbnailJobs.delete(id);
+  const durationMs = Date.now() - job.startedAt;
+  const payload = {
+    job,
+    status,
+    durationMs,
+    memoryMb: getDiagnosticsSnapshot().memoryMb,
+    error: error ? error.message : undefined,
+  };
+
+  if (THUMBNAIL_DIAGNOSTICS_ENABLED || durationMs >= THUMBNAIL_SLOW_JOB_MS) {
+    logger.info(payload, 'Thumbnail job finished');
+  }
+};
+
+const registerExternalProcess = (type, filePath, pid, extra = {}) => {
+  const id = crypto.randomUUID();
+  const item = {
+    id,
+    type,
+    ext: path.extname(filePath).toLowerCase().slice(1) || 'unknown',
+    fileName: path.basename(filePath),
+    pid: pid || null,
+    startedAt: Date.now(),
+    ...extra,
+  };
+
+  activeExternalProcesses.set(id, item);
+  if (type === 'ffmpeg') thumbnailStats.ffmpegStarted += 1;
+  if (type === 'convert') thumbnailStats.convertStarted += 1;
+
+  if (THUMBNAIL_DIAGNOSTICS_ENABLED) {
+    logger.info(
+      { process: item, memoryMb: getDiagnosticsSnapshot().memoryMb },
+      'Thumbnail external process started'
+    );
+  }
+
+  return id;
+};
+
+const unregisterExternalProcess = (id, status, error = null) => {
+  if (!id) return;
+  const item = activeExternalProcesses.get(id);
+  if (!item) return;
+
+  activeExternalProcesses.delete(id);
+  const durationMs = Date.now() - item.startedAt;
+  if (THUMBNAIL_DIAGNOSTICS_ENABLED || durationMs >= THUMBNAIL_SLOW_JOB_MS) {
+    logger.info(
+      {
+        process: item,
+        status,
+        durationMs,
+        error: error ? error.message : undefined,
+        memoryMb: getDiagnosticsSnapshot().memoryMb,
+      },
+      'Thumbnail external process finished'
+    );
+  }
+};
+
+startThumbnailDiagnostics();
 
 const scheduleSharpCacheTrim = ({ delayMs = 2 * 1000 } = {}) => {
   if (sharpCacheTrimTimer) {
@@ -319,6 +547,7 @@ const makeVideoThumb = async (srcPath, destPath) => {
     let stream = null;
     let pipeline = null;
     let command = null;
+    let externalProcessId = null;
     let settled = false;
 
     const cleanup = ({ killProcess = false } = {}) => {
@@ -340,6 +569,7 @@ const makeVideoThumb = async (srcPath, destPath) => {
     const fail = (error) => {
       if (settled) return;
       settled = true;
+      unregisterExternalProcess(externalProcessId, 'error', error);
       cleanup({ killProcess: true });
       reject(error);
     };
@@ -347,6 +577,7 @@ const makeVideoThumb = async (srcPath, destPath) => {
     const done = () => {
       if (settled) return;
       settled = true;
+      unregisterExternalProcess(externalProcessId, 'success');
       cleanup();
       resolve();
     };
@@ -356,6 +587,15 @@ const makeVideoThumb = async (srcPath, destPath) => {
       .seekInput(seconds)
       .outputOptions(['-frames:v', '1', '-vf', `scale=${size}:-1:flags=lanczos`, '-vcodec', 'png'])
       .format('image2pipe')
+      .on('start', () => {
+        externalProcessId = registerExternalProcess('ffmpeg', srcPath, command?.ffmpegProc?.pid, {
+          seekSeconds: seconds,
+          size,
+        });
+      })
+      .on('end', () => {
+        unregisterExternalProcess(externalProcessId, 'success');
+      })
       .on('error', fail);
 
     stream = command.pipe();
@@ -383,6 +623,7 @@ const makeHeicThumb = async (srcPath, destPath) => {
       '100',
       'png:-',
     ]);
+    const externalProcessId = registerExternalProcess('convert', srcPath, convert.pid, { size });
 
     let stderr = '';
     convert.stderr.on('data', (data) => {
@@ -405,6 +646,7 @@ const makeHeicThumb = async (srcPath, destPath) => {
     const fail = (error) => {
       if (settled) return;
       settled = true;
+      unregisterExternalProcess(externalProcessId, 'error', error);
       cleanup({ killProcess: true });
       reject(error);
     };
@@ -427,6 +669,7 @@ const makeHeicThumb = async (srcPath, destPath) => {
       .then(() => {
         if (settled) return;
         settled = true;
+        unregisterExternalProcess(externalProcessId, 'success');
         resolve();
       })
       .catch(fail);
@@ -543,6 +786,8 @@ const cleanupThumbnailCache = async () => {
         },
         'Thumbnail cache cleanup batch completed'
       );
+      thumbnailStats.cacheCleanupDeleted += deleted;
+      logThumbnailDiagnostics('cache-cleanup', { cleanupDeleted: deleted });
 
       if (fileNames.length - deleted > THUMBNAIL_CACHE_MAX_FILES) {
         shouldContinueCleanup = true;
@@ -612,6 +857,7 @@ const getThumbnail = async (filePath) => {
   if (!THUMBNAILS_ENABLED || isThumbnailCachePath(filePath)) {
     return '';
   }
+  thumbnailStats.requests += 1;
 
   const extension = path.extname(filePath).toLowerCase().slice(1);
   if (isPdf(extension)) {
@@ -624,12 +870,14 @@ const getThumbnail = async (filePath) => {
   try {
     await fsPromises.access(thumbPath, fs.constants.F_OK);
     failedThumbnails.delete(thumbPath);
+    thumbnailStats.cacheHits += 1;
     return `/static/thumbnails/${thumbFile}`;
   } catch (error) {
     // Thumbnail doesn't exist, need to generate
   }
 
   if (getFailedThumbnail(thumbPath)) {
+    thumbnailStats.failedTtlSkips += 1;
     return '';
   }
 
@@ -639,13 +887,17 @@ const getThumbnail = async (filePath) => {
   // Check if generation is already in progress for this file
   let pending = inflight.get(thumbPath);
   if (!pending) {
+    thumbnailStats.queued += 1;
     // Queue the thumbnail generation with concurrency limit
     pending = thumbnailQueue
       .add(async () => {
+        const jobId = startThumbnailJob(filePath, thumbPath);
         try {
           // Double-check if another request created it while we were queued
           try {
             await fsPromises.access(thumbPath, fs.constants.F_OK);
+            thumbnailStats.cacheHits += 1;
+            finishThumbnailJob(jobId, 'cache-hit');
             return `/static/thumbnails/${thumbFile}`;
           } catch (error) {
             // Still doesn't exist, generate it
@@ -659,17 +911,22 @@ const getThumbnail = async (filePath) => {
           try {
             await fsPromises.access(thumbPath, fs.constants.F_OK);
             logger.debug({ filePath, thumbPath }, 'Thumbnail generated successfully');
+            thumbnailStats.generated += 1;
+            finishThumbnailJob(jobId, 'generated');
             return `/static/thumbnails/${thumbFile}`;
           } catch (missing) {
             logger.warn(
               { filePath, thumbPath },
               'Thumbnail generation completed but file not found'
             );
+            finishThumbnailJob(jobId, 'missing');
             return '';
           }
         } catch (error) {
+          thumbnailStats.failed += 1;
           markFailedThumbnail(thumbPath);
           logger.error({ filePath, err: error }, 'Thumbnail generation failed');
+          finishThumbnailJob(jobId, 'error', error);
           throw error;
         }
       })

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -124,6 +124,9 @@ const THUMBNAIL_VIDEO_THREADS = Number.isFinite(env.THUMBNAIL_VIDEO_THREADS)
 const THUMBNAIL_VIDEO_SCALE_FLAGS = /^[a-z0-9_+.-]+$/i.test(env.THUMBNAIL_VIDEO_SCALE_FLAGS || '')
   ? env.THUMBNAIL_VIDEO_SCALE_FLAGS
   : 'fast_bilinear';
+const THUMBNAIL_BACKGROUND_QUEUE_LIMIT = Number.isFinite(env.THUMBNAIL_BACKGROUND_QUEUE_LIMIT)
+  ? Math.max(1, Math.min(100, Math.floor(env.THUMBNAIL_BACKGROUND_QUEUE_LIMIT)))
+  : 8;
 const THUMBNAIL_DIAGNOSTICS_ENABLED = env.THUMBNAIL_DIAGNOSTICS_ENABLED === true;
 const THUMBNAIL_DIAGNOSTICS_INTERVAL_MS = Number.isFinite(env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS)
   ? Math.max(5000, Math.floor(env.THUMBNAIL_DIAGNOSTICS_INTERVAL_MS))
@@ -145,6 +148,7 @@ const thumbnailStats = {
   failed: 0,
   failedTtlSkips: 0,
   cacheCleanupDeleted: 0,
+  backgroundQueueSkipped: 0,
   ffmpegStarted: 0,
   convertStarted: 0,
 };
@@ -275,6 +279,7 @@ const startThumbnailDiagnostics = () => {
       videoSeekPercent: THUMBNAIL_VIDEO_SEEK_PERCENT,
       videoThreads: THUMBNAIL_VIDEO_THREADS,
       videoScaleFlags: THUMBNAIL_VIDEO_SCALE_FLAGS,
+      backgroundQueueLimit: THUMBNAIL_BACKGROUND_QUEUE_LIMIT,
     },
     'Thumbnail diagnostics enabled'
   );
@@ -766,6 +771,13 @@ const buildThumbnailPaths = async (filePath) => {
   return { thumbFile, thumbPath };
 };
 
+const getThumbnailQueueLoad = () =>
+  inflight.size +
+  thumbnailQueue.size +
+  thumbnailQueue.pending +
+  videoThumbnailQueue.size +
+  videoThumbnailQueue.pending;
+
 const isThumbnailFresh = async (thumbPath, sourceStats = null, filePath = null) => {
   try {
     const [thumbStats, currentSourceStats] = await Promise.all([
@@ -1023,19 +1035,47 @@ const getThumbnail = async (filePath) => {
   return pending;
 };
 
-const queueThumbnailGeneration = (filePath) => {
+const queueThumbnailGeneration = async (filePath) => {
   if (!THUMBNAILS_ENABLED || !filePath || isThumbnailCachePath(filePath)) {
-    return;
+    return { thumbnail: '', pending: false, queued: false };
   }
 
   const extension = path.extname(filePath).toLowerCase().slice(1);
   if (isPdf(extension)) {
-    return;
+    return { thumbnail: '', pending: false, queued: false };
+  }
+
+  const sourceStats = await fsPromises.stat(filePath);
+  const { thumbFile, thumbPath } = await buildThumbnailPaths(filePath);
+  if (await isThumbnailFresh(thumbPath, sourceStats, filePath)) {
+    failedThumbnails.delete(thumbPath);
+    thumbnailStats.cacheHits += 1;
+    return {
+      thumbnail: `/static/thumbnails/${thumbFile}`,
+      pending: false,
+      queued: false,
+    };
+  }
+
+  if (getFailedThumbnail(thumbPath)) {
+    thumbnailStats.failedTtlSkips += 1;
+    return { thumbnail: '', pending: false, queued: false };
+  }
+
+  if (inflight.has(thumbPath)) {
+    return { thumbnail: '', pending: true, queued: true };
+  }
+
+  if (getThumbnailQueueLoad() >= THUMBNAIL_BACKGROUND_QUEUE_LIMIT) {
+    thumbnailStats.backgroundQueueSkipped += 1;
+    return { thumbnail: '', pending: true, queued: false, retryAfterMs: 1500 };
   }
 
   getThumbnail(filePath).catch((error) => {
     logger.warn({ filePath, err: error }, 'Queued thumbnail generation failed');
   });
+
+  return { thumbnail: '', pending: true, queued: true };
 };
 
 module.exports = {

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -30,7 +30,7 @@ const configureSharpCache = () => {
   sharp.cache({
     memory: SHARP_CACHE_MEMORY_MB,
     files: 0,
-    items: 100,
+    items: SHARP_CACHE_MEMORY_MB > 0 ? 100 : 0,
   });
 };
 const trimSharpCache = () => {
@@ -109,6 +109,9 @@ const THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE = Number.isFinite(env.THUMBNAIL_CACHE_C
   ? Math.max(1, Math.floor(env.THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE))
   : 500;
 const THUMBNAIL_CACHE_CONTINUE_DELAY_MS = 30 * 1000;
+const THUMBNAIL_CACHE_DIR = path.resolve(directories.thumbnails);
+const THUMBNAIL_CACHE_FILE_PATTERN = /^v\d+-(?:[a-f0-9]{40}|[a-f0-9]{64})\.webp$/i;
+const THUMBNAILS_ENABLED = env.THUMBNAILS_ENABLED !== false;
 
 // Create thumbnail generation queue with concurrency limit
 // This prevents overwhelming the system with too many concurrent sharp/ffmpeg operations
@@ -127,7 +130,7 @@ let thumbnailCacheCleanupPromise = null;
 let thumbnailCacheCleanupTimer = null;
 let lastThumbnailCacheCleanupAt = 0;
 
-const scheduleSharpCacheTrim = ({ delayMs = 10 * 1000 } = {}) => {
+const scheduleSharpCacheTrim = ({ delayMs = 2 * 1000 } = {}) => {
   if (sharpCacheTrimTimer) {
     clearTimeout(sharpCacheTrimTimer);
   }
@@ -146,6 +149,29 @@ const scheduleSharpCacheTrim = ({ delayMs = 10 * 1000 } = {}) => {
   if (typeof sharpCacheTrimTimer.unref === 'function') {
     sharpCacheTrimTimer.unref();
   }
+};
+
+const isInsideDirectory = (candidatePath, directoryPath) => {
+  if (!candidatePath) {
+    return false;
+  }
+
+  const relativePath = path.relative(directoryPath, path.resolve(candidatePath));
+  return (
+    relativePath === '' ||
+    (!!relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+};
+
+const isThumbnailCachePath = (filePath) => {
+  if (!filePath) {
+    return false;
+  }
+
+  return (
+    isInsideDirectory(filePath, THUMBNAIL_CACHE_DIR) ||
+    THUMBNAIL_CACHE_FILE_PATTERN.test(path.basename(filePath))
+  );
 };
 
 // Update queue concurrency from settings
@@ -206,16 +232,24 @@ const hashForFile = async (filePath, stats = null) => {
   return hash.digest('hex');
 };
 
-const atomicWrite = async (finalPath, buffer) => {
+const buildTempThumbnailPath = (finalPath) => `${finalPath}.tmp-${process.pid}-${Date.now()}`;
+
+const atomicWriteSharpFile = async (finalPath, pipeline) => {
   await ensureDir(path.dirname(finalPath));
-  const tmpPath = `${finalPath}.tmp-${process.pid}-${Date.now()}`;
-  await fsPromises.writeFile(tmpPath, buffer);
-  await fsPromises.rename(tmpPath, finalPath);
+  const tmpPath = buildTempThumbnailPath(finalPath);
+
+  try {
+    await pipeline.toFile(tmpPath);
+    await fsPromises.rename(tmpPath, finalPath);
+  } catch (error) {
+    await fsPromises.rm(tmpPath, { force: true }).catch(() => {});
+    throw error;
+  }
 };
 
 const makeImageThumb = async (srcPath, destPath) => {
   const { size, quality } = await getThumbOptions();
-  const buffer = await sharp(srcPath)
+  const pipeline = sharp(srcPath)
     .rotate()
     .resize({
       width: size,
@@ -224,10 +258,9 @@ const makeImageThumb = async (srcPath, destPath) => {
       withoutEnlargement: true,
       fastShrinkOnLoad: true,
     })
-    .webp({ quality, effort: 4 })
-    .toBuffer();
+    .webp({ quality, effort: 4 });
 
-  await atomicWrite(destPath, buffer);
+  await atomicWriteSharpFile(destPath, pipeline);
 };
 
 const makeRawImageThumb = async (srcPath, destPath) => {
@@ -302,6 +335,7 @@ const makeVideoThumb = async (srcPath, destPath) => {
     const done = () => {
       if (settled) return;
       settled = true;
+      cleanup();
       resolve();
     };
 
@@ -319,11 +353,7 @@ const makeVideoThumb = async (srcPath, destPath) => {
       const { quality } = await getThumbOptions();
       pipeline = sharp().webp({ quality, effort: 4 });
       stream.pipe(pipeline);
-      pipeline
-        .toBuffer()
-        .then((buffer) => atomicWrite(destPath, buffer))
-        .then(done)
-        .catch(fail);
+      atomicWriteSharpFile(destPath, pipeline).then(done).catch(fail);
     })().catch(fail);
   });
 };
@@ -370,6 +400,7 @@ const makeHeicThumb = async (srcPath, destPath) => {
     const done = () => {
       if (settled) return;
       settled = true;
+      cleanup();
       resolve();
     };
 
@@ -386,11 +417,7 @@ const makeHeicThumb = async (srcPath, destPath) => {
     pipeline = sharp().webp({ quality, effort: 4 });
     convert.stdout.pipe(pipeline);
 
-    pipeline
-      .toBuffer()
-      .then((buffer) => atomicWrite(destPath, buffer))
-      .then(done)
-      .catch(fail);
+    atomicWriteSharpFile(destPath, pipeline).then(done).catch(fail);
   });
 };
 
@@ -550,7 +577,7 @@ const scheduleThumbnailCacheCleanup = ({ force = false, delayMs = 5000 } = {}) =
 scheduleThumbnailCacheCleanup({ force: true, delayMs: 2 * 60 * 1000 });
 
 const getThumbnailPathIfExists = async (filePath, stats = null) => {
-  if (filePath.includes(directories.thumbnails)) {
+  if (!THUMBNAILS_ENABLED || isThumbnailCachePath(filePath)) {
     return '';
   }
 
@@ -570,7 +597,7 @@ const getThumbnailPathIfExists = async (filePath, stats = null) => {
 };
 
 const getThumbnail = async (filePath) => {
-  if (filePath.includes(directories.thumbnails)) {
+  if (!THUMBNAILS_ENABLED || isThumbnailCachePath(filePath)) {
     return '';
   }
 
@@ -647,7 +674,7 @@ const getThumbnail = async (filePath) => {
 };
 
 const queueThumbnailGeneration = (filePath) => {
-  if (!filePath || filePath.includes(directories.thumbnails)) {
+  if (!THUMBNAILS_ENABLED || !filePath || isThumbnailCachePath(filePath)) {
     return;
   }
 
@@ -665,5 +692,6 @@ module.exports = {
   generateThumbnail,
   getThumbnail,
   getThumbnailPathIfExists,
+  isThumbnailCachePath,
   queueThumbnailGeneration,
 };

--- a/backend/src/services/thumbnailService.js
+++ b/backend/src/services/thumbnailService.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const os = require('os');
 const crypto = require('crypto');
 const fs = require('fs');
 const fsPromises = require('fs/promises');
@@ -134,6 +135,9 @@ const THUMBNAIL_DIAGNOSTICS_INTERVAL_MS = Number.isFinite(env.THUMBNAIL_DIAGNOST
 const THUMBNAIL_SLOW_JOB_MS = Number.isFinite(env.THUMBNAIL_SLOW_JOB_MS)
   ? Math.max(1000, Math.floor(env.THUMBNAIL_SLOW_JOB_MS))
   : 10000;
+const THUMBNAIL_PROCESS_NICE = Number.isFinite(env.THUMBNAIL_PROCESS_NICE)
+  ? Math.max(0, Math.min(19, Math.floor(env.THUMBNAIL_PROCESS_NICE)))
+  : 10;
 const THUMBNAIL_CACHE_CONTINUE_DELAY_MS = 30 * 1000;
 const THUMBNAIL_CACHE_DIR = path.resolve(directories.thumbnails);
 const THUMBNAIL_CACHE_FILE_PATTERN = /^v\d+-(?:[a-f0-9]{40}|[a-f0-9]{64})\.webp$/i;
@@ -280,6 +284,8 @@ const startThumbnailDiagnostics = () => {
       videoThreads: THUMBNAIL_VIDEO_THREADS,
       videoScaleFlags: THUMBNAIL_VIDEO_SCALE_FLAGS,
       backgroundQueueLimit: THUMBNAIL_BACKGROUND_QUEUE_LIMIT,
+      processNice: THUMBNAIL_PROCESS_NICE,
+      uvThreadpoolSize: process.env.UV_THREADPOOL_SIZE || null,
     },
     'Thumbnail diagnostics enabled'
   );
@@ -337,6 +343,22 @@ const finishThumbnailJob = (id, status, error = null) => {
 
   if (THUMBNAIL_DIAGNOSTICS_ENABLED || durationMs >= THUMBNAIL_SLOW_JOB_MS) {
     logger.info(payload, 'Thumbnail job finished');
+  }
+};
+
+// Lower the CPU scheduling priority of a spawned child (ffmpeg/convert) so the
+// Node event loop — and therefore directory listings and navigation — keeps CPU
+// during heavy thumbnail generation. Only ever applied to child PIDs, never to
+// the main process. Best-effort: setpriority may be unavailable or denied.
+const lowerChildProcessPriority = (pid) => {
+  if (!pid || THUMBNAIL_PROCESS_NICE <= 0) {
+    return;
+  }
+
+  try {
+    os.setPriority(pid, THUMBNAIL_PROCESS_NICE);
+  } catch (error) {
+    logger.debug({ pid, err: error }, 'Failed to lower thumbnail process priority');
   }
 };
 
@@ -646,10 +668,12 @@ const makeVideoThumb = async (srcPath, destPath) => {
       ])
       .format('image2pipe')
       .on('start', () => {
-        externalProcessId = registerExternalProcess('ffmpeg', srcPath, command?.ffmpegProc?.pid, {
+        const ffmpegPid = command?.ffmpegProc?.pid;
+        externalProcessId = registerExternalProcess('ffmpeg', srcPath, ffmpegPid, {
           seekSeconds: seconds,
           size,
         });
+        lowerChildProcessPriority(ffmpegPid);
       })
       .on('end', () => {
         unregisterExternalProcess(externalProcessId, 'success');
@@ -682,6 +706,7 @@ const makeHeicThumb = async (srcPath, destPath) => {
       'png:-',
     ]);
     const externalProcessId = registerExternalProcess('convert', srcPath, convert.pid, { size });
+    lowerChildProcessPriority(convert.pid);
 
     let stderr = '';
     convert.stderr.on('data', (data) => {

--- a/backend/tests/services/thumbnail-service.test.js
+++ b/backend/tests/services/thumbnail-service.test.js
@@ -28,6 +28,16 @@ describe('Thumbnail Service', () => {
       expect(isThumbnailCachePath(aliasedPath)).toBe(true);
     });
 
+    it('detects current v3 generated thumbnail artifacts', () => {
+      const thumbnailPath = path.join(
+        directories.volume,
+        'media',
+        'v3-0123456789abcdef0123456789abcdef01234567.webp'
+      );
+
+      expect(isThumbnailCachePath(thumbnailPath)).toBe(true);
+    });
+
     it('does not block regular webp files', () => {
       const regularImage = path.join(directories.volume, 'photos', 'cover.webp');
 

--- a/backend/tests/services/thumbnail-service.test.js
+++ b/backend/tests/services/thumbnail-service.test.js
@@ -1,0 +1,37 @@
+import path from 'path';
+import { createRequire } from 'module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { directories } = require('../../src/config');
+const { isThumbnailCachePath } = require('../../src/services/thumbnailService');
+
+describe('Thumbnail Service', () => {
+  describe('isThumbnailCachePath', () => {
+    it('detects files inside the thumbnail cache directory', () => {
+      const thumbnailPath = path.join(
+        directories.thumbnails,
+        'v2-0123456789abcdef0123456789abcdef01234567.webp'
+      );
+
+      expect(isThumbnailCachePath(thumbnailPath)).toBe(true);
+    });
+
+    it('detects generated thumbnail artifacts even when the cache is exposed through another path', () => {
+      const aliasedPath = path.join(
+        directories.volume,
+        'cache',
+        'thumbnails',
+        'v2-0123456789abcdef0123456789abcdef01234567.webp'
+      );
+
+      expect(isThumbnailCachePath(aliasedPath)).toBe(true);
+    });
+
+    it('does not block regular webp files', () => {
+      const regularImage = path.join(directories.volume, 'photos', 'cover.webp');
+
+      expect(isThumbnailCachePath(regularImage)).toBe(false);
+    });
+  });
+});

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -95,6 +95,7 @@ The sharing system (toolbar **Share** button, guest links such as `/share/:token
 | `FFMPEG_HWACCEL_DEVICE`               | _none_             | Optional ffmpeg `-hwaccel_device` value used with `FFMPEG_HWACCEL` (e.g. `0` or `/dev/dri/renderD128`).                                 |
 | `THUMBNAIL_CACHE_MAX_FILES`           | `3000`             | Maximum number of files kept in the thumbnail cache. Set `0` to disable automatic cleanup.                                              |
 | `THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS` | `3600000`          | Minimum delay between thumbnail cache cleanup scans.                                                                                    |
+| `THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE`  | `500`              | Maximum number of thumbnail cache files deleted per cleanup pass.                                                                       |
 
 ## Collabora (WOPI)
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -93,10 +93,11 @@ The sharing system (toolbar **Share** button, guest links such as `/share/:token
 | `FFMPEG_PATH`, `FFPROBE_PATH`         | _bundled binaries_ | Point to custom ffmpeg/ffprobe if the bundle doesn't suit your needs.                                                                   |
 | `FFMPEG_HWACCEL`                      | _none_             | Optional ffmpeg `-hwaccel` value used for video thumbnail generation when supported by your ffmpeg build (e.g. `vaapi`, `qsv`, `cuda`). |
 | `FFMPEG_HWACCEL_DEVICE`               | _none_             | Optional ffmpeg `-hwaccel_device` value used with `FFMPEG_HWACCEL` (e.g. `0` or `/dev/dri/renderD128`).                                 |
+| `THUMBNAILS_ENABLED`                  | `true`             | Set to `false` to disable thumbnail generation globally, regardless of the UI setting.                                                  |
 | `THUMBNAIL_CACHE_MAX_FILES`           | `3000`             | Maximum number of files kept in the thumbnail cache. Set `0` to disable automatic cleanup.                                              |
 | `THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS` | `3600000`          | Minimum delay between thumbnail cache cleanup scans.                                                                                    |
 | `THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE`  | `500`              | Maximum number of thumbnail cache files deleted per cleanup pass.                                                                       |
-| `THUMBNAIL_SHARP_CACHE_MEMORY_MB`     | `32`               | Memory in MB allowed for Sharp/libvips thumbnail cache. Lower values reduce idle RSS after thumbnail generation.                        |
+| `THUMBNAIL_SHARP_CACHE_MEMORY_MB`     | `0`                | Memory in MB allowed for Sharp/libvips thumbnail cache. Keep `0` to minimize idle RSS after thumbnail generation.                       |
 
 ## Collabora (WOPI)
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -99,6 +99,9 @@ The sharing system (toolbar **Share** button, guest links such as `/share/:token
 | `THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE`  | `500`              | Maximum number of thumbnail cache files deleted per cleanup pass.                                                                       |
 | `THUMBNAIL_SHARP_CACHE_MEMORY_MB`     | `0`                | Memory in MB allowed for Sharp/libvips thumbnail cache. Keep `0` to minimize idle RSS after thumbnail generation.                       |
 | `THUMBNAIL_VIDEO_CONCURRENCY`         | `1`                | Maximum number of concurrent ffmpeg thumbnail jobs. Keep low on small hosts to avoid memory spikes.                                     |
+| `THUMBNAIL_DIAGNOSTICS_ENABLED`       | `false`            | Enable periodic thumbnail diagnostics logs with queue, memory, active job, external process, and cache cleanup counters.                |
+| `THUMBNAIL_DIAGNOSTICS_INTERVAL_MS`   | `30000`            | Interval between thumbnail diagnostics logs when diagnostics are enabled.                                                               |
+| `THUMBNAIL_SLOW_JOB_MS`               | `10000`            | Duration threshold after which a thumbnail job/process is logged even when diagnostics are disabled.                                    |
 
 ## Collabora (WOPI)
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -83,16 +83,18 @@ The sharing system (toolbar **Share** button, guest links such as `/share/:token
 
 ## OnlyOffice & thumbnails
 
-| Variable                      | Default            | Description                                                                                                                             |
-| ----------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `ONLYOFFICE_URL`              | _none_             | Public URL for Document Server (must reach your app's `PUBLIC_URL`).                                                                    |
-| `ONLYOFFICE_SECRET`           | _none_             | JWT secret shared with OnlyOffice Document Server for `/api/onlyoffice` calls.                                                          |
-| `ONLYOFFICE_LANG`             | `en`               | Language code for the editor UI.                                                                                                        |
-| `ONLYOFFICE_FORCE_SAVE`       | `false`            | When true, OnlyOffice forces users to save via the editor UI.                                                                           |
-| `ONLYOFFICE_FILE_EXTENSIONS`  | _default list_     | Extra file extensions to surface to the Document Server.                                                                                |
-| `FFMPEG_PATH`, `FFPROBE_PATH` | _bundled binaries_ | Point to custom ffmpeg/ffprobe if the bundle doesn't suit your needs.                                                                   |
-| `FFMPEG_HWACCEL`              | _none_             | Optional ffmpeg `-hwaccel` value used for video thumbnail generation when supported by your ffmpeg build (e.g. `vaapi`, `qsv`, `cuda`). |
-| `FFMPEG_HWACCEL_DEVICE`       | _none_             | Optional ffmpeg `-hwaccel_device` value used with `FFMPEG_HWACCEL` (e.g. `0` or `/dev/dri/renderD128`).                                 |
+| Variable                              | Default            | Description                                                                                                                             |
+| ------------------------------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `ONLYOFFICE_URL`                      | _none_             | Public URL for Document Server (must reach your app's `PUBLIC_URL`).                                                                    |
+| `ONLYOFFICE_SECRET`                   | _none_             | JWT secret shared with OnlyOffice Document Server for `/api/onlyoffice` calls.                                                          |
+| `ONLYOFFICE_LANG`                     | `en`               | Language code for the editor UI.                                                                                                        |
+| `ONLYOFFICE_FORCE_SAVE`               | `false`            | When true, OnlyOffice forces users to save via the editor UI.                                                                           |
+| `ONLYOFFICE_FILE_EXTENSIONS`          | _default list_     | Extra file extensions to surface to the Document Server.                                                                                |
+| `FFMPEG_PATH`, `FFPROBE_PATH`         | _bundled binaries_ | Point to custom ffmpeg/ffprobe if the bundle doesn't suit your needs.                                                                   |
+| `FFMPEG_HWACCEL`                      | _none_             | Optional ffmpeg `-hwaccel` value used for video thumbnail generation when supported by your ffmpeg build (e.g. `vaapi`, `qsv`, `cuda`). |
+| `FFMPEG_HWACCEL_DEVICE`               | _none_             | Optional ffmpeg `-hwaccel_device` value used with `FFMPEG_HWACCEL` (e.g. `0` or `/dev/dri/renderD128`).                                 |
+| `THUMBNAIL_CACHE_MAX_FILES`           | `3000`             | Maximum number of files kept in the thumbnail cache. Set `0` to disable automatic cleanup.                                              |
+| `THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS` | `3600000`          | Minimum delay between thumbnail cache cleanup scans.                                                                                    |
 
 ## Collabora (WOPI)
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -96,6 +96,7 @@ The sharing system (toolbar **Share** button, guest links such as `/share/:token
 | `THUMBNAIL_CACHE_MAX_FILES`           | `3000`             | Maximum number of files kept in the thumbnail cache. Set `0` to disable automatic cleanup.                                              |
 | `THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS` | `3600000`          | Minimum delay between thumbnail cache cleanup scans.                                                                                    |
 | `THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE`  | `500`              | Maximum number of thumbnail cache files deleted per cleanup pass.                                                                       |
+| `THUMBNAIL_SHARP_CACHE_MEMORY_MB`     | `32`               | Memory in MB allowed for Sharp/libvips thumbnail cache. Lower values reduce idle RSS after thumbnail generation.                        |
 
 ## Collabora (WOPI)
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -98,6 +98,7 @@ The sharing system (toolbar **Share** button, guest links such as `/share/:token
 | `THUMBNAIL_CACHE_CLEANUP_INTERVAL_MS` | `3600000`          | Minimum delay between thumbnail cache cleanup scans.                                                                                    |
 | `THUMBNAIL_CACHE_CLEANUP_BATCH_SIZE`  | `500`              | Maximum number of thumbnail cache files deleted per cleanup pass.                                                                       |
 | `THUMBNAIL_SHARP_CACHE_MEMORY_MB`     | `0`                | Memory in MB allowed for Sharp/libvips thumbnail cache. Keep `0` to minimize idle RSS after thumbnail generation.                       |
+| `THUMBNAIL_VIDEO_CONCURRENCY`         | `1`                | Maximum number of concurrent ffmpeg thumbnail jobs. Keep low on small hosts to avoid memory spikes.                                     |
 
 ## Collabora (WOPI)
 

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -94,7 +94,14 @@ async function fetchThumbnail(relativePath, options = {}) {
     throw new Error('A file path is required to fetch a thumbnail.');
   }
   const encodedPath = encodePath(normalizedPath);
-  return requestJson(`/api/thumbnails/${encodedPath}`, { method: 'GET', ...options });
+  // Thumbnails are best-effort/background: never surface a global error toast on
+  // a missing source. Callers inspect the thrown error's statusCode to decide
+  // whether to retry.
+  return requestJson(`/api/thumbnails/${encodedPath}`, {
+    method: 'GET',
+    suppressErrorHandler: true,
+    ...options,
+  });
 }
 
 async function fetchMetadata(relativePath) {

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -88,13 +88,13 @@ function getRawFileUrl(path) {
   return buildUrl(`/api/raw?${params.toString()}`);
 }
 
-async function fetchThumbnail(relativePath) {
+async function fetchThumbnail(relativePath, options = {}) {
   const normalizedPath = normalizePath(relativePath);
   if (!normalizedPath) {
     throw new Error('A file path is required to fetch a thumbnail.');
   }
   const encodedPath = encodePath(normalizedPath);
-  return requestJson(`/api/thumbnails/${encodedPath}`, { method: 'GET' });
+  return requestJson(`/api/thumbnails/${encodedPath}`, { method: 'GET', ...options });
 }
 
 async function fetchMetadata(relativePath) {

--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -54,8 +54,16 @@ const requestRaw = async (endpoint, options = {}) => {
         ...(typeof error === 'object' ? error : { message: error || `Request failed with status ${response.status}` }),
       };
 
-      const translatedMessage = errorHandler?.(errorInfo) || errorInfo.message;
-      throw new Error(translatedMessage);
+      // Best-effort / background requests (e.g. thumbnails) opt out of the
+      // global error handler so a missing file does not raise a user-facing
+      // toast. The status code is still attached so callers can react.
+      const translatedMessage = options.suppressErrorHandler
+        ? errorInfo.message
+        : errorHandler?.(errorInfo) || errorInfo.message;
+      const requestError = new Error(translatedMessage);
+      requestError.statusCode = response.status;
+      if (errorInfo.code) requestError.code = errorInfo.code;
+      throw requestError;
     }
 
     return response;

--- a/frontend/src/icons/FileIcon.vue
+++ b/frontend/src/icons/FileIcon.vue
@@ -119,7 +119,7 @@ const scheduleThumbnailRetry = () => {
   if (thumbnailRetryCount.value >= 20) return;
 
   thumbnailRetryCount.value += 1;
-  const delayMs = Math.min(5000, 1000 + thumbnailRetryCount.value * 500);
+  const delayMs = Math.min(5000, 700 + thumbnailRetryCount.value * 400);
   thumbnailRetryTimer = setTimeout(() => {
     thumbnailRetryTimer = null;
     hasRequestedThumbnail.value = false;

--- a/frontend/src/icons/FileIcon.vue
+++ b/frontend/src/icons/FileIcon.vue
@@ -92,6 +92,9 @@ const canRequestThumbnail = computed(() => {
   if (!isPreviewable.value) return false;
   if (appSettings.thumbnailsEnabledForSession === false) return false;
   if (props.item.thumbnail) return false;
+  // A prior request definitively failed (missing source / unsupported): don't
+  // loop on it. A fresh navigation yields a new item object without this flag.
+  if (props.item.thumbnailUnavailable) return false;
   return Boolean(props.item.supportsThumbnail);
 });
 

--- a/frontend/src/icons/FileIcon.vue
+++ b/frontend/src/icons/FileIcon.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, watchEffect } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
 import { apiBase } from '@/api';
 import { useAppSettings } from '@/stores/appSettings';
@@ -80,25 +80,83 @@ const isPreviewable = computed(() => {
 
 // Track if we've already requested the thumbnail in this component instance
 const hasRequestedThumbnail = ref(false);
+const iconRoot = ref(null);
+const isNearViewport = ref(false);
+let thumbnailObserver = null;
 
-// Automatically request thumbnail when all conditions are met
-// watchEffect automatically tracks all reactive dependencies and re-runs when they change
-watchEffect(() => {
-  // Exit early if already requested
+const canRequestThumbnail = computed(() => {
+  if (props.disableThumbnails) return false;
+  if (!props.item || props.item.kind === 'directory') return false;
+  if (!isPreviewable.value) return false;
+  if (appSettings.thumbnailsEnabledForSession === false) return false;
+  if (props.item.thumbnail) return false;
+  return Boolean(props.item.supportsThumbnail);
+});
+
+const thumbnailRequestKey = computed(() => {
+  if (!props.item) return '';
+  return [
+    props.item.path || '',
+    props.item.name || '',
+    props.item.kind || '',
+    props.item.size || '',
+    props.item.modified || '',
+  ].join('::');
+});
+
+const requestThumbnailIfNeeded = () => {
   if (hasRequestedThumbnail.value) return;
-
-  // Check all conditions
-  if (props.disableThumbnails) return;
-  if (!props.item || props.item.kind === 'directory') return;
-  if (!isPreviewable.value) return;
-  if (appSettings.thumbnailsEnabledForSession === false) return;
-  if (props.item.thumbnail) return;
-  if (!props.item.supportsThumbnail) return;
+  if (!isNearViewport.value) return;
+  if (!canRequestThumbnail.value) return;
 
   // All conditions met - request thumbnail once
   hasRequestedThumbnail.value = true;
   fileStore.ensureItemThumbnail(props.item);
+};
+
+const disconnectThumbnailObserver = () => {
+  if (thumbnailObserver) {
+    thumbnailObserver.disconnect();
+    thumbnailObserver = null;
+  }
+};
+
+const observeThumbnailVisibility = async () => {
+  await nextTick();
+  if (!iconRoot.value) {
+    isNearViewport.value = true;
+    return;
+  }
+
+  if (typeof IntersectionObserver === 'undefined') {
+    isNearViewport.value = true;
+    return;
+  }
+
+  disconnectThumbnailObserver();
+  thumbnailObserver = new IntersectionObserver(
+    (entries) => {
+      const isVisible = entries.some((entry) => entry.isIntersecting);
+      if (!isVisible) return;
+      isNearViewport.value = true;
+      requestThumbnailIfNeeded();
+      disconnectThumbnailObserver();
+    },
+    { root: null, rootMargin: '600px 0px', threshold: 0.01 }
+  );
+  thumbnailObserver.observe(iconRoot.value);
+};
+
+watch([canRequestThumbnail, isNearViewport], requestThumbnailIfNeeded);
+
+watch(thumbnailRequestKey, () => {
+  hasRequestedThumbnail.value = false;
+  isNearViewport.value = false;
+  observeThumbnailVisibility();
 });
+
+onMounted(observeThumbnailVisibility);
+onBeforeUnmount(disconnectThumbnailObserver);
 
 // Additional type groupings
 const audioExts = new Set(['mp3', 'wav', 'flac', 'aac', 'm4a', 'ogg', 'opus', 'wma']);
@@ -255,18 +313,20 @@ const badge = computed(() => {
 </script>
 
 <template>
-  <DirectoryIcon v-if="props.item.kind === 'directory'" />
-  <PdfIcon v-else-if="props.item.kind === 'pdf'" />
-  <div
-    v-else-if="thumbnailUrl"
-    class="aspect-square bg-contain bg-center bg-no-repeat"
-    :style="{ backgroundImage: `url('${thumbnailUrl}')` }"
-  />
-  <ImageIcon v-else-if="isPreviewableImage(ext)" />
-  <VideoIcon v-else-if="isPreviewableVideo(ext)" />
-  <AudioIcon v-else-if="audioExts.has(ext)" />
-  <ArchiveIcon v-else-if="archiveExts.has(ext)" />
-  <FileBadgeIcon v-else-if="badge" v-bind="badge" />
-  <CodeIcon v-else-if="['json', 'vue'].includes(props.item.kind)" />
-  <TxtIcon v-else />
+  <span ref="iconRoot" class="block aspect-square">
+    <DirectoryIcon v-if="props.item.kind === 'directory'" />
+    <PdfIcon v-else-if="props.item.kind === 'pdf'" />
+    <div
+      v-else-if="thumbnailUrl"
+      class="h-full w-full bg-contain bg-center bg-no-repeat"
+      :style="{ backgroundImage: `url('${thumbnailUrl}')` }"
+    />
+    <ImageIcon v-else-if="isPreviewableImage(ext)" />
+    <VideoIcon v-else-if="isPreviewableVideo(ext)" />
+    <AudioIcon v-else-if="audioExts.has(ext)" />
+    <ArchiveIcon v-else-if="archiveExts.has(ext)" />
+    <FileBadgeIcon v-else-if="badge" v-bind="badge" />
+    <CodeIcon v-else-if="['json', 'vue'].includes(props.item.kind)" />
+    <TxtIcon v-else />
+  </span>
 </template>

--- a/frontend/src/icons/FileIcon.vue
+++ b/frontend/src/icons/FileIcon.vue
@@ -82,7 +82,9 @@ const isPreviewable = computed(() => {
 const hasRequestedThumbnail = ref(false);
 const iconRoot = ref(null);
 const isNearViewport = ref(false);
+const thumbnailRetryCount = ref(0);
 let thumbnailObserver = null;
+let thumbnailRetryTimer = null;
 
 const canRequestThumbnail = computed(() => {
   if (props.disableThumbnails) return false;
@@ -104,6 +106,27 @@ const thumbnailRequestKey = computed(() => {
   ].join('::');
 });
 
+const clearThumbnailRetry = () => {
+  if (thumbnailRetryTimer) {
+    clearTimeout(thumbnailRetryTimer);
+    thumbnailRetryTimer = null;
+  }
+};
+
+const scheduleThumbnailRetry = () => {
+  clearThumbnailRetry();
+  if (!canRequestThumbnail.value || !isNearViewport.value) return;
+  if (thumbnailRetryCount.value >= 20) return;
+
+  thumbnailRetryCount.value += 1;
+  const delayMs = Math.min(5000, 1000 + thumbnailRetryCount.value * 500);
+  thumbnailRetryTimer = setTimeout(() => {
+    thumbnailRetryTimer = null;
+    hasRequestedThumbnail.value = false;
+    requestThumbnailIfNeeded();
+  }, delayMs);
+};
+
 const requestThumbnailIfNeeded = () => {
   if (hasRequestedThumbnail.value) return;
   if (!isNearViewport.value) return;
@@ -111,7 +134,13 @@ const requestThumbnailIfNeeded = () => {
 
   // All conditions met - request thumbnail once
   hasRequestedThumbnail.value = true;
-  fileStore.ensureItemThumbnail(props.item);
+  fileStore.ensureItemThumbnail(props.item).then((thumbnail) => {
+    if (thumbnail) {
+      clearThumbnailRetry();
+      return;
+    }
+    scheduleThumbnailRetry();
+  });
 };
 
 const disconnectThumbnailObserver = () => {
@@ -136,13 +165,15 @@ const observeThumbnailVisibility = async () => {
   disconnectThumbnailObserver();
   thumbnailObserver = new IntersectionObserver(
     (entries) => {
-      const isVisible = entries.some((entry) => entry.isIntersecting);
-      if (!isVisible) return;
-      isNearViewport.value = true;
-      requestThumbnailIfNeeded();
-      disconnectThumbnailObserver();
+      isNearViewport.value = entries.some((entry) => entry.isIntersecting);
+      if (isNearViewport.value) {
+        requestThumbnailIfNeeded();
+      } else {
+        clearThumbnailRetry();
+        hasRequestedThumbnail.value = false;
+      }
     },
-    { root: null, rootMargin: '600px 0px', threshold: 0.01 }
+    { root: null, rootMargin: '300px 0px', threshold: 0.01 }
   );
   thumbnailObserver.observe(iconRoot.value);
 };
@@ -150,13 +181,18 @@ const observeThumbnailVisibility = async () => {
 watch([canRequestThumbnail, isNearViewport], requestThumbnailIfNeeded);
 
 watch(thumbnailRequestKey, () => {
+  clearThumbnailRetry();
   hasRequestedThumbnail.value = false;
   isNearViewport.value = false;
+  thumbnailRetryCount.value = 0;
   observeThumbnailVisibility();
 });
 
 onMounted(observeThumbnailVisibility);
-onBeforeUnmount(disconnectThumbnailObserver);
+onBeforeUnmount(() => {
+  clearThumbnailRetry();
+  disconnectThumbnailObserver();
+});
 
 // Additional type groupings
 const audioExts = new Set(['mp3', 'wav', 'flac', 'aac', 'm4a', 'ogg', 'opus', 'wma']);

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -19,7 +19,11 @@ import { useSettingsStore } from '@/stores/settings';
 import { useAppSettings } from '@/stores/appSettings';
 
 export const useFileStore = defineStore('fileStore', () => {
-  const THUMBNAIL_REQUEST_CONCURRENCY = 2;
+  // How many thumbnail HTTP requests the client keeps in flight at once. The
+  // backend keeps navigation responsive under load (enlarged libuv pool + niced
+  // ffmpeg/convert children + bounded background queue), so the client can feed
+  // it several requests concurrently instead of trickling them two at a time.
+  const THUMBNAIL_REQUEST_CONCURRENCY = 6;
 
   // State
   const currentPath = ref('');

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -447,11 +447,28 @@ export const useFileStore = defineStore('fileStore', () => {
             if (target) {
               target.thumbnail = thumbnail;
             }
+            return thumbnail;
           }
-          return thumbnail || null;
+          // No thumbnail yet: only keep polling when the server reported the job
+          // as pending. Anything else is a definitive "no thumbnail" (unsupported
+          // type, generation failed) — mark it so the icon stops re-requesting.
+          if (!response?.pending) {
+            const target = findItemByKey(key);
+            if (target) {
+              target.thumbnailUnavailable = true;
+            }
+          }
+          return null;
         } catch (error) {
-          if (!isAbortError(error)) {
-            console.error(`Failed to fetch thumbnail for ${relativePath}`, error);
+          // Aborted on navigation is not a failure — allow a later attempt.
+          if (isAbortError(error)) {
+            return null;
+          }
+          // Hard failure (404 missing source, other 4xx/5xx). These are silent,
+          // best-effort fetches; mark the item so we never loop on the error.
+          const target = findItemByKey(key);
+          if (target) {
+            target.thumbnailUnavailable = true;
           }
           return null;
         }

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -19,6 +19,8 @@ import { useSettingsStore } from '@/stores/settings';
 import { useAppSettings } from '@/stores/appSettings';
 
 export const useFileStore = defineStore('fileStore', () => {
+  const THUMBNAIL_REQUEST_CONCURRENCY = 2;
+
   // State
   const currentPath = ref('');
   const currentPathItems = ref([]);
@@ -32,6 +34,10 @@ export const useFileStore = defineStore('fileStore', () => {
   const copiedItems = useStorage('nextExplorer_clipboard_copied', []);
   const cutItems = useStorage('nextExplorer_clipboard_cut', []);
   const thumbnailRequests = new Map();
+  const thumbnailRequestQueue = [];
+  const activeThumbnailControllers = new Set();
+  let activeThumbnailRequestCount = 0;
+  let thumbnailQueueGeneration = 0;
 
   const hasSelection = computed(() => selectedItems.value.length > 0);
   const hasClipboardItems = computed(
@@ -74,6 +80,72 @@ export const useFileStore = defineStore('fileStore', () => {
     const parent = normalizePath(item.path || '');
     const combined = parent ? `${parent}/${item.name}` : item.name;
     return normalizePath(combined);
+  };
+
+  const isAbortError = (error) =>
+    error?.name === 'AbortError' ||
+    (typeof DOMException !== 'undefined' && error?.code === DOMException.ABORT_ERR) ||
+    /aborted/i.test(error?.message || '');
+
+  const pumpThumbnailRequestQueue = () => {
+    while (
+      activeThumbnailRequestCount < THUMBNAIL_REQUEST_CONCURRENCY &&
+      thumbnailRequestQueue.length > 0
+    ) {
+      const task = thumbnailRequestQueue.shift();
+
+      if (!task || task.generation !== thumbnailQueueGeneration) {
+        task?.resolve?.(null);
+        continue;
+      }
+
+      const controller = new AbortController();
+      activeThumbnailControllers.add(controller);
+      activeThumbnailRequestCount += 1;
+
+      task
+        .run(controller.signal)
+        .then(task.resolve)
+        .catch((error) => {
+          if (!isAbortError(error)) {
+            task.reject(error);
+            return;
+          }
+          task.resolve(null);
+        })
+        .finally(() => {
+          activeThumbnailRequestCount = Math.max(0, activeThumbnailRequestCount - 1);
+          activeThumbnailControllers.delete(controller);
+          thumbnailRequests.delete(task.key);
+          pumpThumbnailRequestQueue();
+        });
+    }
+  };
+
+  const queueThumbnailRequest = (key, run) =>
+    new Promise((resolve, reject) => {
+      thumbnailRequestQueue.push({
+        key,
+        generation: thumbnailQueueGeneration,
+        run,
+        resolve,
+        reject,
+      });
+      pumpThumbnailRequestQueue();
+    });
+
+  const cancelThumbnailRequests = () => {
+    thumbnailQueueGeneration += 1;
+
+    const queued = thumbnailRequestQueue.splice(0);
+    for (const task of queued) {
+      thumbnailRequests.delete(task.key);
+      task.resolve(null);
+    }
+
+    for (const controller of activeThumbnailControllers) {
+      controller.abort();
+    }
   };
 
   const serializeItems = (items) =>
@@ -359,9 +431,12 @@ export const useFileStore = defineStore('fileStore', () => {
         return null;
       }
 
-      pending = (async () => {
+      pending = queueThumbnailRequest(key, async (signal) => {
         try {
-          const response = await fetchThumbnailApi(relativePath);
+          const response = await fetchThumbnailApi(relativePath, {
+            signal,
+            retryNetworkErrors: false,
+          });
           const thumbnail = response?.thumbnail || '';
           if (thumbnail) {
             const target = findItemByKey(key);
@@ -371,12 +446,12 @@ export const useFileStore = defineStore('fileStore', () => {
           }
           return thumbnail || null;
         } catch (error) {
-          console.error(`Failed to fetch thumbnail for ${relativePath}`, error);
+          if (!isAbortError(error)) {
+            console.error(`Failed to fetch thumbnail for ${relativePath}`, error);
+          }
           return null;
-        } finally {
-          thumbnailRequests.delete(key);
         }
-      })();
+      });
 
       thumbnailRequests.set(key, pending);
     }
@@ -415,6 +490,7 @@ export const useFileStore = defineStore('fileStore', () => {
     const previousItems = Array.isArray(currentPathItems.value) ? currentPathItems.value : [];
 
     const normalizedPath = normalizePath(typeof path === 'string' ? path : currentPath.value);
+    cancelThumbnailRequests();
     currentPath.value = normalizedPath;
     clearSelection();
     // When changing folders, exit selection mode (mobile UX).


### PR DESCRIPTION
## Summary
- stabilizes thumbnail queue refresh behavior
- makes thumbnail cache cleanup incremental
- reduces Sharp/libvips memory retention
- avoids generating thumbnails for the thumbnail cache itself
- adds THUMBNAILS_ENABLED to disable thumbnail generation globally
- writes thumbnails directly to temporary files instead of buffering in memory

## Validation
- node --check backend/src/config/env.js
- node --check backend/src/services/thumbnailService.js
- npm run test -w backend -- thumbnail-service.test.js settings.test.js
- package tested through GHCR image
