### PR TITLE
Handle large directories and bulk deletes

### DIFF
--- a/backend/src/services/directoryListingService.js
+++ b/backend/src/services/directoryListingService.js
@@ -7,6 +7,8 @@ const { getAccessInfo } = require('./accessManager');
 const { createPermissionResolver } = require('./accessControlService');
 const logger = require('../utils/logger');
 
+const LIST_DIRECTORY_CONCURRENCY = 64;
+
 const previewable = new Set([
   ...extensions.images,
   ...(extensions.rawImages || []),
@@ -19,6 +21,23 @@ const toKind = (stats, name) => {
   const ext = path.extname(name).slice(1).toLowerCase();
   if (!ext) return 'unknown';
   return ext.length > 10 ? 'unknown' : ext;
+};
+
+const mapWithConcurrency = async (items, concurrency, mapper) => {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index], index);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
 };
 
 /**
@@ -57,52 +76,45 @@ const listDirectoryItems = async ({
       excludeDownloadArtifacts ? path.extname(name).toLowerCase() !== '.download' : true
     );
 
-  const items = await Promise.all(
-    filtered.map(async (name) => {
-      const filePath = path.join(absoluteDir, name);
+  const items = await mapWithConcurrency(filtered, LIST_DIRECTORY_CONCURRENCY, async (name) => {
+    const filePath = path.join(absoluteDir, name);
 
-      let stats;
-      try {
-        stats = await fs.stat(filePath);
-      } catch (err) {
-        if (['EPERM', 'EACCES', 'ENOENT', 'ELOOP'].includes(err?.code)) {
-          logger.warn({ filePath, err }, 'Skipping unreadable entry');
-          return null;
-        }
-        throw err;
-      }
-
-      const logicalChildPath = combineRelativePath(parentLogicalPath || '', name);
-      const childAccess = await getAccessInfo(context, logicalChildPath, accessOptions);
-      if (!childAccess?.canAccess) {
+    let stats;
+    try {
+      stats = await fs.stat(filePath);
+    } catch (err) {
+      if (['EPERM', 'EACCES', 'ENOENT', 'ELOOP'].includes(err?.code)) {
+        logger.warn({ filePath, err }, 'Skipping unreadable entry');
         return null;
       }
+      throw err;
+    }
 
-      const kind = toKind(stats, name);
-      const item = {
-        name,
-        path: parentLogicalPath,
-        dateModified: stats.mtime,
-        size: stats.size,
-        kind,
-      };
+    const logicalChildPath = combineRelativePath(parentLogicalPath || '', name);
+    const childAccess = await getAccessInfo(context, logicalChildPath, accessOptions);
+    if (!childAccess?.canAccess) {
+      return null;
+    }
 
-      if (
-        thumbsEnabled &&
-        stats.isFile() &&
-        kind !== 'pdf' &&
-        previewable.has(kind.toLowerCase())
-      ) {
-        item.supportsThumbnail = true;
-      }
+    const kind = toKind(stats, name);
+    const item = {
+      name,
+      path: parentLogicalPath,
+      dateModified: stats.mtime,
+      size: stats.size,
+      kind,
+    };
 
-      if (typeof itemExtras === 'function') {
-        Object.assign(item, itemExtras({ name, stats, kind, access: childAccess }) || {});
-      }
+    if (thumbsEnabled && stats.isFile() && kind !== 'pdf' && previewable.has(kind.toLowerCase())) {
+      item.supportsThumbnail = true;
+    }
 
-      return item;
-    })
-  );
+    if (typeof itemExtras === 'function') {
+      Object.assign(item, itemExtras({ name, stats, kind, access: childAccess }) || {});
+    }
+
+    return item;
+  });
 
   return items.filter(Boolean);
 };

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -1,5 +1,7 @@
 import { requestJson, requestRaw, normalizePath, encodePath, buildUrl } from './http';
 
+const DELETE_BATCH_SIZE = 100;
+
 async function browse(path = '') {
   const normalizedPath = normalizePath(path);
   const encodedPath = encodePath(normalizedPath);
@@ -32,10 +34,26 @@ async function moveItems(items, destination) {
 }
 
 async function deleteItems(items) {
-  return requestJson('/api/files', {
-    method: 'DELETE',
-    body: JSON.stringify({ items }),
-  });
+  const normalizedItems = Array.isArray(items) ? items : [];
+  if (normalizedItems.length <= DELETE_BATCH_SIZE) {
+    return requestJson('/api/files', {
+      method: 'DELETE',
+      body: JSON.stringify({ items: normalizedItems }),
+    });
+  }
+
+  const deletedItems = [];
+  for (let index = 0; index < normalizedItems.length; index += DELETE_BATCH_SIZE) {
+    const batch = normalizedItems.slice(index, index + DELETE_BATCH_SIZE);
+    // eslint-disable-next-line no-await-in-loop
+    const response = await requestJson('/api/files', {
+      method: 'DELETE',
+      body: JSON.stringify({ items: batch }),
+    });
+    deletedItems.push(...(Array.isArray(response?.items) ? response.items : []));
+  }
+
+  return { success: true, items: deletedItems };
 }
 
 async function createFolder(destination, name) {

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -56,6 +56,36 @@ async function deleteItems(items) {
   return { success: true, items: deletedItems };
 }
 
+async function getDeleteImpact(items) {
+  const normalizedItems = Array.isArray(items) ? items : [];
+  if (normalizedItems.length <= DELETE_BATCH_SIZE) {
+    return requestJson('/api/files/delete-impact', {
+      method: 'POST',
+      body: JSON.stringify({ items: normalizedItems }),
+    });
+  }
+
+  const sharesById = new Map();
+  for (let index = 0; index < normalizedItems.length; index += DELETE_BATCH_SIZE) {
+    const batch = normalizedItems.slice(index, index + DELETE_BATCH_SIZE);
+    // eslint-disable-next-line no-await-in-loop
+    const response = await requestJson('/api/files/delete-impact', {
+      method: 'POST',
+      body: JSON.stringify({ items: batch }),
+    });
+    const shares = Array.isArray(response?.shares) ? response.shares : [];
+    shares.forEach((share) => {
+      if (share?.id) sharesById.set(share.id, share);
+    });
+  }
+
+  const shares = Array.from(sharesById.values());
+  return {
+    shareCount: shares.length,
+    shares,
+  };
+}
+
 async function createFolder(destination, name) {
   const normalizedDestination = normalizePath(destination || '');
   const payload = { path: normalizedDestination };
@@ -232,6 +262,7 @@ export {
   copyItems,
   moveItems,
   deleteItems,
+  getDeleteImpact,
   createFolder,
   renameItem,
   fetchFileContent,

--- a/frontend/src/components/ClipboardProgress.vue
+++ b/frontend/src/components/ClipboardProgress.vue
@@ -6,7 +6,7 @@ import { useFileStore } from '@/stores/fileStore';
 const fileStore = useFileStore();
 const { t } = useI18n();
 
-const operation = computed(() => fileStore.clipboardOperation);
+const operation = computed(() => fileStore.deleteOperation || fileStore.clipboardOperation);
 
 const title = computed(() => {
   const op = operation.value;
@@ -14,6 +14,10 @@ const title = computed(() => {
 
   const count = Number(op.itemCount) || 0;
   const itemsLabel = count === 1 ? t('common.item') : t('common.items');
+
+  if (op.type === 'delete') {
+    return `${t('common.deleting')} ${count} ${itemsLabel}`;
+  }
 
   return op.type === 'move'
     ? t('clipboard.moving', { count, items: itemsLabel })

--- a/frontend/src/components/ExplorerContextMenu.vue
+++ b/frontend/src/components/ExplorerContextMenu.vue
@@ -153,7 +153,7 @@ const getItemKey = (item) => {
 const ensureItemInSelection = (item) => {
   if (!item) return;
   const key = getItemKey(item);
-  const alreadySelected = fileStore.selectedItems.some((selected) => getItemKey(selected) === key);
+  const alreadySelected = fileStore.selectedItemKeys.has(key);
 
   if (alreadySelected) {
     return;

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -386,7 +386,11 @@ if (isTouchDevice.value) {
       ]"
       :style="{ gridTemplateColumns: settings.listViewGridTemplateColumns }"
     >
-      <div class="relative flex items-center justify-center">
+      <div
+        class="relative flex items-center justify-center"
+        :class="selectionMode ? 'cursor-pointer' : ''"
+        @click="selectionMode ? handleToggleSelection($event) : undefined"
+      >
         <FileIcon :item="item" class="w-6 shrink-0" />
         <button
           v-if="showSelectionControl"

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -392,16 +392,22 @@ if (isTouchDevice.value) {
           v-if="showSelectionControl"
           type="button"
           :class="[
-            selectionButtonBaseClass,
-            selectionButtonStateClass(selected),
+            'absolute inset-y-0 left-1/2 z-10 flex w-7 -translate-x-1/2 items-center justify-center',
             selectionMode || selected ? 'opacity-100' : 'opacity-0 group-hover/item:opacity-100',
-            'absolute left-1/2 top-1/2 z-10 h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-md',
           ]"
           :aria-label="`Select ${item.name}`"
           @click="handleToggleSelection"
           @dblclick.stop.prevent
         >
-          <CheckIcon class="h-4 w-4" />
+          <span
+            :class="[
+              selectionButtonBaseClass,
+              selectionButtonStateClass(selected),
+              'flex h-5 w-5 items-center justify-center rounded-md',
+            ]"
+          >
+            <CheckIcon class="h-4 w-4" />
+          </span>
         </button>
       </div>
       <div :title="item.name" class="min-w-0 overflow-hidden text-sm">

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -388,8 +388,8 @@ if (isTouchDevice.value) {
     >
       <div
         class="relative flex items-center justify-center"
-        :class="selectionMode ? 'cursor-pointer' : ''"
-        @click="selectionMode ? handleToggleSelection($event) : undefined"
+        :class="showSelectionControl ? 'cursor-pointer' : ''"
+        @click="showSelectionControl ? handleToggleSelection($event) : undefined"
       >
         <FileIcon :item="item" class="w-6 shrink-0" />
         <button

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -57,6 +57,8 @@ const isCut = computed(() =>
   )
 );
 
+const selected = computed(() => isSelected(props.item));
+
 const showSelectionControl = computed(() => !isTouchDevice.value || selectionMode.value);
 
 const selectionButtonBaseClass =
@@ -220,7 +222,7 @@ if (isTouchDevice.value) {
       :draggable="canDragDrop() && !isRenaming"
       class="photo-cell relative w-full rounded-md overflow-hidden cursor-pointer select-none bg-neutral-100 dark:bg-zinc-800/60 hover:brightness-105"
       :class="{
-        'ring-2 ring-blue-500 dark:ring-blue-400': isSelected(item),
+        'ring-2 ring-blue-500 dark:ring-blue-400': selected,
         'opacity-60': isCut,
         'cursor-move': canDragDrop() && !isRenaming,
       }"
@@ -230,10 +232,8 @@ if (isTouchDevice.value) {
         type="button"
         :class="[
           selectionButtonBaseClass,
-          selectionButtonStateClass(isSelected(item)),
-          selectionMode || isSelected(item)
-            ? 'opacity-100'
-            : 'opacity-0 group-hover/item:opacity-100',
+          selectionButtonStateClass(selected),
+          selectionMode || selected ? 'opacity-100' : 'opacity-0 group-hover/item:opacity-100',
           'absolute right-2 top-2 z-10 h-5 w-5 rounded-md',
         ]"
         :aria-label="`Select ${item.name}`"
@@ -257,7 +257,7 @@ if (isTouchDevice.value) {
       class="relative flex flex-col items-center gap-2 p-2 rounded-xl cursor-pointer select-none"
       :class="[
         { 'opacity-60': isCut },
-        isSelected(item) ? 'bg-zinc-200/70 dark:bg-zinc-700/60' : '',
+        selected ? 'bg-zinc-200/70 dark:bg-zinc-700/60' : '',
         canDragDrop() && !isRenaming ? 'cursor-move' : '',
       ]"
     >
@@ -266,10 +266,8 @@ if (isTouchDevice.value) {
         type="button"
         :class="[
           selectionButtonBaseClass,
-          selectionButtonStateClass(isSelected(item)),
-          selectionMode || isSelected(item)
-            ? 'opacity-100'
-            : 'opacity-0 group-hover/item:opacity-100',
+          selectionButtonStateClass(selected),
+          selectionMode || selected ? 'opacity-100' : 'opacity-0 group-hover/item:opacity-100',
           'absolute right-2 top-2 z-10 h-5 w-5 rounded-md',
         ]"
         :aria-label="`Select ${item.name}`"
@@ -282,7 +280,7 @@ if (isTouchDevice.value) {
       <div
         class="text-sm text-center break-all line-clamp-2 rounded-md"
         :class="{
-          'bg-blue-500 text-white dark:bg-blue-600': isSelected(item) && !isRenaming,
+          'bg-blue-500 text-white dark:bg-blue-600': selected && !isRenaming,
         }"
       >
         <template v-if="isRenaming">
@@ -316,7 +314,7 @@ if (isTouchDevice.value) {
       class="relative flex items-center gap-2 p-4 rounded-md cursor-pointer select-none"
       :class="[
         { 'opacity-60': isCut },
-        isSelected(item) ? 'bg-zinc-200/70 dark:bg-zinc-700/60' : '',
+        selected ? 'bg-zinc-200/70 dark:bg-zinc-700/60' : '',
         canDragDrop() && !isRenaming ? 'cursor-move' : '',
       ]"
     >
@@ -325,10 +323,8 @@ if (isTouchDevice.value) {
         type="button"
         :class="[
           selectionButtonBaseClass,
-          selectionButtonStateClass(isSelected(item)),
-          selectionMode || isSelected(item)
-            ? 'opacity-100'
-            : 'opacity-0 group-hover/item:opacity-100',
+          selectionButtonStateClass(selected),
+          selectionMode || selected ? 'opacity-100' : 'opacity-0 group-hover/item:opacity-100',
           'absolute right-2 top-2 z-10 h-5 w-5 rounded-md',
         ]"
         :aria-label="`Select ${item.name}`"
@@ -341,7 +337,7 @@ if (isTouchDevice.value) {
       <div
         class="grow rounded-md px-2 -mx-2"
         :class="{
-          'bg-blue-500 text-white dark:bg-blue-600': isSelected(item) && !isRenaming,
+          'bg-blue-500 text-white dark:bg-blue-600': selected && !isRenaming,
         }"
       >
         <div class="break-all line-clamp-2">
@@ -383,8 +379,8 @@ if (isTouchDevice.value) {
         'group-even/item:bg-zinc-100 dark:group-even/item:bg-neutral-700/30',
         {
           'text-white dark:text-white bg-blue-600 dark:bg-blue-600/80 group-even/item:bg-blue-600! dark:group-even/item:bg-blue-600/80!':
-            isSelected(item),
-          'opacity-60': isCut && !isSelected(item),
+            selected,
+          'opacity-60': isCut && !selected,
           'cursor-move': canDragDrop() && !isRenaming,
         },
       ]"
@@ -397,10 +393,8 @@ if (isTouchDevice.value) {
           type="button"
           :class="[
             selectionButtonBaseClass,
-            selectionButtonStateClass(isSelected(item)),
-            selectionMode || isSelected(item)
-              ? 'opacity-100'
-              : 'opacity-0 group-hover/item:opacity-100',
+            selectionButtonStateClass(selected),
+            selectionMode || selected ? 'opacity-100' : 'opacity-0 group-hover/item:opacity-100',
             'absolute left-1/2 top-1/2 z-10 h-5 w-5 -translate-x-1/2 -translate-y-1/2 rounded-md',
           ]"
           :aria-label="`Select ${item.name}`"

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -386,20 +386,19 @@ if (isTouchDevice.value) {
       ]"
       :style="{ gridTemplateColumns: settings.listViewGridTemplateColumns }"
     >
-      <div
-        class="relative flex items-center justify-center"
-        :class="showSelectionControl ? 'cursor-pointer' : ''"
-        @click="showSelectionControl ? handleToggleSelection($event) : undefined"
-      >
+      <div class="relative flex items-center justify-center">
         <FileIcon :item="item" class="w-6 shrink-0" />
         <button
           v-if="showSelectionControl"
           type="button"
           :class="[
-            'absolute inset-y-0 left-1/2 z-10 flex w-7 -translate-x-1/2 items-center justify-center',
+            'absolute -top-1 -bottom-1 left-1/2 z-20 flex w-7 -translate-x-1/2 items-center justify-center',
             selectionMode || selected ? 'opacity-100' : 'opacity-0 group-hover/item:opacity-100',
           ]"
           :aria-label="`Select ${item.name}`"
+          @pointerdown.stop
+          @mousedown.stop
+          @mouseup.stop
           @click="handleToggleSelection"
           @dblclick.stop.prevent
         >

--- a/frontend/src/composables/itemSelection.js
+++ b/frontend/src/composables/itemSelection.js
@@ -15,18 +15,19 @@ export function useSelection() {
     return fileStore.getCurrentPathItems.find((candidate) => getItemKey(candidate) === key) || item;
   };
 
-  const isSelected = (item) =>
-    fileStore.selectedItems.some((selected) => getItemKey(selected) === getItemKey(item));
+  const isSelected = (item) => fileStore.selectedItemKeys.has(getItemKey(item));
 
   const toggleSelection = (item) => {
     const key = getItemKey(item);
-    const index = fileStore.selectedItems.findIndex((selected) => getItemKey(selected) === key);
+    const isAlreadySelected = fileStore.selectedItemKeys.has(key);
 
-    if (index === -1) {
+    if (!isAlreadySelected) {
       const resolved = findInCurrentItems(item);
       fileStore.selectedItems = [...fileStore.selectedItems, resolved];
     } else {
       const nextSelection = [...fileStore.selectedItems];
+      const index = nextSelection.findIndex((selected) => getItemKey(selected) === key);
+      if (index === -1) return;
       nextSelection.splice(index, 1);
       fileStore.selectedItems = nextSelection;
     }

--- a/frontend/src/composables/useDeleteConfirm.js
+++ b/frontend/src/composables/useDeleteConfirm.js
@@ -28,9 +28,9 @@ export function useDeleteConfirm() {
   const confirmDelete = async () => {
     if (!actions.canDelete.value || isDeleting.value) return;
     isDeleting.value = true;
+    isDeleteConfirmOpen.value = false;
     try {
       await actions.deleteNow();
-      isDeleteConfirmOpen.value = false;
     } catch (err) {
       console.error('Delete operation failed', err);
     } finally {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -235,7 +235,11 @@
     "noPhotos": "No photos in this folder",
     "noPhotosHint": "Switch to another view mode to see all files",
     "empty": "This folder is empty",
-    "emptyHint": "Upload or create files to get started."
+    "emptyHint": "Upload or create files to get started.",
+    "scrollTop": "Top",
+    "scrollBottom": "Bottom",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all"
   },
   "volumes": {
     "quickAccess": "Quick access",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -235,7 +235,11 @@
     "noPhotos": "Aucune photo dans ce dossier",
     "noPhotosHint": "Passez à un autre mode d’affichage pour voir tous les fichiers",
     "empty": "Ce dossier est vide",
-    "emptyHint": "Importez ou créez des fichiers pour commencer."
+    "emptyHint": "Importez ou créez des fichiers pour commencer.",
+    "scrollTop": "Haut",
+    "scrollBottom": "Bas",
+    "selectAll": "Tout sélectionner",
+    "deselectAll": "Tout désélectionner"
   },
   "volumes": {
     "quickAccess": "Accès rapide",

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -34,6 +34,14 @@ export const useFileStore = defineStore('fileStore', () => {
   const thumbnailRequests = new Map();
 
   const hasSelection = computed(() => selectedItems.value.length > 0);
+  const selectedItemKeys = computed(() => {
+    const keys = new Set();
+    for (const item of selectedItems.value) {
+      const key = itemKey(item);
+      if (key) keys.add(key);
+    }
+    return keys;
+  });
   const hasClipboardItems = computed(
     () => copiedItems.value.length > 0 || cutItems.value.length > 0
   );
@@ -508,6 +516,7 @@ export const useFileStore = defineStore('fileStore', () => {
     getCurrentPathItems,
     fetchPathItems,
     selectedItems,
+    selectedItemKeys,
     selectionMode,
     setSelectionMode,
     toggleSelectionMode,

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -28,6 +28,7 @@ export const useFileStore = defineStore('fileStore', () => {
   const renameState = ref(null);
 
   const clipboardOperation = ref(null);
+  const deleteOperation = ref(null);
 
   const copiedItems = useStorage('nextExplorer_clipboard_copied', []);
   const cutItems = useStorage('nextExplorer_clipboard_cut', []);
@@ -153,9 +154,19 @@ export const useFileStore = defineStore('fileStore', () => {
     const payload = serializeItems(selectedItems.value);
     if (payload.length === 0) return;
 
-    await deleteItems(payload);
-    clearSelection();
-    await fetchPathItems(currentPath.value);
+    deleteOperation.value = {
+      type: 'delete',
+      itemCount: payload.length,
+      startedAt: Date.now(),
+    };
+
+    try {
+      await deleteItems(payload);
+      clearSelection();
+      await fetchPathItems(currentPath.value);
+    } finally {
+      deleteOperation.value = null;
+    }
   };
 
   const createFolder = async (baseName) => {
@@ -522,6 +533,7 @@ export const useFileStore = defineStore('fileStore', () => {
     toggleSelectionMode,
     clearSelection,
     clipboardOperation,
+    deleteOperation,
     copiedItems,
     cutItems,
     hasSelection,

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -46,6 +46,15 @@ const INITIAL_VISIBLE_ITEMS = 500;
 const VISIBLE_ITEMS_INCREMENT = 500;
 let loadMoreObserver = null;
 
+const getScrollTarget = () => {
+  const localTarget = dropTargetRef.value;
+  if (localTarget && localTarget.scrollHeight - localTarget.clientHeight > 2) {
+    return localTarget;
+  }
+
+  return document.scrollingElement || document.documentElement;
+};
+
 const applySelectionFromQuery = () => {
   const selectName = typeof route.query?.select === 'string' ? route.query.select : '';
   if (!selectName) return;
@@ -91,7 +100,7 @@ const revealMoreItems = () => {
 };
 
 const updateScrollState = () => {
-  const target = dropTargetRef.value;
+  const target = getScrollTarget();
   if (!target) {
     isScrollable.value = false;
     canScrollUp.value = false;
@@ -117,13 +126,13 @@ const revealAllItems = async () => {
 };
 
 const scrollToTop = () => {
-  dropTargetRef.value?.scrollTo?.({ top: 0, behavior: 'smooth' });
+  getScrollTarget()?.scrollTo?.({ top: 0, behavior: 'smooth' });
 };
 
 const scrollToBottom = async () => {
   await revealAllItems();
   await nextTick();
-  const target = dropTargetRef.value;
+  const target = getScrollTarget();
   target?.scrollTo?.({ top: target.scrollHeight, behavior: 'smooth' });
   updateScrollState();
 };
@@ -326,6 +335,7 @@ useEventListener(window, 'pointermove', (event) => {
 useEventListener(window, 'pointerup', stopResize);
 useEventListener(window, 'pointercancel', stopResize);
 useEventListener(window, 'resize', updateScrollState);
+useEventListener(window, 'scroll', updateScrollState, { passive: true });
 
 onBeforeUnmount(() => {
   stopResize();
@@ -453,11 +463,14 @@ onBeforeUnmount(() => {
         </div>
       </DragSelect>
 
-      <div v-if="isScrollable" class="fixed bottom-6 right-6 z-40 flex flex-col gap-2">
+      <div
+        v-if="isScrollable"
+        class="pointer-events-none fixed bottom-6 right-6 z-[100] flex flex-col gap-2"
+      >
         <button
           v-if="canScrollUp"
           type="button"
-          class="grid h-10 w-10 place-items-center rounded-full border border-neutral-200 bg-white/90 text-neutral-700 shadow-lg backdrop-blur transition hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900/90 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          class="pointer-events-auto grid h-10 w-10 place-items-center rounded-full border border-neutral-200 bg-white/90 text-neutral-700 shadow-lg backdrop-blur transition hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900/90 dark:text-neutral-100 dark:hover:bg-neutral-800"
           :aria-label="$t('folder.scrollTop')"
           :title="$t('folder.scrollTop')"
           @click="scrollToTop"
@@ -467,7 +480,7 @@ onBeforeUnmount(() => {
         <button
           v-if="canScrollDown"
           type="button"
-          class="grid h-10 w-10 place-items-center rounded-full border border-neutral-200 bg-white/90 text-neutral-700 shadow-lg backdrop-blur transition hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900/90 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          class="pointer-events-auto grid h-10 w-10 place-items-center rounded-full border border-neutral-200 bg-white/90 text-neutral-700 shadow-lg backdrop-blur transition hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900/90 dark:text-neutral-100 dark:hover:bg-neutral-800"
           :aria-label="$t('folder.scrollBottom')"
           :title="$t('folder.scrollBottom')"
           @click="scrollToBottom"

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, onMounted, computed, onBeforeUnmount, nextTick, watch } from 'vue';
 import { useRoute } from 'vue-router';
+import { normalizePath } from '@/api';
 import { useSettingsStore } from '@/stores/settings';
 import FileObject from '@/components/FileObject.vue';
 import { useFileStore } from '@/stores/fileStore';
@@ -49,6 +50,25 @@ const applySelectionFromQuery = () => {
 const sortedItems = computed(() => fileStore.getCurrentPathItems);
 const visibleItems = computed(() => sortedItems.value.slice(0, visibleLimit.value));
 const hasMoreItems = computed(() => visibleItems.value.length < sortedItems.value.length);
+const showLargeFolderControls = computed(() => sortedItems.value.length > INITIAL_VISIBLE_ITEMS);
+
+const getItemKey = (item) => {
+  if (!item || !item.name) return '';
+  const parent = normalizePath(item.path || '');
+  return `${parent}::${item.name}`;
+};
+
+const allItemsSelected = computed(
+  () =>
+    sortedItems.value.length > 0 &&
+    sortedItems.value.every((item) => fileStore.selectedItemKeys.has(getItemKey(item)))
+);
+
+const someItemsSelected = computed(
+  () =>
+    sortedItems.value.length > 0 &&
+    sortedItems.value.some((item) => fileStore.selectedItemKeys.has(getItemKey(item)))
+);
 
 const resetVisibleItems = () => {
   visibleLimit.value = INITIAL_VISIBLE_ITEMS;
@@ -60,6 +80,24 @@ const revealMoreItems = () => {
     sortedItems.value.length,
     visibleLimit.value + VISIBLE_ITEMS_INCREMENT
   );
+};
+
+const scrollToTop = () => {
+  dropTargetRef.value?.scrollTo?.({ top: 0, behavior: 'smooth' });
+};
+
+const scrollToBottom = () => {
+  const target = dropTargetRef.value;
+  target?.scrollTo?.({ top: target.scrollHeight, behavior: 'smooth' });
+};
+
+const toggleSelectAll = () => {
+  if (allItemsSelected.value) {
+    clearSelection();
+    return;
+  }
+
+  fileStore.selectedItems = [...sortedItems.value];
 };
 
 const disconnectLoadMoreObserver = () => {
@@ -250,10 +288,23 @@ onBeforeUnmount(() => {
 <template>
   <div
     ref="dropTargetRef"
-    class="upload-drop-target relative flex flex-col flex-1 min-h-0"
+    class="upload-drop-target relative flex flex-col flex-1 min-h-0 overflow-y-auto"
     @click.self="clearSelection()"
   >
     <template v-if="!loading">
+      <div
+        v-if="showLargeFolderControls"
+        class="sticky top-0 z-20 flex items-center justify-end gap-2 bg-default/90 px-3 py-2 text-xs backdrop-blur"
+      >
+        <button
+          type="button"
+          class="rounded-md border border-neutral-200 px-3 py-1.5 transition hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          @click="scrollToBottom"
+        >
+          {{ $t('folder.scrollBottom') }}
+        </button>
+      </div>
+
       <DragSelect
         v-model="selectionModel"
         :click-option-to-select="false"
@@ -283,7 +334,17 @@ onBeforeUnmount(() => {
               gridTemplateColumns: settings.listViewGridTemplateColumns,
             }"
           >
-            <div></div>
+            <div class="flex items-center justify-center">
+              <input
+                type="checkbox"
+                class="h-4 w-4 rounded border-neutral-300 text-blue-600 focus:ring-blue-500"
+                :checked="allItemsSelected"
+                :indeterminate.prop="someItemsSelected && !allItemsSelected"
+                :aria-label="allItemsSelected ? $t('folder.deselectAll') : $t('folder.selectAll')"
+                @change="toggleSelectAll"
+                @click.stop
+              />
+            </div>
             <div v-for="col in listColumns" :key="col.key" class="relative flex items-center">
               <button
                 type="button"
@@ -355,6 +416,19 @@ onBeforeUnmount(() => {
           </div>
         </div>
       </DragSelect>
+
+      <div
+        v-if="showLargeFolderControls"
+        class="sticky bottom-0 z-20 flex items-center justify-end gap-2 bg-default/90 px-3 py-2 text-xs backdrop-blur"
+      >
+        <button
+          type="button"
+          class="rounded-md border border-neutral-200 px-3 py-1.5 transition hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          @click="scrollToTop"
+        >
+          {{ $t('folder.scrollTop') }}
+        </button>
+      </div>
     </template>
 
     <template v-else>

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed, onBeforeUnmount } from 'vue';
+import { ref, onMounted, computed, onBeforeUnmount, nextTick, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { useSettingsStore } from '@/stores/settings';
 import FileObject from '@/components/FileObject.vue';
@@ -23,6 +23,8 @@ const fileStore = useFileStore();
 const route = useRoute();
 const { gridClasses, gridStyle } = useViewConfig();
 const loading = ref(true);
+const visibleLimit = ref(500);
+const loadMoreTrigger = ref(null);
 const { clearSelection } = useSelection();
 const contextMenu = useExplorerContextMenu();
 const dropTargetRef = ref(null);
@@ -31,6 +33,10 @@ useUppyDropTarget(dropTargetRef);
 const { isTouchDevice } = useInputMode();
 const { handleDragOver, handleDragLeave, handleDrop, isDragTarget } = useFileDragDrop();
 
+const INITIAL_VISIBLE_ITEMS = 500;
+const VISIBLE_ITEMS_INCREMENT = 500;
+let loadMoreObserver = null;
+
 const applySelectionFromQuery = () => {
   const selectName = typeof route.query?.select === 'string' ? route.query.select : '';
   if (!selectName) return;
@@ -38,6 +44,52 @@ const applySelectionFromQuery = () => {
   if (match) {
     fileStore.selectedItems = [match];
   }
+};
+
+const sortedItems = computed(() => fileStore.getCurrentPathItems);
+const visibleItems = computed(() => sortedItems.value.slice(0, visibleLimit.value));
+const hasMoreItems = computed(() => visibleItems.value.length < sortedItems.value.length);
+
+const resetVisibleItems = () => {
+  visibleLimit.value = INITIAL_VISIBLE_ITEMS;
+};
+
+const revealMoreItems = () => {
+  if (!hasMoreItems.value) return;
+  visibleLimit.value = Math.min(
+    sortedItems.value.length,
+    visibleLimit.value + VISIBLE_ITEMS_INCREMENT
+  );
+};
+
+const disconnectLoadMoreObserver = () => {
+  if (loadMoreObserver) {
+    loadMoreObserver.disconnect();
+    loadMoreObserver = null;
+  }
+};
+
+const setupLoadMoreObserver = async () => {
+  disconnectLoadMoreObserver();
+
+  if (!hasMoreItems.value || typeof IntersectionObserver === 'undefined') {
+    return;
+  }
+
+  await nextTick();
+  if (!loadMoreTrigger.value) {
+    return;
+  }
+
+  loadMoreObserver = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        revealMoreItems();
+      }
+    },
+    { root: null, rootMargin: '800px 0px' }
+  );
+  loadMoreObserver.observe(loadMoreTrigger.value);
 };
 
 const selectionModel = computed({
@@ -53,6 +105,7 @@ const selectionModel = computed({
 
 const loadFiles = async () => {
   loading.value = true;
+  resetVisibleItems();
   const path = route.params.path || '';
   try {
     await fileStore.fetchPathItems(path);
@@ -61,10 +114,22 @@ const loadFiles = async () => {
     console.error('Failed to load directory contents', error);
   } finally {
     loading.value = false;
+    await setupLoadMoreObserver();
   }
 };
 
 onMounted(loadFiles);
+
+watch(hasMoreItems, () => {
+  setupLoadMoreObserver();
+});
+
+watch(
+  () => route.params.path,
+  () => {
+    resetVisibleItems();
+  }
+);
 
 const handleBackgroundContextMenu = (event) => {
   if (!contextMenu || !event) return;
@@ -178,6 +243,7 @@ useEventListener(window, 'pointercancel', stopResize);
 
 onBeforeUnmount(() => {
   stopResize();
+  disconnectLoadMoreObserver();
 });
 </script>
 
@@ -242,7 +308,7 @@ onBeforeUnmount(() => {
           </div>
 
           <FileObject
-            v-for="item in fileStore.getCurrentPathItems"
+            v-for="item in visibleItems"
             :key="(item.path || '') + '::' + item.name"
             :item="item"
             :view="settings.view"
@@ -256,6 +322,20 @@ onBeforeUnmount(() => {
             @dragleave="(e) => item.kind === 'directory' && handleDragLeave(e, item)"
             @drop="(e) => item.kind === 'directory' && handleDrop(e, item)"
           />
+
+          <div
+            v-if="hasMoreItems"
+            ref="loadMoreTrigger"
+            class="flex items-center justify-center py-4 text-xs text-neutral-500 dark:text-neutral-400"
+          >
+            <button
+              type="button"
+              class="rounded-md border border-neutral-200 px-3 py-1.5 transition hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+              @click="revealMoreItems"
+            >
+              {{ visibleItems.length }} / {{ sortedItems.length }} {{ $t('common.items') }}
+            </button>
+          </div>
 
           <!-- No photos message -->
           <div

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -44,7 +44,12 @@ const { handleDragOver, handleDragLeave, handleDrop, isDragTarget } = useFileDra
 
 const INITIAL_VISIBLE_ITEMS = 500;
 const VISIBLE_ITEMS_INCREMENT = 500;
+const VIRTUAL_LIST_THRESHOLD = 1000;
+const LIST_ROW_HEIGHT = 37;
+const LIST_ROW_OVERSCAN = 20;
 let loadMoreObserver = null;
+const scrollTop = ref(0);
+const scrollViewportHeight = ref(0);
 
 const getScrollTarget = () => {
   const localTarget = dropTargetRef.value;
@@ -65,8 +70,36 @@ const applySelectionFromQuery = () => {
 };
 
 const sortedItems = computed(() => fileStore.getCurrentPathItems);
-const visibleItems = computed(() => sortedItems.value.slice(0, visibleLimit.value));
-const hasMoreItems = computed(() => visibleItems.value.length < sortedItems.value.length);
+const useVirtualList = computed(
+  () => settings.view === 'list' && sortedItems.value.length > VIRTUAL_LIST_THRESHOLD
+);
+const virtualStartIndex = computed(() => {
+  if (!useVirtualList.value) return 0;
+  return Math.max(0, Math.floor(scrollTop.value / LIST_ROW_HEIGHT) - LIST_ROW_OVERSCAN);
+});
+const virtualEndIndex = computed(() => {
+  if (!useVirtualList.value) return visibleLimit.value;
+  const visibleCount =
+    Math.ceil(scrollViewportHeight.value / LIST_ROW_HEIGHT) + LIST_ROW_OVERSCAN * 2;
+  return Math.min(sortedItems.value.length, virtualStartIndex.value + visibleCount);
+});
+const visibleItems = computed(() => {
+  if (useVirtualList.value) {
+    return sortedItems.value.slice(virtualStartIndex.value, virtualEndIndex.value);
+  }
+  return sortedItems.value.slice(0, visibleLimit.value);
+});
+const hasMoreItems = computed(
+  () => !useVirtualList.value && visibleItems.value.length < sortedItems.value.length
+);
+const virtualTopSpacerHeight = computed(() =>
+  useVirtualList.value ? virtualStartIndex.value * LIST_ROW_HEIGHT : 0
+);
+const virtualBottomSpacerHeight = computed(() =>
+  useVirtualList.value
+    ? Math.max(0, (sortedItems.value.length - virtualEndIndex.value) * LIST_ROW_HEIGHT)
+    : 0
+);
 
 const getItemKey = (item) => {
   if (!item || !item.name) return '';
@@ -109,6 +142,8 @@ const updateScrollState = () => {
   }
 
   const maxScrollTop = Math.max(0, target.scrollHeight - target.clientHeight);
+  scrollTop.value = target.scrollTop;
+  scrollViewportHeight.value = target.clientHeight;
   isScrollable.value = maxScrollTop > 2;
   canScrollUp.value = target.scrollTop > 2;
   canScrollDown.value = target.scrollTop < maxScrollTop - 2;
@@ -126,14 +161,19 @@ const revealAllItems = async () => {
 };
 
 const scrollToTop = () => {
-  getScrollTarget()?.scrollTo?.({ top: 0, behavior: 'smooth' });
+  getScrollTarget()?.scrollTo?.({ top: 0, behavior: useVirtualList.value ? 'auto' : 'smooth' });
 };
 
 const scrollToBottom = async () => {
-  await revealAllItems();
+  if (!useVirtualList.value) {
+    await revealAllItems();
+  }
   await nextTick();
   const target = getScrollTarget();
-  target?.scrollTo?.({ top: target.scrollHeight, behavior: 'smooth' });
+  target?.scrollTo?.({
+    top: target.scrollHeight,
+    behavior: useVirtualList.value ? 'auto' : 'smooth',
+  });
   updateScrollState();
 };
 
@@ -212,7 +252,7 @@ watch(hasMoreItems, () => {
 });
 
 watch(
-  () => [visibleItems.value.length, sortedItems.value.length, settings.view],
+  () => [visibleItems.value.length, sortedItems.value.length, settings.view, useVirtualList.value],
   () => {
     nextTick(updateScrollState);
   }
@@ -414,6 +454,12 @@ onBeforeUnmount(() => {
             </div>
           </div>
 
+          <div
+            v-if="useVirtualList && virtualTopSpacerHeight > 0"
+            class="shrink-0"
+            :style="{ height: `${virtualTopSpacerHeight}px` }"
+          ></div>
+
           <FileObject
             v-for="item in visibleItems"
             :key="(item.path || '') + '::' + item.name"
@@ -429,6 +475,12 @@ onBeforeUnmount(() => {
             @dragleave="(e) => item.kind === 'directory' && handleDragLeave(e, item)"
             @drop="(e) => item.kind === 'directory' && handleDrop(e, item)"
           />
+
+          <div
+            v-if="useVirtualList && virtualBottomSpacerHeight > 0"
+            class="shrink-0"
+            :style="{ height: `${virtualBottomSpacerHeight}px` }"
+          ></div>
 
           <div
             v-if="hasMoreItems"

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -14,7 +14,12 @@ import { useViewConfig } from '@/composables/useViewConfig';
 import { DragSelect } from '@coleqiu/vue-drag-select';
 import { useUppyDropTarget } from '@/composables/fileUploader';
 import { FolderOpenIcon } from '@heroicons/vue/24/outline';
-import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/20/solid';
+import {
+  ChevronDoubleDownIcon,
+  ChevronDoubleUpIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from '@heroicons/vue/20/solid';
 import { useEventListener } from '@vueuse/core';
 import { useInputMode } from '@/composables/useInputMode';
 import { useFileDragDrop } from '@/composables/useFileDragDrop';
@@ -26,6 +31,9 @@ const { gridClasses, gridStyle } = useViewConfig();
 const loading = ref(true);
 const visibleLimit = ref(500);
 const loadMoreTrigger = ref(null);
+const isScrollable = ref(false);
+const canScrollUp = ref(false);
+const canScrollDown = ref(false);
 const { clearSelection } = useSelection();
 const contextMenu = useExplorerContextMenu();
 const dropTargetRef = ref(null);
@@ -50,7 +58,6 @@ const applySelectionFromQuery = () => {
 const sortedItems = computed(() => fileStore.getCurrentPathItems);
 const visibleItems = computed(() => sortedItems.value.slice(0, visibleLimit.value));
 const hasMoreItems = computed(() => visibleItems.value.length < sortedItems.value.length);
-const showLargeFolderControls = computed(() => sortedItems.value.length > INITIAL_VISIBLE_ITEMS);
 
 const getItemKey = (item) => {
   if (!item || !item.name) return '';
@@ -80,15 +87,45 @@ const revealMoreItems = () => {
     sortedItems.value.length,
     visibleLimit.value + VISIBLE_ITEMS_INCREMENT
   );
+  nextTick(updateScrollState);
+};
+
+const updateScrollState = () => {
+  const target = dropTargetRef.value;
+  if (!target) {
+    isScrollable.value = false;
+    canScrollUp.value = false;
+    canScrollDown.value = false;
+    return;
+  }
+
+  const maxScrollTop = Math.max(0, target.scrollHeight - target.clientHeight);
+  isScrollable.value = maxScrollTop > 2;
+  canScrollUp.value = target.scrollTop > 2;
+  canScrollDown.value = target.scrollTop < maxScrollTop - 2;
+};
+
+const revealAllItems = async () => {
+  while (visibleLimit.value < sortedItems.value.length) {
+    visibleLimit.value = Math.min(
+      sortedItems.value.length,
+      visibleLimit.value + VISIBLE_ITEMS_INCREMENT
+    );
+    await nextTick();
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  }
 };
 
 const scrollToTop = () => {
   dropTargetRef.value?.scrollTo?.({ top: 0, behavior: 'smooth' });
 };
 
-const scrollToBottom = () => {
+const scrollToBottom = async () => {
+  await revealAllItems();
+  await nextTick();
   const target = dropTargetRef.value;
   target?.scrollTo?.({ top: target.scrollHeight, behavior: 'smooth' });
+  updateScrollState();
 };
 
 const toggleSelectAll = () => {
@@ -153,6 +190,8 @@ const loadFiles = async () => {
   } finally {
     loading.value = false;
     await setupLoadMoreObserver();
+    await nextTick();
+    updateScrollState();
   }
 };
 
@@ -160,7 +199,15 @@ onMounted(loadFiles);
 
 watch(hasMoreItems, () => {
   setupLoadMoreObserver();
+  nextTick(updateScrollState);
 });
+
+watch(
+  () => [visibleItems.value.length, sortedItems.value.length, settings.view],
+  () => {
+    nextTick(updateScrollState);
+  }
+);
 
 watch(
   () => route.params.path,
@@ -278,6 +325,7 @@ useEventListener(window, 'pointermove', (event) => {
 
 useEventListener(window, 'pointerup', stopResize);
 useEventListener(window, 'pointercancel', stopResize);
+useEventListener(window, 'resize', updateScrollState);
 
 onBeforeUnmount(() => {
   stopResize();
@@ -290,21 +338,9 @@ onBeforeUnmount(() => {
     ref="dropTargetRef"
     class="upload-drop-target relative flex flex-col flex-1 min-h-0 overflow-y-auto"
     @click.self="clearSelection()"
+    @scroll.passive="updateScrollState"
   >
     <template v-if="!loading">
-      <div
-        v-if="showLargeFolderControls"
-        class="sticky top-0 z-20 flex items-center justify-end gap-2 bg-default/90 px-3 py-2 text-xs backdrop-blur"
-      >
-        <button
-          type="button"
-          class="rounded-md border border-neutral-200 px-3 py-1.5 transition hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
-          @click="scrollToBottom"
-        >
-          {{ $t('folder.scrollBottom') }}
-        </button>
-      </div>
-
       <DragSelect
         v-model="selectionModel"
         :click-option-to-select="false"
@@ -417,16 +453,26 @@ onBeforeUnmount(() => {
         </div>
       </DragSelect>
 
-      <div
-        v-if="showLargeFolderControls"
-        class="sticky bottom-0 z-20 flex items-center justify-end gap-2 bg-default/90 px-3 py-2 text-xs backdrop-blur"
-      >
+      <div v-if="isScrollable" class="fixed bottom-6 right-6 z-40 flex flex-col gap-2">
         <button
+          v-if="canScrollUp"
           type="button"
-          class="rounded-md border border-neutral-200 px-3 py-1.5 transition hover:bg-neutral-100 dark:border-neutral-700 dark:hover:bg-neutral-800"
+          class="grid h-10 w-10 place-items-center rounded-full border border-neutral-200 bg-white/90 text-neutral-700 shadow-lg backdrop-blur transition hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900/90 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          :aria-label="$t('folder.scrollTop')"
+          :title="$t('folder.scrollTop')"
           @click="scrollToTop"
         >
-          {{ $t('folder.scrollTop') }}
+          <ChevronDoubleUpIcon class="h-5 w-5" />
+        </button>
+        <button
+          v-if="canScrollDown"
+          type="button"
+          class="grid h-10 w-10 place-items-center rounded-full border border-neutral-200 bg-white/90 text-neutral-700 shadow-lg backdrop-blur transition hover:bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900/90 dark:text-neutral-100 dark:hover:bg-neutral-800"
+          :aria-label="$t('folder.scrollBottom')"
+          :title="$t('folder.scrollBottom')"
+          @click="scrollToBottom"
+        >
+          <ChevronDoubleDownIcon class="h-5 w-5" />
         </button>
       </div>
     </template>


### PR DESCRIPTION
## Summary
- limit backend directory listing concurrency to keep large folders responsive
- progressively render and virtualize large list views so 10k-item folders stay usable
- chunk bulk delete requests to avoid request body limits
- add delete progress feedback, top/bottom navigation controls, and select-all support
- improve list checkbox hit target for multi-selection

## Testing
- npm run -w frontend build -- --sourcemap false

Tested on fork image: ghcr.io/cerede2000/explorer:large-directory-and-bulk-delete