### PR TITLE
Add INTERNAL_URL for additional trusted origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ services:
 
 
       # Reverse proxy / networking (optional)
+      # INTERNAL_URL: "http://192.168.1.250:3017" # Extra origin(s) the app may also be reached from (e.g. a LAN IP for fast local uploads), comma-separated. Treated as valid (no public-URL mismatch warning) and accepted by CORS; PUBLIC_URL stays the canonical URL for share links / OIDC.
       # TRUST_PROXY: "loopback,uniquelocal" # Express trust proxy config; set when running behind a reverse proxy (often auto-derived when `PUBLIC_URL` is set).
       # CORS_ORIGINS: "" # Comma-separated allowed origins; aliases: `CORS_ORIGIN`, `ALLOWED_ORIGINS` (defaults to `PUBLIC_URL` origin when set).
 

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -21,6 +21,11 @@ module.exports = {
 
   // Public URL & Network
   PUBLIC_URL: process.env.PUBLIC_URL?.trim() || null,
+  // Additional origin(s) the app can legitimately be reached from (e.g. a LAN IP
+  // used for fast local uploads). Comma-separated. These are treated as valid
+  // (no public-URL mismatch warning) and accepted by CORS, while PUBLIC_URL stays
+  // the canonical URL used to build share links, OIDC callbacks, etc.
+  INTERNAL_URL: process.env.INTERNAL_URL?.trim() || null,
   TRUST_PROXY: process.env.TRUST_PROXY?.trim().toLowerCase(),
 
   // CORS

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -76,6 +76,29 @@ if (env.PUBLIC_URL) {
   }
 }
 
+// --- Additional (internal) origins ---
+// Extra origins the app can be reached from (e.g. a LAN IP), comma-separated.
+// They are considered valid so accessing the app that way doesn't raise the
+// public-URL mismatch warning, and they're accepted by CORS. PUBLIC_URL remains
+// the canonical URL used to build absolute links (shares, OIDC callbacks, WOPI).
+const parseOriginList = (value) =>
+  (typeof value === 'string' ? value.split(',') : [])
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      try {
+        return new URL(entry).origin;
+      } catch (err) {
+        console.warn(`[Config] Invalid INTERNAL_URL entry: ${entry}`);
+        return null;
+      }
+    })
+    .filter(Boolean);
+
+const internalOrigins = parseOriginList(env.INTERNAL_URL);
+// All origins the frontend should treat as valid (publicOrigin first, deduped).
+const knownOrigins = [...new Set([publicOrigin, ...internalOrigins].filter(Boolean))];
+
 // --- CORS ---
 const buildCorsConfig = () => {
   if (env.CORS_ORIGINS) {
@@ -87,7 +110,7 @@ const buildCorsConfig = () => {
         .filter(Boolean),
     };
   }
-  if (publicOrigin) return { allowAll: false, origins: [publicOrigin] };
+  if (knownOrigins.length) return { allowAll: false, origins: [...knownOrigins] };
   return { allowAll: true, origins: [] }; // Backwards compatibility
 };
 
@@ -239,7 +262,7 @@ module.exports = {
     passwordConfig: path.join(configDir, 'app-config.json'),
   },
 
-  public: { url: publicUrl, origin: publicOrigin },
+  public: { url: publicUrl, origin: publicOrigin, origins: knownOrigins },
 
   extensions: {
     images: constants.IMAGE_EXTENSIONS,

--- a/backend/src/routes/features.js
+++ b/backend/src/routes/features.js
@@ -18,6 +18,8 @@ router.get('/features', (_req, res) => {
     public: {
       url: publicConfig?.url || null,
       origin: publicConfig?.origin || null,
+      // All origins the app may legitimately be reached from (public + internal).
+      origins: Array.isArray(publicConfig?.origins) ? publicConfig.origins : [],
     },
     onlyoffice: {
       enabled: Boolean(onlyoffice && onlyoffice.serverUrl),

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -9,6 +9,7 @@ nextExplorer is configured almost entirely through environment variables. The ba
 | `PORT`                                           | `3000`                                          | Port the Express API and frontend listen on inside the container.                                                       |
 | `HTTP_TIMEOUT`                                   | `0`                                             | Node.js HTTP `requestTimeout` (ms). Use `0` to disable (avoids the Node 5-minute default that can abort large uploads). |
 | `PUBLIC_URL`                                     | _none_                                          | External URL (no trailing slash). Drives cookie settings, CORS defaults, and derived callback URLs (OIDC/OnlyOffice).   |
+| `INTERNAL_URL`                                   | _none_                                          | Additional origin(s) the app may also be reached from (e.g. a LAN IP for fast local uploads), comma-separated. Treated as valid (no public-URL mismatch warning) and accepted by CORS; `PUBLIC_URL` stays canonical for share links / OIDC. |
 | `TRUST_PROXY`                                    | `loopback,uniquelocal` when `PUBLIC_URL` is set | Express trust proxy configuration. Accepts `false`, numbers, CIDRs, or lists.                                           |
 | `CORS_ORIGIN`, `CORS_ORIGINS`, `ALLOWED_ORIGINS` | _empty_                                         | Comma-separated list of allowed CORS origins. Defaults to `PUBLIC_URL` origin when set.                                 |
 

--- a/frontend/src/composables/useConfigErrorGate.js
+++ b/frontend/src/composables/useConfigErrorGate.js
@@ -16,7 +16,15 @@ export function useConfigErrorGate() {
     try {
       await features.ensureLoaded();
       const expectedOrigin = features.publicOrigin || '';
-      if (expectedOrigin && expectedOrigin !== requestOrigin) {
+      // Accept the public origin AND any configured internal origins (e.g. a LAN
+      // IP). Only warn when the current origin matches none of them.
+      const acceptedOrigins =
+        Array.isArray(features.publicOrigins) && features.publicOrigins.length
+          ? features.publicOrigins
+          : expectedOrigin
+            ? [expectedOrigin]
+            : [];
+      if (acceptedOrigins.length && !acceptedOrigins.includes(requestOrigin)) {
         configError.value = { mode: 'mismatch', expectedOrigin, requestOrigin };
       }
     } catch (_) {

--- a/frontend/src/stores/features.js
+++ b/frontend/src/stores/features.js
@@ -5,6 +5,8 @@ import { fetchFeatures } from '@/api';
 export const useFeaturesStore = defineStore('features', () => {
   const publicUrl = ref('');
   const publicOrigin = ref('');
+  // Every origin the app may legitimately be reached from (public + internal).
+  const publicOrigins = ref([]);
   const editorExtensions = ref([]);
   const onlyofficeEnabled = ref(false);
   const onlyofficeExtensions = ref([]);
@@ -43,6 +45,9 @@ export const useFeaturesStore = defineStore('features', () => {
         publicUrl.value = typeof features?.public?.url === 'string' ? features.public.url : '';
         publicOrigin.value =
           typeof features?.public?.origin === 'string' ? features.public.origin : '';
+        publicOrigins.value = Array.isArray(features?.public?.origins)
+          ? features.public.origins.filter((o) => typeof o === 'string' && o)
+          : [];
 
         // Editor extensions
         editorExtensions.value = Array.isArray(features?.editor?.extensions)
@@ -89,6 +94,7 @@ export const useFeaturesStore = defineStore('features', () => {
         // Set defaults on error
         publicUrl.value = '';
         publicOrigin.value = '';
+        publicOrigins.value = [];
         editorExtensions.value = [];
         onlyofficeEnabled.value = false;
         onlyofficeExtensions.value = [];
@@ -120,6 +126,7 @@ export const useFeaturesStore = defineStore('features', () => {
   return {
     publicUrl,
     publicOrigin,
+    publicOrigins,
     editorExtensions,
     onlyofficeEnabled,
     onlyofficeExtensions,


### PR DESCRIPTION
## Summary
When `PUBLIC_URL` (+ `TRUST_PROXY`) is set but the app is also reached locally
via a LAN IP (e.g. `http://192.168.1.x:3000` for faster local uploads), the UI
shows a "PUBLIC_URL does not match this domain" warning on every load, and CORS
only trusts the public origin.

This adds an optional **`INTERNAL_URL`** env var (comma-separated list of extra
origins). Those origins are treated as valid (no mismatch warning) and accepted
by CORS. `PUBLIC_URL` stays canonical for share links / OIDC / OnlyOffice.

## Changes
- `config`: `INTERNAL_URL` parsed into `internalOrigins`; `knownOrigins =
  unique([publicOrigin, ...internalOrigins])`, exposed as `public.origins` and
  used by the CORS allow-list. `public.origin` (canonical) is unchanged.
- `/api/features` returns `public.origins`; frontend `features` store exposes
  `publicOrigins`; `useConfigErrorGate` warns only when the current origin
  matches none of them (falls back to `[publicOrigin]` → backwards compatible).
- Docs: README + `docs/configuration/environment.md`.

Fully backwards-compatible (no `INTERNAL_URL` → identical behavior).