### PR TITLE
Make VA-API and RAW support optional via build args (smaller image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,22 +50,32 @@ RUN addgroup -S appuser && \
 
 # Runtime packages only.
 #
-# Core:
-#   ffmpeg          – video thumbnail extraction & HW-accel transcoding
+# Core (always installed):
+#   ffmpeg          – video thumbnail extraction & software transcoding
 #   gosu            – UID/GID remapping in entrypoint
 #   ripgrep         – fast file-content search
 #   imagemagick     – HEIC → PNG thumbnail conversion
-#   openssh-client  – optional SSH remote access
+#   openssh-client  – optional SSH remote access (terminal only)
 #   unzip           – demo mode sample extraction (downloadSamples.js)
 #   bash            – entrypoint.sh is a bash script
 #   shadow          – provides usermod/groupmod for UID/GID remapping
-#   perl            – required by exiftool-vendored for RAW image previews
-#   curl            – For terminal users 
+#   curl            – For terminal users
 #
-# VA-API hardware-accelerated video decode (Intel Quick Sync / AMD):
+# Optional (see INCLUDE_RAW / INCLUDE_VAAPI build args below):
+#   perl            – required by exiftool-vendored for RAW image previews
 #   libva           – core VA-API runtime (includes libva-drm)
-#   mesa-va-gallium – Mesa VA-API GPU drivers
+#   mesa-va-gallium – Mesa VA-API GPU drivers (pulls Mesa + LLVM, ~80 MB)
 
+
+# Optional feature stacks — toggled at build time. Defaults keep the FULL image
+# byte-for-byte identical to before.
+#   INCLUDE_RAW=false    drops perl + the exiftool-vendored node module: removes
+#                        RAW-photo previews only (normal EXIF still works via exifr).
+#   INCLUDE_VAAPI=false  drops libva + mesa-va-gallium (Mesa + LLVM, ~80 MB): ffmpeg
+#                        still decodes video in software. VA-API is opt-in anyway,
+#                        used only when FFMPEG_HWACCEL is set with a GPU passed in.
+ARG INCLUDE_RAW=true
+ARG INCLUDE_VAAPI=true
 
 RUN apk add --no-cache \
       ffmpeg \
@@ -76,10 +86,9 @@ RUN apk add --no-cache \
       unzip \
       bash \
       shadow \
-      perl \
-      libva \
-      mesa-va-gallium \
       curl \
+  && if [ "$INCLUDE_RAW" = "true" ]; then apk add --no-cache perl; fi \
+  && if [ "$INCLUDE_VAAPI" = "true" ]; then apk add --no-cache libva mesa-va-gallium; fi \
   && rm -rf /tmp/* /var/cache/apk/*
 
 WORKDIR /app
@@ -96,6 +105,13 @@ ENV REPO_URL=${REPO_URL}
 # Build tools from backend_deps stage are NOT included — only the output.
 COPY --from=backend_deps /app/node_modules ./node_modules
 COPY --from=backend_deps /app/package.json ./
+
+# When RAW support is disabled, drop the vendored ExifTool (~20 MB) from the
+# runtime node_modules. rawPreviewService.js already degrades gracefully when the
+# module is absent (the require is wrapped in try/catch).
+RUN if [ "$INCLUDE_RAW" != "true" ]; then \
+      rm -rf node_modules/exiftool-vendored node_modules/exiftool-vendored.pl; \
+    fi
 
 # Copy backend source and healthcheck.
 COPY backend/src ./src


### PR DESCRIPTION
## Summary
The published image is ~260 MB compressed (amd64), and ~60% of it is a single
`apk add` layer. Two of those stacks are shipped in every image but only help a
minority of deployments:

- **VA-API GPU decode — ~80 MB.** `mesa-va-gallium` → `mesa` → `libLLVM`
  (llvm-libs is ~67 MB download alone). Only used when `FFMPEG_HWACCEL` is set
  with a GPU passed in (`/dev/dri`); otherwise ffmpeg already decodes in
  software and these ~80 MB do nothing.
- **RAW-photo previews — ~18 MB.** system `perl` + `exiftool-vendored`, used
  only by `rawPreviewService.js` (which already degrades gracefully when the
  module is absent). Normal EXIF uses `exifr` (pure JS), which stays.

## Change
Two build args (both default `true`, so the default image is unchanged):

    ARG INCLUDE_RAW=true      # perl + exiftool-vendored
    ARG INCLUDE_VAAPI=true    # libva + mesa-va-gallium

When `false`, the corresponding apk packages are skipped and (for RAW) the
vendored ExifTool is removed from `node_modules`. This lets a lean variant be
built from the same Dockerfile — the pattern used by linuxserver.io, Jellyfin,
Immich, etc. (default full + opt-in tag variants).

## Result (measured)
Built with both args `false`: **165 MB vs 260 MB (−94 MB, −36 %)** — the apk
layer drops from 156 MB to 62 MB — and the app runs fine (software video
thumbnails, image thumbnails, HEIC, search, terminal, shares all work).

Fully backwards-compatible: defaults keep the current image byte-for-byte.

Closes https://github.com/nxzai/NextExplorer/issues/324