### PR TITLE
Fix settings toggles so the knob actually slides

### DIFF
--- a/frontend/src/components/ToggleSwitch.vue
+++ b/frontend/src/components/ToggleSwitch.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { computed } from 'vue';
+
+// Accessible on/off switch. The knob position is driven by Vue state (not a CSS
+// `peer-checked:` sibling selector, which silently fails when the knob is nested
+// inside the track), so the knob actually SLIDES left↔right — the active state is
+// unmistakable: knob on the right + a green track, vs knob on the left + a grey
+// track.
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+  size: { type: String, default: 'md' }, // 'md' | 'sm'
+});
+const emit = defineEmits(['update:modelValue']);
+
+const toggle = () => {
+  if (props.disabled) return;
+  emit('update:modelValue', !props.modelValue);
+};
+
+const dims = computed(() =>
+  props.size === 'sm'
+    ? { track: 'h-5 w-9', knob: 'h-4 w-4', on: 'translate-x-[18px]', off: 'translate-x-[2px]' }
+    : { track: 'h-6 w-11', knob: 'h-5 w-5', on: 'translate-x-[22px]', off: 'translate-x-[2px]' }
+);
+</script>
+
+<template>
+  <button
+    type="button"
+    role="switch"
+    :aria-checked="modelValue"
+    :disabled="disabled"
+    @click.stop="toggle"
+    class="relative inline-flex shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 dark:focus-visible:ring-offset-zinc-900"
+    :class="[dims.track, modelValue ? 'bg-emerald-500' : 'bg-zinc-300 dark:bg-zinc-600']"
+  >
+    <span
+      class="pointer-events-none inline-block transform rounded-full bg-white shadow ring-1 ring-black/5 transition-transform duration-200 ease-in-out"
+      :class="[dims.knob, modelValue ? dims.on : dims.off]"
+    ></span>
+  </button>
+</template>

--- a/frontend/src/views/settings/SettingsFilesThumbnails.vue
+++ b/frontend/src/views/settings/SettingsFilesThumbnails.vue
@@ -2,6 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 import { useAppSettings } from '@/stores/appSettings';
 import { useI18n } from 'vue-i18n';
+import ToggleSwitch from '@/components/ToggleSwitch.vue';
 
 const appSettings = useAppSettings();
 const { t } = useI18n();
@@ -106,16 +107,7 @@ const save = async () => {
               {{ t('settings.thumbs.enableHelp') }}
             </div>
           </div>
-          <label class="inline-flex cursor-pointer items-center">
-            <input type="checkbox" v-model="local.enabled" class="peer sr-only" />
-            <div
-              class="peer relative h-6 w-11 rounded-full bg-zinc-200 transition-colors peer-checked:bg-zinc-900 dark:bg-zinc-700 dark:peer-checked:bg-zinc-100"
-            >
-              <div
-                class="absolute left-[2px] top-[2px] h-5 w-5 rounded-full bg-white transition-transform peer-checked:translate-x-5"
-              ></div>
-            </div>
-          </label>
+          <ToggleSwitch v-model="local.enabled" />
         </div>
 
         <div

--- a/frontend/src/views/settings/SettingsUserPreferences.vue
+++ b/frontend/src/views/settings/SettingsUserPreferences.vue
@@ -2,6 +2,7 @@
 import { computed, reactive, watch } from 'vue';
 import { useAppSettings } from '@/stores/appSettings';
 import { useI18n } from 'vue-i18n';
+import ToggleSwitch from '@/components/ToggleSwitch.vue';
 
 const appSettings = useAppSettings();
 const { t } = useI18n();
@@ -163,16 +164,7 @@ const save = async () => {
               {{ t('settings.userPreferences.showHiddenFilesHelp') }}
             </div>
           </div>
-          <label class="inline-flex cursor-pointer items-center">
-            <input type="checkbox" v-model="local.showHiddenFiles" class="peer sr-only" />
-            <div
-              class="peer relative h-6 w-11 rounded-full bg-zinc-200 transition-colors peer-checked:bg-zinc-900 dark:bg-zinc-700 dark:peer-checked:bg-zinc-100"
-            >
-              <div
-                class="absolute left-[2px] top-[2px] h-5 w-5 rounded-full bg-white transition-transform peer-checked:translate-x-5"
-              ></div>
-            </div>
-          </label>
+          <ToggleSwitch v-model="local.showHiddenFiles" />
         </div>
 
         <div class="flex items-center justify-between py-3 border-b border-zinc-100 dark:border-zinc-800 last:border-0">
@@ -184,16 +176,7 @@ const save = async () => {
               {{ t('settings.userPreferences.showThumbnailsHelp') }}
             </div>
           </div>
-          <label class="inline-flex cursor-pointer items-center">
-            <input type="checkbox" v-model="local.showThumbnails" class="peer sr-only" />
-            <div
-              class="peer relative h-6 w-11 rounded-full bg-zinc-200 transition-colors peer-checked:bg-zinc-900 dark:bg-zinc-700 dark:peer-checked:bg-zinc-100"
-            >
-              <div
-                class="absolute left-[2px] top-[2px] h-5 w-5 rounded-full bg-white transition-transform peer-checked:translate-x-5"
-              ></div>
-            </div>
-          </label>
+          <ToggleSwitch v-model="local.showThumbnails" />
         </div>
 
         <div
@@ -209,16 +192,7 @@ const save = async () => {
               {{ t(row.help) }}
             </div>
           </div>
-          <label class="inline-flex cursor-pointer items-center">
-            <input type="checkbox" v-model="local[row.key]" class="peer sr-only" />
-            <div
-              class="peer relative h-6 w-11 rounded-full bg-zinc-200 transition-colors peer-checked:bg-zinc-900 dark:bg-zinc-700 dark:peer-checked:bg-zinc-100"
-            >
-              <div
-                class="absolute left-[2px] top-[2px] h-5 w-5 rounded-full bg-white transition-transform peer-checked:translate-x-5"
-              ></div>
-            </div>
-          </label>
+          <ToggleSwitch v-model="local[row.key]" />
         </div>
 
         <div class="flex items-center justify-between py-3 border-b border-zinc-100 dark:border-zinc-800 last:border-0">


### PR DESCRIPTION
## Problem
The settings toggle knob never moved — only the track colour changed, which
is hard to tell apart. The knob `<div>` is nested **inside** the track, but
`peer-checked:translate-x-5` needs the checked `<input>` to be a **sibling**,
so it never matched.

## Fix
New reusable `ToggleSwitch.vue` (`role="switch"`, keyboard-accessible,
`v-model`) drives the knob position from Vue state instead of a CSS peer
selector, so it actually slides: **knob left + grey track when off, knob
right + green track when on** — unmistakable at a glance. A `size="sm"` prop
is available for dense lists.

Replaces the hand-rolled toggles in user preferences and thumbnail settings.