### PR TITLE
Add real progress for copy/move and reposition to the pasted entry

### DIFF
--- a/backend/src/routes/files/transfer.js
+++ b/backend/src/routes/files/transfer.js
@@ -1,30 +1,59 @@
-const { transferItems } = require('../../services/fileTransferService');
+const { prepareTransfer, executeTransfer } = require('../../services/fileTransferService');
 const asyncHandler = require('../../utils/asyncHandler');
 
 const router = require('express').Router();
 
-router.post(
-  '/files/copy',
+// Copy/move stream newline-delimited JSON events so the client can render a
+// determinate progress bar:
+//   {type:'start',    totalBytes, totalItems, destination}
+//   {type:'progress', copiedBytes, totalBytes, currentName}   (throttled)
+//   {type:'done',     success, destination, items}
+//   {type:'error',    message, code}
+// Validation/authorization runs first (prepareTransfer); if it throws, no
+// streaming header has been sent yet, so asyncHandler forwards it to the error
+// middleware and the client gets a normal HTTP error response.
+const runTransfer = (operation) =>
   asyncHandler(async (req, res) => {
     const { items = [], destination = '' } = req.body || {};
-    const result = await transferItems(items, destination, 'copy', {
-      user: req.user,
-      guestSession: req.guestSession,
-    });
-    res.json({ success: true, ...result });
-  })
-);
+    const options = { user: req.user, guestSession: req.guestSession };
 
-router.post(
-  '/files/move',
-  asyncHandler(async (req, res) => {
-    const { items = [], destination = '' } = req.body || {};
-    const result = await transferItems(items, destination, 'move', {
-      user: req.user,
-      guestSession: req.guestSession,
+    const prep = await prepareTransfer(items, destination, operation, options);
+
+    res.status(200);
+    res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    // Disable proxy buffering so progress lines reach the client promptly.
+    res.setHeader('X-Accel-Buffering', 'no');
+
+    const writeEvent = (event) => {
+      if (res.writableEnded) return;
+      res.write(`${JSON.stringify(event)}\n`);
+    };
+
+    writeEvent({
+      type: 'start',
+      totalBytes: prep.totalBytes,
+      totalItems: prep.totalItems,
+      destination: prep.destinationRelative,
     });
-    res.json({ success: true, ...result });
-  })
-);
+
+    try {
+      const result = await executeTransfer(prep, operation, (progress) =>
+        writeEvent({ type: 'progress', ...progress })
+      );
+      writeEvent({ type: 'done', success: true, ...result });
+    } catch (error) {
+      writeEvent({
+        type: 'error',
+        message: error.message || 'Transfer failed.',
+        code: error.code || 'TRANSFER_FAILED',
+      });
+    } finally {
+      res.end();
+    }
+  });
+
+router.post('/files/copy', runTransfer('copy'));
+router.post('/files/move', runTransfer('move'));
 
 module.exports = router;

--- a/backend/src/services/fileTransferService.js
+++ b/backend/src/services/fileTransferService.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs/promises');
+const fsSync = require('fs');
 
 const { ensureDir, pathExists } = require('../utils/fsUtils');
 const {
@@ -10,35 +11,112 @@ const {
 const { ACTIONS, authorizeAndResolve, authorizePath } = require('./authorizationService');
 const { getSharesForSourceTargets, deleteSharesByIds } = require('./sharesService');
 
-const copyEntry = async (sourcePath, destinationPath, isDirectory) => {
-  if (isDirectory) {
-    if (typeof fs.cp === 'function') {
-      await fs.cp(sourcePath, destinationPath, {
-        recursive: true,
-        force: false,
-        errorOnExist: true,
-      });
-    } else {
-      await ensureDir(destinationPath);
-      const entries = await fs.readdir(sourcePath, { withFileTypes: true });
-      for (const entry of entries) {
-        const src = path.join(sourcePath, entry.name);
-        const dest = path.join(destinationPath, entry.name);
-        // eslint-disable-next-line no-await-in-loop
-        await copyEntry(src, dest, entry.isDirectory());
+// How often (ms) progress is reported to the caller while bytes stream, so a
+// large file emits a steady trickle of updates rather than one per chunk.
+const PROGRESS_THROTTLE_MS = 150;
+
+// Recursively sum the byte size of a file or directory subtree. Symlinks count
+// as zero (they are recreated, not byte-copied). Best-effort: entries that
+// cannot be stat()ed are skipped so a partial tree still yields a usable total.
+const computeEntrySize = async (absolutePath, isDirectory) => {
+  if (!isDirectory) {
+    try {
+      const stats = await fs.lstat(absolutePath);
+      return stats.isSymbolicLink() ? 0 : stats.size;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  let total = 0;
+  const stack = [absolutePath];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch (_) {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile()) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const stats = await fs.stat(full);
+          total += stats.size;
+        } catch (_) {
+          // Unreadable entry: skip it, keep the total best-effort.
+        }
       }
     }
-  } else {
-    await fs.copyFile(sourcePath, destinationPath);
+  }
+  return total;
+};
+
+// Copy a single regular file through streams so bytes can be reported as they
+// are written. The source mode is applied at creation to mirror fs.copyFile.
+const copyFileWithProgress = (sourcePath, destinationPath, mode, onBytes) =>
+  new Promise((resolve, reject) => {
+    const readStream = fsSync.createReadStream(sourcePath);
+    const writeStream = fsSync.createWriteStream(
+      destinationPath,
+      mode != null ? { mode } : undefined
+    );
+
+    const fail = (error) => {
+      readStream.destroy();
+      writeStream.destroy();
+      reject(error);
+    };
+
+    readStream.on('error', fail);
+    writeStream.on('error', fail);
+    if (typeof onBytes === 'function') {
+      readStream.on('data', (chunk) => onBytes(chunk.length));
+    }
+    writeStream.on('finish', resolve);
+    readStream.pipe(writeStream);
+  });
+
+// Recursively copy a file/dir, reporting copied bytes. Symlinks are recreated.
+const copyEntryWithProgress = async (sourcePath, destinationPath, isDirectory, onBytes) => {
+  if (!isDirectory) {
+    const stats = await fs.lstat(sourcePath);
+    if (stats.isSymbolicLink()) {
+      const linkTarget = await fs.readlink(sourcePath);
+      await fs.symlink(linkTarget, destinationPath);
+      return;
+    }
+    await copyFileWithProgress(sourcePath, destinationPath, stats.mode, onBytes);
+    return;
+  }
+
+  await ensureDir(destinationPath);
+  const entries = await fs.readdir(sourcePath, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = path.join(sourcePath, entry.name);
+    const dest = path.join(destinationPath, entry.name);
+    // eslint-disable-next-line no-await-in-loop
+    await copyEntryWithProgress(src, dest, entry.isDirectory(), onBytes);
   }
 };
 
-const moveEntry = async (sourcePath, destinationPath, isDirectory) => {
+// Move an entry, reporting progress. A same-filesystem rename is atomic and
+// instant, so the entry's whole size is reported at once; a cross-device move
+// (EXDEV) falls back to a byte-tracked copy followed by removal of the source.
+const moveEntryWithProgress = async (sourcePath, destinationPath, isDirectory, size, onBytes) => {
   try {
     await fs.rename(sourcePath, destinationPath);
+    if (typeof onBytes === 'function' && size > 0) {
+      onBytes(size);
+    }
   } catch (error) {
     if (error.code === 'EXDEV') {
-      await copyEntry(sourcePath, destinationPath, isDirectory);
+      await copyEntryWithProgress(sourcePath, destinationPath, isDirectory, onBytes);
       await fs.rm(sourcePath, { recursive: isDirectory, force: true });
     } else {
       throw error;
@@ -46,7 +124,11 @@ const moveEntry = async (sourcePath, destinationPath, isDirectory) => {
   }
 };
 
-const transferItems = async (items, destination, operation, options = {}) => {
+// Phase 1: authorize + resolve every item, stat it, and pre-compute the total
+// byte count so the client can render a determinate progress bar. Throws on any
+// validation/authorization failure — the route runs this BEFORE it commits to a
+// streaming response, so these surface as a normal HTTP error (status + code).
+const prepareTransfer = async (items, destination, operation, options = {}) => {
   if (!Array.isArray(items) || items.length === 0) {
     throw new Error('At least one item is required.');
   }
@@ -76,9 +158,8 @@ const transferItems = async (items, destination, operation, options = {}) => {
 
   const { absolutePath: destinationAbsolute } = destResolved;
 
-  await ensureDir(destinationAbsolute);
-
-  const results = [];
+  const plans = [];
+  let totalBytes = 0;
 
   for (const item of items) {
     const sourceCombined = combineRelativePath(item.path || '', item.name);
@@ -86,6 +167,7 @@ const transferItems = async (items, destination, operation, options = {}) => {
       allowed: srcAllowed,
       accessInfo: srcAccess,
       resolved: srcResolved,
+      // eslint-disable-next-line no-await-in-loop
     } = await authorizeAndResolve(context, sourceCombined, ACTIONS.read);
     if (!srcAllowed || !srcResolved) {
       throw new Error(srcAccess?.denialReason || `Source path not accessible: ${sourceCombined}`);
@@ -93,46 +175,121 @@ const transferItems = async (items, destination, operation, options = {}) => {
 
     const { relativePath: sourceRelative, absolutePath: sourceAbsolute } = srcResolved;
 
+    // eslint-disable-next-line no-await-in-loop
     if (!(await pathExists(sourceAbsolute))) {
       throw new Error(`Source path not found: ${sourceRelative}`);
     }
 
     if (operation === 'move') {
-      const { allowed: deleteAllowed, accessInfo: deleteAccess } = await authorizePath(
-        context,
-        sourceCombined,
-        ACTIONS.delete
-      );
+      const { allowed: deleteAllowed, accessInfo: deleteAccess } =
+        // eslint-disable-next-line no-await-in-loop
+        await authorizePath(context, sourceCombined, ACTIONS.delete);
       if (!deleteAllowed) {
         throw new Error(deleteAccess?.denialReason || 'Cannot move items from this path.');
       }
     }
 
+    // eslint-disable-next-line no-await-in-loop
     const stats = await fs.stat(sourceAbsolute);
+    const isDirectory = stats.isDirectory();
     const sourceParent = normalizeRelativePath(path.dirname(sourceRelative));
 
     if (operation === 'move' && destinationRelative === sourceParent) {
-      results.push({ from: sourceRelative, to: sourceRelative, skipped: true });
+      plans.push({ sourceRelative, skipped: true });
       continue;
     }
 
-    const desiredName = item.newName || item.name;
-    const availableName = await findAvailableName(destinationAbsolute, desiredName);
+    // eslint-disable-next-line no-await-in-loop
+    const size = await computeEntrySize(sourceAbsolute, isDirectory);
+    totalBytes += size;
+
+    plans.push({
+      sourceAbsolute,
+      sourceRelative,
+      isDirectory,
+      size,
+      desiredName: item.newName || item.name,
+    });
+  }
+
+  return {
+    destinationRelative,
+    destinationAbsolute,
+    plans,
+    totalBytes,
+    totalItems: plans.filter((plan) => !plan.skipped).length,
+  };
+};
+
+// Phase 2: perform the copy/move for each prepared plan, reporting progress via
+// onProgress({ copiedBytes, totalBytes, currentName }). Runs after the response
+// has switched to streaming mode, so an error here is surfaced in the stream.
+const executeTransfer = async (prep, operation, onProgress) => {
+  const { destinationRelative, destinationAbsolute, plans, totalBytes } = prep;
+
+  await ensureDir(destinationAbsolute);
+
+  const results = [];
+  let copiedBytes = 0;
+  let lastEmit = 0;
+  let currentName = '';
+
+  const emit = (force = false) => {
+    if (typeof onProgress !== 'function') return;
+    const now = Date.now();
+    if (!force && now - lastEmit < PROGRESS_THROTTLE_MS) return;
+    lastEmit = now;
+    onProgress({ copiedBytes, totalBytes, currentName });
+  };
+
+  const onBytes = (delta) => {
+    copiedBytes += delta;
+    emit(false);
+  };
+
+  for (const plan of plans) {
+    if (plan.skipped) {
+      results.push({ from: plan.sourceRelative, to: plan.sourceRelative, skipped: true });
+      continue;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const availableName = await findAvailableName(destinationAbsolute, plan.desiredName);
     const targetAbsolute = path.join(destinationAbsolute, availableName);
     const targetRelative = combineRelativePath(destinationRelative, availableName);
+    currentName = availableName;
+    emit(true);
 
     if (operation === 'copy') {
-      await copyEntry(sourceAbsolute, targetAbsolute, stats.isDirectory());
+      // eslint-disable-next-line no-await-in-loop
+      await copyEntryWithProgress(plan.sourceAbsolute, targetAbsolute, plan.isDirectory, onBytes);
     } else if (operation === 'move') {
-      await moveEntry(sourceAbsolute, targetAbsolute, stats.isDirectory());
+      // eslint-disable-next-line no-await-in-loop
+      await moveEntryWithProgress(
+        plan.sourceAbsolute,
+        targetAbsolute,
+        plan.isDirectory,
+        plan.size,
+        onBytes
+      );
     } else {
       throw new Error(`Unsupported operation: ${operation}`);
     }
 
-    results.push({ from: sourceRelative, to: targetRelative });
+    results.push({ from: plan.sourceRelative, to: targetRelative });
   }
 
+  // Snap to 100% once every entry is done (covers rounding and any skipped work).
+  copiedBytes = totalBytes;
+  emit(true);
+
   return { destination: destinationRelative, items: results };
+};
+
+// One-shot API preserved for callers that do not need progress reporting.
+const transferItems = async (items, destination, operation, options = {}) => {
+  const prep = await prepareTransfer(items, destination, operation, options);
+  return executeTransfer(prep, operation, options.onProgress);
 };
 
 const getShareSourceTarget = (resolved, includeChildren = false) => {
@@ -245,6 +402,8 @@ const deleteItems = async (items = [], options = {}) => {
 };
 
 module.exports = {
+  prepareTransfer,
+  executeTransfer,
   transferItems,
   getDeleteImpact,
   deleteItems,

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -1,4 +1,4 @@
-import { requestJson, requestRaw, normalizePath, encodePath, buildUrl } from './http';
+import { requestJson, requestRaw, requestStream, normalizePath, encodePath, buildUrl } from './http';
 
 const DELETE_BATCH_SIZE = 100;
 
@@ -19,17 +19,19 @@ async function getUsage(path = '') {
   return requestJson(`/api/usage/${encodedPath}`, { method: 'GET' });
 }
 
-async function copyItems(items, destination) {
-  return requestJson('/api/files/copy', {
+async function copyItems(items, destination, options = {}) {
+  return requestStream('/api/files/copy', {
     method: 'POST',
     body: JSON.stringify({ items, destination }),
+    onEvent: options.onEvent,
   });
 }
 
-async function moveItems(items, destination) {
-  return requestJson('/api/files/move', {
+async function moveItems(items, destination, options = {}) {
+  return requestStream('/api/files/move', {
     method: 'POST',
     body: JSON.stringify({ items, destination }),
+    onEvent: options.onEvent,
   });
 }
 

--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -100,4 +100,82 @@ const requestJson = async (endpoint, options = {}) => {
   return response.json();
 };
 
-export { apiBase, buildUrl, encodePath, normalizePath, requestJson, requestRaw };
+// Consume a newline-delimited JSON (NDJSON) response, invoking `onEvent` for
+// each streamed event and resolving with the final `{type:'done', ...}` payload.
+// A `{type:'error', ...}` line is turned into a thrown Error routed through the
+// global error handler, matching requestJson's behaviour. Pre-flight failures
+// (non-2xx) are still handled by requestRaw before streaming begins.
+const requestStream = async (endpoint, { onEvent, ...options } = {}) => {
+  const response = await requestRaw(endpoint, options);
+
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    // No readable stream available: fall back to a single JSON parse.
+    return response.json().catch(() => null);
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let result = null;
+  let streamError = null;
+
+  const handleLine = (rawLine) => {
+    const line = rawLine.trim();
+    if (!line) return;
+
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch (_) {
+      return;
+    }
+
+    if (event.type === 'error') {
+      streamError = event;
+    } else if (event.type === 'done') {
+      result = event;
+    } else if (typeof onEvent === 'function') {
+      onEvent(event);
+    }
+  };
+
+  for (;;) {
+    // eslint-disable-next-line no-await-in-loop
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let newlineIndex;
+    while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+      handleLine(buffer.slice(0, newlineIndex));
+      buffer = buffer.slice(newlineIndex + 1);
+    }
+  }
+  buffer += decoder.decode();
+  handleLine(buffer);
+
+  if (streamError) {
+    const errorInfo = {
+      statusCode: streamError.statusCode || 500,
+      message: streamError.message || 'Request failed',
+      code: streamError.code,
+    };
+    const translatedMessage = options.suppressErrorHandler
+      ? errorInfo.message
+      : errorHandler?.(errorInfo) || errorInfo.message;
+    const error = new Error(translatedMessage);
+    if (streamError.code) error.code = streamError.code;
+    throw error;
+  }
+
+  return result;
+};
+
+export {
+  apiBase,
+  buildUrl,
+  encodePath,
+  normalizePath,
+  requestJson,
+  requestRaw,
+  requestStream,
+};

--- a/frontend/src/components/ClipboardProgress.vue
+++ b/frontend/src/components/ClipboardProgress.vue
@@ -2,11 +2,29 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useFileStore } from '@/stores/fileStore';
+import { formatBytes } from '@/utils';
 
 const fileStore = useFileStore();
 const { t } = useI18n();
 
 const operation = computed(() => fileStore.deleteOperation || fileStore.clipboardOperation);
+
+const totalBytes = computed(() => Number(operation.value?.totalBytes) || 0);
+const copiedBytes = computed(() =>
+  Math.min(Number(operation.value?.copiedBytes) || 0, totalBytes.value || Number.POSITIVE_INFINITY)
+);
+
+// Determinate only when the backend reported a byte total (copy / cross-device
+// move). Same-filesystem moves and deletes keep the indeterminate animation.
+const hasProgress = computed(() => totalBytes.value > 0);
+const percent = computed(() =>
+  hasProgress.value ? Math.min(100, Math.round((copiedBytes.value / totalBytes.value) * 100)) : 0
+);
+const progressLabel = computed(() =>
+  hasProgress.value
+    ? `${formatBytes(copiedBytes.value)} / ${formatBytes(totalBytes.value)} · ${percent.value}%`
+    : t('clipboard.working')
+);
 
 const title = computed(() => {
   const op = operation.value;
@@ -47,12 +65,17 @@ const destination = computed(() => operation.value?.destination ?? '');
       <div
         class="w-full h-2 rounded-full overflow-hidden border border-zinc-200/70 dark:border-zinc-700/50 bg-zinc-100/80 dark:bg-zinc-800/70"
       >
-        <div class="h-full rounded-full clipboard-bar clipboard-bar--animated" />
+        <div
+          v-if="hasProgress"
+          class="h-full rounded-full clipboard-bar clipboard-bar--determinate"
+          :style="{ width: `${percent}%` }"
+        />
+        <div v-else class="h-full rounded-full clipboard-bar clipboard-bar--animated" />
       </div>
     </div>
 
-    <div class="mt-2 text-xs text-zinc-600 dark:text-zinc-300">
-      {{ t('clipboard.working') }}
+    <div class="mt-2 text-xs text-zinc-600 dark:text-zinc-300 tabular-nums">
+      {{ progressLabel }}
     </div>
   </div>
 </template>
@@ -70,6 +93,12 @@ const destination = computed(() => operation.value?.destination ?? '');
 
 .clipboard-bar--animated {
   animation: clipboardSlide 1.35s ease-in-out infinite;
+}
+
+/* Determinate bar: width is driven by the copied/total ratio; the inline width
+   set in the template overrides the base 42% used by the animated variant. */
+.clipboard-bar--determinate {
+  transition: width 0.2s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/components/ClipboardProgress.vue
+++ b/frontend/src/components/ClipboardProgress.vue
@@ -43,6 +43,13 @@ const title = computed(() => {
 });
 
 const destination = computed(() => operation.value?.destination ?? '');
+
+// The reposition toggle only applies to copy/move (clipboard) operations, never
+// to deletes.
+const isTransfer = computed(() => {
+  const type = operation.value?.type;
+  return type === 'copy' || type === 'move';
+});
 </script>
 
 <template>
@@ -77,6 +84,18 @@ const destination = computed(() => operation.value?.destination ?? '');
     <div class="mt-2 text-xs text-zinc-600 dark:text-zinc-300 tabular-nums">
       {{ progressLabel }}
     </div>
+
+    <label
+      v-if="isTransfer"
+      class="mt-3 flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-300 cursor-pointer select-none"
+    >
+      <input
+        v-model="fileStore.repositionAfterTransfer"
+        type="checkbox"
+        class="h-3.5 w-3.5 rounded border-zinc-300 text-indigo-600 focus:ring-indigo-500"
+      />
+      {{ t('clipboard.reposition') }}
+    </label>
   </div>
 </template>
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Kopieren von {count} {items}…",
     "moving": "Verschieben von {count} {items}…",
-    "working": "Wird verarbeitet…"
+    "working": "Wird verarbeitet…",
+    "reposition": "Nach Abschluss zum Element zurückkehren"
   },
   "upload": {
     "toggleDetailsShow": "Details anzeigen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -301,7 +301,8 @@
   "clipboard": {
     "copying": "Copying {count} {items}…",
     "moving": "Moving {count} {items}…",
-    "working": "Working…"
+    "working": "Working…",
+    "reposition": "Return to the item when done"
   },
   "upload": {
     "toggleDetailsShow": "Show details",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Copiando {count} {items}…",
     "moving": "Moviendo {count} {items}…",
-    "working": "Procesando…"
+    "working": "Procesando…",
+    "reposition": "Volver al elemento al terminar"
   },
   "upload": {
     "toggleDetailsShow": "Mostrar detalles",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -301,7 +301,8 @@
   "clipboard": {
     "copying": "Copie de {count} {items}…",
     "moving": "Déplacement de {count} {items}…",
-    "working": "Traitement…"
+    "working": "Traitement…",
+    "reposition": "Revenir sur l'élément à la fin"
   },
   "upload": {
     "toggleDetailsShow": "Afficher les détails",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "{count} {items} कॉपी किए जा रहे हैं…",
     "moving": "{count} {items} स्थानांतरित किए जा रहे हैं…",
-    "working": "प्रक्रिया जारी है…"
+    "working": "प्रक्रिया जारी है…",
+    "reposition": "पूरा होने पर आइटम पर लौटें"
   },
   "upload": {
     "toggleDetailsShow": "विवरण दिखाएँ",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Copia di {count} {items}…",
     "moving": "Spostamento di {count} {items}…",
-    "working": "In corso…"
+    "working": "In corso…",
+    "reposition": "Torna all'elemento al termine"
   },
   "upload": {
     "toggleDetailsShow": "Mostra dettagli",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "{count}개 {items} 복사 중…",
     "moving": "{count}개 {items} 이동 중…",
-    "working": "처리 중…"
+    "working": "처리 중…",
+    "reposition": "완료 후 항목으로 돌아가기"
   },
   "upload": {
     "toggleDetailsShow": "상세 정보 보기",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Kopiowanie {count} {items}…",
     "moving": "Przenoszenie {count} {items}…",
-    "working": "Przetwarzanie…"
+    "working": "Przetwarzanie…",
+    "reposition": "Wróć do elementu po zakończeniu"
   },
   "upload": {
     "toggleDetailsShow": "Pokaż szczegóły",

--- a/frontend/src/i18n/locales/ro.json
+++ b/frontend/src/i18n/locales/ro.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Se copiază {count} {items}…",
     "moving": "Se mută {count} {items}…",
-    "working": "În lucru…"
+    "working": "În lucru…",
+    "reposition": "Revino la element la final"
   },
   "upload": {
     "toggleDetailsShow": "Afișează detalii",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Копирование {count} {items}…",
     "moving": "Перемещение {count} {items}…",
-    "working": "Обработка…"
+    "working": "Обработка…",
+    "reposition": "Вернуться к объекту по завершении"
   },
   "upload": {
     "toggleDetailsShow": "Показать детали",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Kopierar {count} {items}…",
     "moving": "Flyttar {count} {items}…",
-    "working": "Arbetar…"
+    "working": "Arbetar…",
+    "reposition": "Återgå till objektet när det är klart"
   },
   "upload": {
     "toggleDetailsShow": "Visa detaljer",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "正在复制 {count} 个{items}…",
     "moving": "正在移动 {count} 个{items}…",
-    "working": "处理中…"
+    "working": "处理中…",
+    "reposition": "完成后返回该项目"
   },
   "upload": {
     "toggleDetailsShow": "显示详细信息",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "正在複製 {count} 個{items}…",
     "moving": "正在移動 {count} 個{items}…",
-    "working": "處理中…"
+    "working": "處理中…",
+    "reposition": "完成後返回該項目"
   },
   "upload": {
     "toggleDetailsShow": "顯示詳細資訊",

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -128,20 +128,36 @@ export const useFileStore = defineStore('fileStore', () => {
         destination,
         itemCount: totalCount,
         startedAt: Date.now(),
+        totalBytes: 0,
+        copiedBytes: 0,
       };
     }
+
+    // Fold streamed transfer events into the reactive operation so the progress
+    // bar tracks real bytes copied against the pre-computed total.
+    const onTransferEvent = (event) => {
+      const op = clipboardOperation.value;
+      if (!op || !event) return;
+      if (event.type === 'start') {
+        op.totalBytes = Number(event.totalBytes) || 0;
+        op.copiedBytes = 0;
+      } else if (event.type === 'progress') {
+        if (event.totalBytes != null) op.totalBytes = Number(event.totalBytes) || 0;
+        op.copiedBytes = Number(event.copiedBytes) || 0;
+      }
+    };
 
     try {
       if (copiedItems.value.length > 0) {
         if (copyPayload.length > 0) {
-          await copyItems(copyPayload, destination);
+          await copyItems(copyPayload, destination, { onEvent: onTransferEvent });
         }
         copiedItems.value = [];
       }
 
       if (cutItems.value.length > 0) {
         if (movePayload.length > 0) {
-          await moveItems(movePayload, destination);
+          await moveItems(movePayload, destination, { onEvent: onTransferEvent });
         }
         cutItems.value = [];
       }

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { useStorage } from '@vueuse/core';
+import router from '@/router';
 import {
   browse,
   copyItems,
@@ -34,6 +35,11 @@ export const useFileStore = defineStore('fileStore', () => {
 
   const copiedItems = useStorage('nextExplorer_clipboard_copied', []);
   const cutItems = useStorage('nextExplorer_clipboard_cut', []);
+  // When true, a finished copy/move re-focuses the pasted entry in its destination
+  // folder (navigating there via the router so the address bar stays in sync).
+  // When false, the current view is left untouched — handy for launching a long
+  // transfer and continuing to browse elsewhere. Persisted across sessions.
+  const repositionAfterTransfer = useStorage('nextExplorer_paste_reposition', true);
   const thumbnailRequests = new Map();
 
   const hasSelection = computed(() => selectedItems.value.length > 0);
@@ -113,13 +119,79 @@ export const useFileStore = defineStore('fileStore', () => {
     cutItems.value = selectedItems.value.map((item) => ({ ...item }));
   };
 
+  // Final name of a copied/moved entry, from its destination-relative path.
+  const transferredBaseName = (relativePath) => {
+    const normalized = normalizePath(relativePath || '');
+    const idx = normalized.lastIndexOf('/');
+    return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+  };
+
+  // Collect the final entry names from a streamed transfer result ({ items:[{ to }] }).
+  const collectTransferredNames = (result, out) => {
+    const items = Array.isArray(result?.items) ? result.items : [];
+    for (const entry of items) {
+      const name = transferredBaseName(entry?.to);
+      if (name) out.push(name);
+    }
+  };
+
+  const selectItemsByName = (names) => {
+    const wanted = new Set((names || []).filter(Boolean));
+    if (wanted.size === 0) return;
+    const matches = currentPathItems.value.filter((it) => it && wanted.has(it.name));
+    if (matches.length > 0) {
+      selectedItems.value = matches;
+    }
+  };
+
+  // Refresh the view (and optionally reposition) once a copy/move settles. The
+  // address bar is driven by the router, so "repositioning" navigates through the
+  // router to keep the URL/breadcrumb in sync with the listing. When repositioning
+  // is disabled we only refresh the folder the user is *currently* viewing (which
+  // always matches the route), so navigating away mid-transfer is never disrupted.
+  const settleAfterTransfer = async (finalDestination, moveSourceParents, pastedNames) => {
+    const userLocation = normalizePath(currentPath.value || '');
+    const onDestination = userLocation === finalDestination;
+
+    if (repositionAfterTransfer.value) {
+      if (onDestination || !finalDestination) {
+        // Already at the destination (or destination is the root, which has no
+        // routable path): refresh in place and highlight the result. The address
+        // bar is already correct, so no navigation is needed.
+        await fetchPathItems(userLocation);
+        selectItemsByName(pastedNames);
+      } else {
+        // Elsewhere (navigated away, or pasted into another folder): navigate to
+        // the destination and select the entry, which also updates the address bar.
+        const firstName = pastedNames[0];
+        router
+          .push({
+            name: 'FolderView',
+            params: { path: finalDestination },
+            ...(firstName ? { query: { select: firstName } } : {}),
+          })
+          .catch(() => {});
+      }
+      return;
+    }
+
+    // Repositioning disabled: leave the user where they are. Refresh only when the
+    // current folder was actually affected (it is the destination, or a move source
+    // that just lost entries) so its listing stays accurate without any view jump.
+    if (onDestination || moveSourceParents.has(userLocation)) {
+      await fetchPathItems(userLocation);
+    }
+  };
+
   const paste = async (targetPath) => {
     const hasTarget = typeof targetPath === 'string' && targetPath.trim().length > 0;
     const destination = normalizePath(hasTarget ? targetPath : currentPath.value || '');
-    const refreshTarget = normalizePath(currentPath.value || '');
 
     const copyPayload = serializeItems(copiedItems.value);
     const movePayload = serializeItems(cutItems.value);
+    const moveSourceParents = new Set(
+      movePayload.map((item) => normalizePath(item.path || ''))
+    );
     const totalCount = copyPayload.length + movePayload.length;
 
     if (totalCount > 0) {
@@ -148,21 +220,28 @@ export const useFileStore = defineStore('fileStore', () => {
     };
 
     try {
+      const pastedNames = [];
+      let finalDestination = destination;
+
       if (copiedItems.value.length > 0) {
         if (copyPayload.length > 0) {
-          await copyItems(copyPayload, destination, { onEvent: onTransferEvent });
+          const result = await copyItems(copyPayload, destination, { onEvent: onTransferEvent });
+          collectTransferredNames(result, pastedNames);
+          if (result?.destination != null) finalDestination = normalizePath(result.destination);
         }
         copiedItems.value = [];
       }
 
       if (cutItems.value.length > 0) {
         if (movePayload.length > 0) {
-          await moveItems(movePayload, destination, { onEvent: onTransferEvent });
+          const result = await moveItems(movePayload, destination, { onEvent: onTransferEvent });
+          collectTransferredNames(result, pastedNames);
+          if (result?.destination != null) finalDestination = normalizePath(result.destination);
         }
         cutItems.value = [];
       }
 
-      await fetchPathItems(refreshTarget);
+      await settleAfterTransfer(finalDestination, moveSourceParents, pastedNames);
     } finally {
       clipboardOperation.value = null;
     }
@@ -554,6 +633,7 @@ export const useFileStore = defineStore('fileStore', () => {
     clearSelection,
     clipboardOperation,
     deleteOperation,
+    repositionAfterTransfer,
     copiedItems,
     cutItems,
     hasSelection,

--- a/frontend/src/stores/paste.reposition.spec.js
+++ b/frontend/src/stores/paste.reposition.spec.js
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const routerPush = vi.fn(() => Promise.resolve());
+const copyItems = vi.fn();
+const moveItems = vi.fn();
+const browse = vi.fn();
+
+vi.mock('@/router', () => ({
+  default: { push: (...args) => routerPush(...args) },
+}));
+
+vi.mock('@/api', () => ({
+  browse: (...args) => browse(...args),
+  copyItems: (...args) => copyItems(...args),
+  moveItems: (...args) => moveItems(...args),
+  deleteItems: vi.fn(),
+  // Kept identical to the real helper: strips leading/trailing slashes.
+  normalizePath: (p) => (p || '').replace(/^\/+|\/+$/g, ''),
+  createFolder: vi.fn(),
+  renameItem: vi.fn(),
+  saveFileContent: vi.fn(),
+  fetchThumbnail: vi.fn(),
+  extractZip: vi.fn(),
+  compressToZip: vi.fn(),
+  browseShare: vi.fn(),
+}));
+
+vi.mock('@/stores/settings', () => ({
+  useSettingsStore: () => ({ sortBy: { by: 'name', order: 'asc' } }),
+}));
+vi.mock('@/stores/appSettings', () => ({
+  useAppSettings: () => ({ thumbnailsEnabledForSession: true }),
+}));
+vi.mock('@/stores/favorites', () => ({
+  useFavoritesStore: () => ({ loadFavorites: vi.fn() }),
+}));
+vi.mock('@/stores/volumeUsage', () => ({
+  useVolumeUsageStore: () => ({ scheduleRefresh: vi.fn() }),
+}));
+vi.mock('@/stores/folderSize', () => ({
+  useFolderSizeStore: () => ({ scheduleRefresh: vi.fn(), sizeFor: () => null }),
+}));
+
+import { useFileStore } from '@/stores/fileStore';
+
+// browse() returns a listing containing the pasted entry so that, after an
+// in-place refresh, the store can re-select it by name.
+const listingWith = (name, parent) => ({
+  items: [{ name, path: parent, kind: 'file' }],
+  path: parent,
+});
+
+describe('fileStore paste repositioning', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    routerPush.mockClear();
+    copyItems.mockReset();
+    moveItems.mockReset();
+    browse.mockReset();
+  });
+
+  it('reposition ON, still on destination: refreshes in place and selects the pasted entry (no navigation)', async () => {
+    copyItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+    browse.mockResolvedValue(listingWith('f.bin', 'Usb/temp'));
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = true;
+    store.setCurrentPath('Usb/temp'); // user is viewing the destination
+    store.copiedItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste();
+
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(browse).toHaveBeenCalledWith('Usb/temp');
+    expect(store.selectedItems.map((i) => i.name)).toEqual(['f.bin']);
+    expect(store.copiedItems).toEqual([]);
+  });
+
+  it('reposition ON, navigated away: navigates to the destination with a select query (updates the address bar)', async () => {
+    copyItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = true;
+    store.setCurrentPath('some/other/folder'); // user browsed elsewhere during the copy
+    store.copiedItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste('Usb/temp');
+
+    expect(routerPush).toHaveBeenCalledTimes(1);
+    expect(routerPush).toHaveBeenCalledWith({
+      name: 'FolderView',
+      params: { path: 'Usb/temp' },
+      query: { select: 'f.bin' },
+    });
+    // The router-driven remount performs the fetch; the store must not refresh directly.
+    expect(browse).not.toHaveBeenCalled();
+  });
+
+  it('reposition OFF, still on destination: refreshes in place without navigating', async () => {
+    copyItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+    browse.mockResolvedValue(listingWith('f.bin', 'Usb/temp'));
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = false;
+    store.setCurrentPath('Usb/temp');
+    store.copiedItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste();
+
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(browse).toHaveBeenCalledWith('Usb/temp');
+  });
+
+  it('reposition OFF, navigated to an unaffected folder: leaves the view untouched (no fetch, no navigation)', async () => {
+    copyItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = false;
+    store.setCurrentPath('unrelated/place');
+    store.copiedItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste('Usb/temp');
+
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(browse).not.toHaveBeenCalled();
+  });
+
+  it('reposition OFF, viewing a move source: refreshes it so removed entries disappear', async () => {
+    moveItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+    browse.mockResolvedValue({ items: [], path: 'src' });
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = false;
+    store.setCurrentPath('src'); // viewing the folder the item is being moved out of
+    store.cutItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste('Usb/temp');
+
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(browse).toHaveBeenCalledWith('src');
+    expect(store.cutItems).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two quality-of-life improvements for copy/move operations:

## Real byte-level progress
The clipboard card showed an indeterminate "Working…" bar no matter how large the transfer. The copy/move endpoints now stream **NDJSON progress events** over the same POST (`start` → throttled `progress` → `done`/`error`): the backend walks the sources first (recursive size total), then streams byte-tracked copies (read/write streams, mode preserved, symlinks recreated; same-fs moves stay atomic renames and cross-device moves are byte-tracked copy+rm). The card shows `copied/total · N%`. Validation errors still fail before streaming begins, so they surface as normal HTTP errors.

## Reposition to the pasted entry
After a long copy/move finished, the view silently refreshed the *origin* folder even if you had navigated elsewhere — listing and address bar could end up out of sync. Pasting now settles through the router: if you're on the destination it refreshes in place and selects the pasted entry; if you navigated away it `router.push`es to the destination with `?select=` (address bar stays correct). A persisted checkbox on the progress card ("Return to the item when done", translated in all 13 locales) lets you opt out — then an unrelated folder you browsed to is left untouched.

Includes a unit-tested reposition spec (5 cases) and backend transfer tests; `vite build`, eslint and the test suites pass (the 4 failing backend tests on main are pre-existing and unrelated).

**Draft on purpose**: #320 adds folder-size hooks in the same code paths — once it lands I'll rebase this branch (re-adding the hook calls in `executeTransfer`) and mark it ready.