### PR TITLE
Fix the failing backend test suites

### DIFF
--- a/backend/src/services/db.js
+++ b/backend/src/services/db.js
@@ -580,7 +580,14 @@ const getDb = async () => {
   return dbInstance;
 };
 
+const closeDb = () => {
+  if (!dbInstance) return;
+  dbInstance.close();
+  dbInstance = null;
+};
+
 module.exports = {
   getDb,
+  closeDb,
   getDbPath,
 };

--- a/backend/src/services/fileTransferService.js
+++ b/backend/src/services/fileTransferService.js
@@ -9,6 +9,7 @@ const {
 } = require('../utils/pathUtils');
 const { ACTIONS, authorizeAndResolve, authorizePath } = require('./authorizationService');
 const { getSharesForSourceTargets, deleteSharesByIds } = require('./sharesService');
+const { removeFavoritesForDeletedPath } = require('./favoritesService');
 
 const copyEntry = async (sourcePath, destinationPath, isDirectory) => {
   if (isDirectory) {
@@ -234,10 +235,16 @@ const deleteItems = async (items = [], options = {}) => {
 
     await fs.rm(absolutePath, { recursive: isDirectory || stats.isDirectory(), force: true });
     const deletedShareCount = await deleteSharesByIds(affectedShares.map((share) => share.id));
+    const removedFavoriteCount = context.user?.id
+      ? await removeFavoritesForDeletedPath(context.user.id, relativePath, {
+          includeChildren: isDirectory || stats.isDirectory(),
+        })
+      : 0;
     results.push({
       path: relativePath,
       status: 'deleted',
       ...(deletedShareCount > 0 ? { deletedShareCount } : {}),
+      ...(removedFavoriteCount > 0 ? { removedFavoriteCount } : {}),
     });
   }
 

--- a/backend/tests/routes/auth.test.js
+++ b/backend/tests/routes/auth.test.js
@@ -27,6 +27,8 @@ const buildApp = ({ authEnabled } = {}) => {
 
   // Ensure each test app starts with a clean database.
   try {
+    const dbService = require('../../src/services/db');
+    dbService.closeDb?.();
     fs.rmSync(path.join(envContext.configDir, 'app.db'), { force: true });
   } catch (_) {
     // ignore

--- a/backend/tests/routes/browse-hidden-files.test.js
+++ b/backend/tests/routes/browse-hidden-files.test.js
@@ -17,11 +17,22 @@ const createBrowseContext = async () => {
       'src/middleware/errorHandler',
       'src/services/accessManager',
       'src/services/settingsService',
+      'src/utils/pathUtils',
     ],
   });
 
   const browseRoutes = envContext.requireFresh('src/routes/browse');
   const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
+  const { getDb } = envContext.requireFresh('src/services/db');
+  const db = await getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `
+    INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `
+  ).run('admin', 'admin@example.com', 1, 'admin', 'Admin', '["admin"]', now, now);
+
   const app = createTestApp({
     router: browseRoutes,
     mountPath: '/api',

--- a/backend/tests/routes/search-hidden-files.test.js
+++ b/backend/tests/routes/search-hidden-files.test.js
@@ -18,11 +18,22 @@ const createSearchContext = async () => {
       'src/middleware/errorHandler',
       'src/services/accessManager',
       'src/services/settingsService',
+      'src/utils/pathUtils',
     ],
   });
 
   const searchRoutes = envContext.requireFresh('src/routes/search');
   const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
+  const { getDb } = envContext.requireFresh('src/services/db');
+  const db = await getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `
+    INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `
+  ).run('admin', 'admin@example.com', 1, 'admin', 'Admin', '["admin"]', now, now);
+
   const app = createTestApp({
     router: searchRoutes,
     mountPath: '/api',


### PR DESCRIPTION
Three backend suites currently fail on a clean checkout of `main` (`cd backend && npm test`):

| Suite | Failure | Cause | Fix |
|---|---|---|---|
| `tests/services/file-delete-favorites` | expects `removedFavoriteCount` from `deleteItems` | the favorites cleanup wiring was lost in a conflict resolution — `fileTransferService` never calls `removeFavoritesForDeletedPath` (this is also a **user-facing regression**: deleting a favorited folder leaves a dead favorite behind) | restore the call in `deleteItems` and report `removedFavoriteCount` |
| `tests/routes/browse-hidden-files` / `search-hidden-files` | `SqliteError: FOREIGN KEY constraint failed` in `setUserSetting('admin', …)` | the suites assume an `admin` user exists and reuse a stale `pathUtils` module cache | seed the user, fresh-require `pathUtils` |
| `tests/routes/auth` | order-dependent 400/201 mismatch | the previous suite's database handle stays open | new `closeDb()` helper in `services/db`, called from the suite |

With these changes the full backend suite passes **63/63**. No behaviour change outside the favorites-cleanup restoration.
