### PR TITLE
Add copy drag-and-drop to folders and favorites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN addgroup -S appuser && \
 #   bash            – entrypoint.sh is a bash script
 #   shadow          – provides usermod/groupmod for UID/GID remapping
 #   curl            – For terminal users
+#   rsync           – native, cancellable local copies with byte progress
 #
 # Optional (see INCLUDE_RAW / INCLUDE_VAAPI build args below):
 #   perl            – required by exiftool-vendored for RAW image previews
@@ -87,6 +88,7 @@ RUN apk add --no-cache \
       bash \
       shadow \
       curl \
+      rsync \
   && if [ "$INCLUDE_RAW" = "true" ]; then apk add --no-cache perl; fi \
   && if [ "$INCLUDE_VAAPI" = "true" ]; then apk add --no-cache libva mesa-va-gallium; fi \
   && rm -rf /tmp/* /var/cache/apk/*

--- a/backend/src/routes/files/delete.js
+++ b/backend/src/routes/files/delete.js
@@ -27,4 +27,46 @@ router.delete(
   })
 );
 
+router.post(
+  '/files/delete-stream',
+  asyncHandler(async (req, res) => {
+    const { items = [] } = req.body || {};
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    const onClose = () => {
+      if (!res.writableEnded) abort();
+    };
+    req.once('aborted', abort);
+    res.status(200);
+    res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.once('close', onClose);
+    const writeEvent = (event) => {
+      if (!res.writableEnded && !res.destroyed) res.write(`${JSON.stringify(event)}\n`);
+    };
+
+    try {
+      writeEvent({ type: 'start', totalItems: Array.isArray(items) ? items.length : 0 });
+      const results = await deleteItems(items, {
+        user: req.user,
+        guestSession: req.guestSession,
+        signal: controller.signal,
+        onProgress: (progress) => writeEvent({ type: 'progress', ...progress }),
+      });
+      writeEvent({ type: 'done', success: true, items: results });
+    } catch (error) {
+      writeEvent({
+        type: 'error',
+        message: error.message || 'Deletion failed.',
+        code: error.code || 'DELETE_FAILED',
+      });
+    } finally {
+      req.off('aborted', abort);
+      res.off('close', onClose);
+      if (!res.writableEnded) res.end();
+    }
+  })
+);
+
 module.exports = router;

--- a/backend/src/routes/files/transfer.js
+++ b/backend/src/routes/files/transfer.js
@@ -1,30 +1,59 @@
-const { transferItems } = require('../../services/fileTransferService');
+const { prepareTransfer, executeTransfer } = require('../../services/fileTransferService');
 const asyncHandler = require('../../utils/asyncHandler');
 
 const router = require('express').Router();
 
-router.post(
-  '/files/copy',
+// Copy/move stream newline-delimited JSON events so the client can render a
+// determinate progress bar:
+//   {type:'start',    totalBytes, totalItems, destination}
+//   {type:'progress', copiedBytes, totalBytes, currentName}   (throttled)
+//   {type:'done',     success, destination, items}
+//   {type:'error',    message, code}
+// Validation/authorization runs first (prepareTransfer); if it throws, no
+// streaming header has been sent yet, so asyncHandler forwards it to the error
+// middleware and the client gets a normal HTTP error response.
+const runTransfer = (operation) =>
   asyncHandler(async (req, res) => {
     const { items = [], destination = '' } = req.body || {};
-    const result = await transferItems(items, destination, 'copy', {
-      user: req.user,
-      guestSession: req.guestSession,
-    });
-    res.json({ success: true, ...result });
-  })
-);
+    const options = { user: req.user, guestSession: req.guestSession };
 
-router.post(
-  '/files/move',
-  asyncHandler(async (req, res) => {
-    const { items = [], destination = '' } = req.body || {};
-    const result = await transferItems(items, destination, 'move', {
-      user: req.user,
-      guestSession: req.guestSession,
+    const prep = await prepareTransfer(items, destination, operation, options);
+
+    res.status(200);
+    res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    // Disable proxy buffering so progress lines reach the client promptly.
+    res.setHeader('X-Accel-Buffering', 'no');
+
+    const writeEvent = (event) => {
+      if (res.writableEnded) return;
+      res.write(`${JSON.stringify(event)}\n`);
+    };
+
+    writeEvent({
+      type: 'start',
+      totalBytes: prep.totalBytes,
+      totalItems: prep.totalItems,
+      destination: prep.destinationRelative,
     });
-    res.json({ success: true, ...result });
-  })
-);
+
+    try {
+      const result = await executeTransfer(prep, operation, (progress) =>
+        writeEvent({ type: 'progress', ...progress })
+      );
+      writeEvent({ type: 'done', success: true, ...result });
+    } catch (error) {
+      writeEvent({
+        type: 'error',
+        message: error.message || 'Transfer failed.',
+        code: error.code || 'TRANSFER_FAILED',
+      });
+    } finally {
+      res.end();
+    }
+  });
+
+router.post('/files/copy', runTransfer('copy'));
+router.post('/files/move', runTransfer('move'));
 
 module.exports = router;

--- a/backend/src/services/fileTransferService.js
+++ b/backend/src/services/fileTransferService.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs/promises');
 const fsSync = require('fs');
+const { spawn } = require('child_process');
 
 const { ensureDir, pathExists } = require('../utils/fsUtils');
 const {
@@ -13,122 +14,317 @@ const { getSharesForSourceTargets, deleteSharesByIds } = require('./sharesServic
 
 // How often (ms) progress is reported to the caller while bytes stream, so a
 // large file emits a steady trickle of updates rather than one per chunk.
-const PROGRESS_THROTTLE_MS = 150;
+const PROGRESS_THROTTLE_MS = 75;
+// Node defaults file streams to 64 KiB buffers. That makes a 90 GiB transfer
+// cross JavaScript over 1.4 million times. Keep the transfer cancellable, but
+// use a bounded 4 MiB buffer to cut that overhead drastically without growing
+// memory with the size of the copy.
+const COPY_STREAM_HIGH_WATER_MARK = 4 * 1024 * 1024;
+const NATIVE_TRANSFER_ENABLED =
+  process.platform === 'linux' && process.env.FILE_TRANSFER_ENGINE !== 'stream';
+const activeNativeOperations = new Map();
+let nextNativeOperationId = 1;
 
-// Recursively sum the byte size of a file or directory subtree. Symlinks count
-// as zero (they are recreated, not byte-copied). Best-effort: entries that
-// cannot be stat()ed are skipped so a partial tree still yields a usable total.
-const computeEntrySize = async (absolutePath, isDirectory) => {
-  if (!isDirectory) {
-    try {
-      const stats = await fs.lstat(absolutePath);
-      return stats.isSymbolicLink() ? 0 : stats.size;
-    } catch (_) {
-      return 0;
-    }
-  }
-
-  let total = 0;
-  const stack = [absolutePath];
-  while (stack.length > 0) {
-    const dir = stack.pop();
-    let entries;
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch (_) {
-      continue;
-    }
-    for (const entry of entries) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        stack.push(full);
-      } else if (entry.isFile()) {
-        try {
-          // eslint-disable-next-line no-await-in-loop
-          const stats = await fs.stat(full);
-          total += stats.size;
-        } catch (_) {
-          // Unreadable entry: skip it, keep the total best-effort.
-        }
-      }
-    }
-  }
-  return total;
+const registerNativeOperation = (type, child, sourcePath, destinationPath = null) => {
+  const id = nextNativeOperationId;
+  nextNativeOperationId += 1;
+  activeNativeOperations.set(id, {
+    id,
+    type,
+    pid: child?.pid || null,
+    sourceName: path.basename(sourcePath),
+    ...(destinationPath ? { destinationName: path.basename(destinationPath) } : {}),
+    startedAt: Date.now(),
+  });
+  return id;
 };
+
+const unregisterNativeOperation = (id) => {
+  if (id != null) activeNativeOperations.delete(id);
+};
+
+const getDiagnosticsSnapshot = () => {
+  const now = Date.now();
+  return {
+    nativeTransferEnabled: NATIVE_TRANSFER_ENABLED,
+    activeNativeOperations: Array.from(activeNativeOperations.values())
+      .map((operation) => ({ ...operation, ageMs: now - operation.startedAt }))
+      .sort((a, b) => b.ageMs - a.ageMs)
+      .slice(0, 5),
+  };
+};
+
+const createCancellationError = () => {
+  const error = new Error('Operation cancelled.');
+  error.code = 'OPERATION_CANCELLED';
+  return error;
+};
+
+const throwIfCancelled = (signal) => {
+  if (signal?.aborted) throw createCancellationError();
+};
+
+const parseRsyncProgress = (line) => {
+  const match = line.match(/^\s*([\d,]+)\s+(\d+)%/);
+  if (!match) return null;
+  return {
+    copiedBytes: Number(match[1].replaceAll(',', '')) || 0,
+    percent: Math.min(100, Number(match[2]) || 0),
+  };
+};
+
+const stopChildProcessGroup = (child, signal) => {
+  if (!child?.pid) return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch (_) {
+    child.kill(signal);
+  }
+};
+
+// rsync keeps file transfer outside the Node event loop while retaining three
+// properties the UI needs: safe argv handling, global progress, and immediate
+// cancellation. It is used only in the Linux container; local development and
+// the explicit FILE_TRANSFER_ENGINE=stream override keep the JS fallback.
+const copyWithNativeRsync = (sourcePath, destinationPath, onProgress, signal) =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createCancellationError());
+      return;
+    }
+
+    const child = spawn(
+      'rsync',
+      [
+        '-a',
+        '--no-owner',
+        '--no-group',
+        '--info=progress2',
+        '--outbuf=L',
+        '--out-format=%n',
+        '--',
+        sourcePath,
+        destinationPath,
+      ],
+      {
+        detached: true,
+        env: { ...process.env, LC_ALL: 'C' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+    const operationId = registerNativeOperation('rsync', child, sourcePath, destinationPath);
+    let output = '';
+    let errorOutput = '';
+    let settled = false;
+    let killTimer = null;
+    const cleanup = () => {
+      signal?.removeEventListener('abort', abort);
+      if (killTimer) clearTimeout(killTimer);
+      unregisterNativeOperation(operationId);
+    };
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+    const emitOutput = (chunk) => {
+      output += chunk.toString();
+      const lines = output.split(/[\r\n]/);
+      output = lines.pop() || '';
+      for (const line of lines) {
+        const progress = parseRsyncProgress(line);
+        if (progress) onProgress?.(progress);
+      }
+    };
+    const abort = () => {
+      stopChildProcessGroup(child, 'SIGTERM');
+      killTimer = setTimeout(() => stopChildProcessGroup(child, 'SIGKILL'), 3000);
+    };
+
+    child.stdout.on('data', emitOutput);
+    child.stderr.on('data', (chunk) => {
+      errorOutput += chunk.toString();
+    });
+    child.once('error', (error) => finish(reject, error));
+    child.once('close', (code) => {
+      if (signal?.aborted) return finish(reject, createCancellationError());
+      if (code === 0) return finish(resolve);
+      const error = new Error(errorOutput.trim() || `Native copy failed with exit code ${code}.`);
+      error.code = 'NATIVE_COPY_FAILED';
+      return finish(reject, error);
+    });
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+
+const removeWithNativeRm = (absolutePath, signal) =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) return reject(createCancellationError());
+    const child = spawn('rm', ['-rf', '--', absolutePath], { detached: true, stdio: 'ignore' });
+    const operationId = registerNativeOperation('rm', child, absolutePath);
+    let settled = false;
+    let killTimer = null;
+    const cleanup = () => {
+      signal?.removeEventListener('abort', abort);
+      if (killTimer) clearTimeout(killTimer);
+      unregisterNativeOperation(operationId);
+    };
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+    const abort = () => {
+      stopChildProcessGroup(child, 'SIGTERM');
+      killTimer = setTimeout(() => stopChildProcessGroup(child, 'SIGKILL'), 3000);
+    };
+    child.once('error', (error) => finish(reject, error));
+    child.once('close', (code) => {
+      if (signal?.aborted) return finish(reject, createCancellationError());
+      if (code === 0) return finish(resolve);
+      const error = new Error(`Native deletion failed with exit code ${code}.`);
+      error.code = 'NATIVE_DELETE_FAILED';
+      return finish(reject, error);
+    });
+    signal?.addEventListener('abort', abort, { once: true });
+  });
 
 // Copy a single regular file through streams so bytes can be reported as they
 // are written. The source mode is applied at creation to mirror fs.copyFile.
-const copyFileWithProgress = (sourcePath, destinationPath, mode, onBytes) =>
+const copyFileWithProgress = (sourcePath, destinationPath, mode, onBytes, signal) =>
   new Promise((resolve, reject) => {
-    const readStream = fsSync.createReadStream(sourcePath);
+    if (signal?.aborted) {
+      reject(createCancellationError());
+      return;
+    }
+
+    const readStream = fsSync.createReadStream(sourcePath, {
+      highWaterMark: COPY_STREAM_HIGH_WATER_MARK,
+    });
     const writeStream = fsSync.createWriteStream(
       destinationPath,
-      mode != null ? { mode } : undefined
+      mode != null
+        ? { mode, highWaterMark: COPY_STREAM_HIGH_WATER_MARK }
+        : { highWaterMark: COPY_STREAM_HIGH_WATER_MARK }
     );
 
+    let settled = false;
+    const cleanup = () => signal?.removeEventListener('abort', abort);
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback(value);
+    };
     const fail = (error) => {
       readStream.destroy();
       writeStream.destroy();
-      reject(error);
+      finish(reject, error);
     };
+    const abort = () => fail(createCancellationError());
 
     readStream.on('error', fail);
     writeStream.on('error', fail);
     if (typeof onBytes === 'function') {
       readStream.on('data', (chunk) => onBytes(chunk.length));
     }
-    writeStream.on('finish', resolve);
+    writeStream.on('finish', () => finish(resolve));
+    signal?.addEventListener('abort', abort, { once: true });
     readStream.pipe(writeStream);
   });
 
-// Recursively copy a file/dir, reporting copied bytes. Symlinks are recreated.
-const copyEntryWithProgress = async (sourcePath, destinationPath, isDirectory, onBytes) => {
+// Recursively copy a file/dir, reporting copied bytes. It returns the actual
+// copied byte count, so folder-size updates never need a second filesystem walk.
+const copyEntryWithProgress = async (sourcePath, destinationPath, isDirectory, onBytes, signal) => {
+  throwIfCancelled(signal);
+  if (NATIVE_TRANSFER_ENABLED) {
+    const stats = await fs.lstat(sourcePath);
+    if (stats.isDirectory()) {
+      // Keep the target name chosen by findAvailableName. rsync copies the
+      // directory itself when the source lacks a trailing slash; the explorer
+      // contract is to copy its contents into the target directory instead.
+      await ensureDir(destinationPath);
+      await copyWithNativeRsync(
+        `${sourcePath}${path.sep}`,
+        `${destinationPath}${path.sep}`,
+        onBytes,
+        signal
+      );
+    } else {
+      await copyWithNativeRsync(sourcePath, destinationPath, onBytes, signal);
+    }
+    return stats.isDirectory() ? null : stats.size;
+  }
   if (!isDirectory) {
     const stats = await fs.lstat(sourcePath);
     if (stats.isSymbolicLink()) {
       const linkTarget = await fs.readlink(sourcePath);
       await fs.symlink(linkTarget, destinationPath);
-      return;
+      return 0;
     }
-    await copyFileWithProgress(sourcePath, destinationPath, stats.mode, onBytes);
-    return;
+    await copyFileWithProgress(sourcePath, destinationPath, stats.mode, onBytes, signal);
+    return stats.size;
   }
 
   await ensureDir(destinationPath);
   const entries = await fs.readdir(sourcePath, { withFileTypes: true });
+  let copiedBytes = 0;
   for (const entry of entries) {
+    throwIfCancelled(signal);
     const src = path.join(sourcePath, entry.name);
     const dest = path.join(destinationPath, entry.name);
     // eslint-disable-next-line no-await-in-loop
-    await copyEntryWithProgress(src, dest, entry.isDirectory(), onBytes);
+    copiedBytes += await copyEntryWithProgress(src, dest, entry.isDirectory(), onBytes, signal);
   }
+  return copiedBytes;
 };
 
 // Move an entry, reporting progress. A same-filesystem rename is atomic and
 // instant, so the entry's whole size is reported at once; a cross-device move
 // (EXDEV) falls back to a byte-tracked copy followed by removal of the source.
-const moveEntryWithProgress = async (sourcePath, destinationPath, isDirectory, size, onBytes) => {
+const moveEntryWithProgress = async (
+  sourcePath,
+  destinationPath,
+  isDirectory,
+  size,
+  onBytes,
+  signal
+) => {
+  throwIfCancelled(signal);
   try {
     await fs.rename(sourcePath, destinationPath);
     if (typeof onBytes === 'function' && size > 0) {
       onBytes(size);
     }
+    return size;
   } catch (error) {
     if (error.code === 'EXDEV') {
-      await copyEntryWithProgress(sourcePath, destinationPath, isDirectory, onBytes);
-      await fs.rm(sourcePath, { recursive: isDirectory, force: true });
+      const copiedBytes = await copyEntryWithProgress(
+        sourcePath,
+        destinationPath,
+        isDirectory,
+        onBytes,
+        signal
+      );
+      throwIfCancelled(signal);
+      if (NATIVE_TRANSFER_ENABLED) await removeWithNativeRm(sourcePath, signal);
+      else await fs.rm(sourcePath, { recursive: isDirectory, force: true });
+      return copiedBytes;
     } else {
       throw error;
     }
   }
 };
 
-// Phase 1: authorize + resolve every item, stat it, and pre-compute the total
-// byte count so the client can render a determinate progress bar. Throws on any
-// validation/authorization failure — the route runs this BEFORE it commits to a
-// streaming response, so these surface as a normal HTTP error (status + code).
+// Phase 1: authorize + resolve every item. Recursive directory-size walks are
+// deliberately avoided here: a large copy used to read every source file once
+// for progress, then read it all again to copy. Indexed directory sizes give a
+// determinate bar in O(1); otherwise the UI uses its indeterminate state while
+// the copy starts immediately.
 const prepareTransfer = async (items, destination, operation, options = {}) => {
+  const { signal } = options;
+  throwIfCancelled(signal);
   if (!Array.isArray(items) || items.length === 0) {
     throw new Error('At least one item is required.');
   }
@@ -160,8 +356,10 @@ const prepareTransfer = async (items, destination, operation, options = {}) => {
 
   const plans = [];
   let totalBytes = 0;
+  let hasUnknownSize = false;
 
   for (const item of items) {
+    throwIfCancelled(signal);
     const sourceCombined = combineRelativePath(item.path || '', item.name);
     const {
       allowed: srcAllowed,
@@ -194,14 +392,24 @@ const prepareTransfer = async (items, destination, operation, options = {}) => {
     const isDirectory = stats.isDirectory();
     const sourceParent = normalizeRelativePath(path.dirname(sourceRelative));
 
+    if (
+      isDirectory &&
+      (destinationAbsolute === sourceAbsolute ||
+        destinationAbsolute.startsWith(`${sourceAbsolute}${path.sep}`))
+    ) {
+      throw new Error('Cannot copy or move a folder into itself.');
+    }
+
     if (operation === 'move' && destinationRelative === sourceParent) {
       plans.push({ sourceRelative, skipped: true });
       continue;
     }
 
-    // eslint-disable-next-line no-await-in-loop
-    const size = await computeEntrySize(sourceAbsolute, isDirectory);
-    totalBytes += size;
+    // Avoid walking a directory before copying it: rsync can start immediately
+    // and reports its own progress. Directory transfers stay indeterminate.
+    const size = isDirectory ? null : stats.size;
+    if (Number.isFinite(size)) totalBytes += size;
+    else hasUnknownSize = true;
 
     plans.push({
       sourceAbsolute,
@@ -216,7 +424,7 @@ const prepareTransfer = async (items, destination, operation, options = {}) => {
     destinationRelative,
     destinationAbsolute,
     plans,
-    totalBytes,
+    totalBytes: hasUnknownSize ? 0 : totalBytes,
     totalItems: plans.filter((plan) => !plan.skipped).length,
   };
 };
@@ -224,72 +432,123 @@ const prepareTransfer = async (items, destination, operation, options = {}) => {
 // Phase 2: perform the copy/move for each prepared plan, reporting progress via
 // onProgress({ copiedBytes, totalBytes, currentName }). Runs after the response
 // has switched to streaming mode, so an error here is surfaced in the stream.
-const executeTransfer = async (prep, operation, onProgress) => {
+const executeTransfer = async (prep, operation, onProgress, options = {}) => {
   const { destinationRelative, destinationAbsolute, plans, totalBytes } = prep;
+  const { signal } = options;
 
+  throwIfCancelled(signal);
   await ensureDir(destinationAbsolute);
 
   const results = [];
   let copiedBytes = 0;
   let lastEmit = 0;
   let currentName = '';
+  let nativePercent = null;
+  let activeTarget = null;
 
   const emit = (force = false) => {
     if (typeof onProgress !== 'function') return;
     const now = Date.now();
     if (!force && now - lastEmit < PROGRESS_THROTTLE_MS) return;
     lastEmit = now;
-    onProgress({ copiedBytes, totalBytes, currentName });
+    onProgress({
+      copiedBytes,
+      totalBytes,
+      currentName,
+      ...(nativePercent != null ? { percent: nativePercent } : {}),
+    });
   };
 
   const onBytes = (delta) => {
+    const wasAtStart = copiedBytes === 0;
     copiedBytes += delta;
-    emit(false);
+    // Show the first byte immediately, then throttle the steady stream of
+    // updates. Besides making the UI feel responsive, this lets an operation
+    // become cancellable as soon as data starts moving.
+    emit(wasAtStart);
   };
 
-  for (const plan of plans) {
-    if (plan.skipped) {
-      results.push({ from: plan.sourceRelative, to: plan.sourceRelative, skipped: true });
-      continue;
+  try {
+    for (const plan of plans) {
+      throwIfCancelled(signal);
+      if (plan.skipped) {
+        results.push({ from: plan.sourceRelative, to: plan.sourceRelative, skipped: true });
+        continue;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const availableName = await findAvailableName(destinationAbsolute, plan.desiredName);
+      const targetAbsolute = path.join(destinationAbsolute, availableName);
+      const targetRelative = combineRelativePath(destinationRelative, availableName);
+      activeTarget = { absolutePath: targetAbsolute, isDirectory: plan.isDirectory };
+      currentName = availableName;
+      nativePercent = null;
+      emit(true);
+
+      const copiedBeforePlan = copiedBytes;
+      const onCopyProgress = (progress) => {
+        if (typeof progress === 'number') {
+          onBytes(progress);
+          return;
+        }
+        nativePercent = Number.isFinite(progress?.percent) ? progress.percent : null;
+        if (Number.isFinite(plan.size) && nativePercent != null) {
+          copiedBytes = copiedBeforePlan + (plan.size * nativePercent) / 100;
+        }
+        emit(true);
+      };
+
+      if (operation === 'copy') {
+        // eslint-disable-next-line no-await-in-loop
+        await copyEntryWithProgress(
+          plan.sourceAbsolute,
+          targetAbsolute,
+          plan.isDirectory,
+          onCopyProgress,
+          signal
+        );
+      } else if (operation === 'move') {
+        // eslint-disable-next-line no-await-in-loop
+        await moveEntryWithProgress(
+          plan.sourceAbsolute,
+          targetAbsolute,
+          plan.isDirectory,
+          plan.size,
+          onCopyProgress,
+          signal
+        );
+      } else {
+        throw new Error(`Unsupported operation: ${operation}`);
+      }
+
+      results.push({ from: plan.sourceRelative, to: targetRelative });
+      activeTarget = null;
     }
 
-    // eslint-disable-next-line no-await-in-loop
-    const availableName = await findAvailableName(destinationAbsolute, plan.desiredName);
-    const targetAbsolute = path.join(destinationAbsolute, availableName);
-    const targetRelative = combineRelativePath(destinationRelative, availableName);
-    currentName = availableName;
+    // Snap to 100% once every entry is done when the total was known before
+    // starting. Unknown directory totals intentionally stay indeterminate.
+    if (totalBytes > 0) copiedBytes = totalBytes;
     emit(true);
 
-    if (operation === 'copy') {
-      // eslint-disable-next-line no-await-in-loop
-      await copyEntryWithProgress(plan.sourceAbsolute, targetAbsolute, plan.isDirectory, onBytes);
-    } else if (operation === 'move') {
-      // eslint-disable-next-line no-await-in-loop
-      await moveEntryWithProgress(
-        plan.sourceAbsolute,
-        targetAbsolute,
-        plan.isDirectory,
-        plan.size,
-        onBytes
-      );
-    } else {
-      throw new Error(`Unsupported operation: ${operation}`);
+    return { destination: destinationRelative, items: results };
+  } catch (error) {
+    // A cancellation can interrupt a recursive copy part-way through an entry.
+    // Remove only that incomplete destination; already completed entries remain
+    // intact, which is the least surprising and safest cancellation semantics.
+    if (error?.code === 'OPERATION_CANCELLED' && activeTarget) {
+      await fs.rm(activeTarget.absolutePath, {
+        recursive: activeTarget.isDirectory,
+        force: true,
+      });
     }
-
-    results.push({ from: plan.sourceRelative, to: targetRelative });
+    throw error;
   }
-
-  // Snap to 100% once every entry is done (covers rounding and any skipped work).
-  copiedBytes = totalBytes;
-  emit(true);
-
-  return { destination: destinationRelative, items: results };
 };
 
 // One-shot API preserved for callers that do not need progress reporting.
 const transferItems = async (items, destination, operation, options = {}) => {
   const prep = await prepareTransfer(items, destination, operation, options);
-  return executeTransfer(prep, operation, options.onProgress);
+  return executeTransfer(prep, operation, options.onProgress, { signal: options.signal });
 };
 
 const getShareSourceTarget = (resolved, includeChildren = false) => {
@@ -374,7 +633,9 @@ const deleteItems = async (items = [], options = {}) => {
   };
   const targets = await resolveDeleteTargets(items, context);
 
+  let completedItems = 0;
   for (const target of targets) {
+    throwIfCancelled(options.signal);
     const { relativePath, absolutePath, exists, stats, isDirectory, shareSourceTarget } = target;
     const affectedShares = shareSourceTarget
       ? await getSharesForSourceTargets([shareSourceTarget])
@@ -386,15 +647,37 @@ const deleteItems = async (items = [], options = {}) => {
       if (deletedShareCount > 0) {
         results[results.length - 1].deletedShareCount = deletedShareCount;
       }
+      completedItems += 1;
+      options.onProgress?.({
+        completedItems,
+        totalItems: targets.length,
+        currentName: target.item?.name || relativePath,
+        percent: Math.round((completedItems / targets.length) * 100),
+      });
       continue;
     }
 
-    await fs.rm(absolutePath, { recursive: isDirectory || stats.isDirectory(), force: true });
+    const deletedEntryStats = stats || (await fs.stat(absolutePath));
+    if (NATIVE_TRANSFER_ENABLED) {
+      await removeWithNativeRm(absolutePath, options.signal);
+    } else {
+      await fs.rm(absolutePath, {
+        recursive: isDirectory || deletedEntryStats.isDirectory(),
+        force: true,
+      });
+    }
     const deletedShareCount = await deleteSharesByIds(affectedShares.map((share) => share.id));
     results.push({
       path: relativePath,
       status: 'deleted',
       ...(deletedShareCount > 0 ? { deletedShareCount } : {}),
+    });
+    completedItems += 1;
+    options.onProgress?.({
+      completedItems,
+      totalItems: targets.length,
+      currentName: target.item?.name || relativePath,
+      percent: Math.round((completedItems / targets.length) * 100),
     });
   }
 
@@ -404,7 +687,9 @@ const deleteItems = async (items = [], options = {}) => {
 module.exports = {
   prepareTransfer,
   executeTransfer,
+  createCancellationError,
   transferItems,
   getDeleteImpact,
   deleteItems,
+  getDiagnosticsSnapshot,
 };

--- a/backend/src/services/fileTransferService.js
+++ b/backend/src/services/fileTransferService.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs/promises');
+const fsSync = require('fs');
 
 const { ensureDir, pathExists } = require('../utils/fsUtils');
 const {
@@ -10,35 +11,112 @@ const {
 const { ACTIONS, authorizeAndResolve, authorizePath } = require('./authorizationService');
 const { getSharesForSourceTargets, deleteSharesByIds } = require('./sharesService');
 
-const copyEntry = async (sourcePath, destinationPath, isDirectory) => {
-  if (isDirectory) {
-    if (typeof fs.cp === 'function') {
-      await fs.cp(sourcePath, destinationPath, {
-        recursive: true,
-        force: false,
-        errorOnExist: true,
-      });
-    } else {
-      await ensureDir(destinationPath);
-      const entries = await fs.readdir(sourcePath, { withFileTypes: true });
-      for (const entry of entries) {
-        const src = path.join(sourcePath, entry.name);
-        const dest = path.join(destinationPath, entry.name);
-        // eslint-disable-next-line no-await-in-loop
-        await copyEntry(src, dest, entry.isDirectory());
+// How often (ms) progress is reported to the caller while bytes stream, so a
+// large file emits a steady trickle of updates rather than one per chunk.
+const PROGRESS_THROTTLE_MS = 150;
+
+// Recursively sum the byte size of a file or directory subtree. Symlinks count
+// as zero (they are recreated, not byte-copied). Best-effort: entries that
+// cannot be stat()ed are skipped so a partial tree still yields a usable total.
+const computeEntrySize = async (absolutePath, isDirectory) => {
+  if (!isDirectory) {
+    try {
+      const stats = await fs.lstat(absolutePath);
+      return stats.isSymbolicLink() ? 0 : stats.size;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  let total = 0;
+  const stack = [absolutePath];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch (_) {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.isFile()) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const stats = await fs.stat(full);
+          total += stats.size;
+        } catch (_) {
+          // Unreadable entry: skip it, keep the total best-effort.
+        }
       }
     }
-  } else {
-    await fs.copyFile(sourcePath, destinationPath);
+  }
+  return total;
+};
+
+// Copy a single regular file through streams so bytes can be reported as they
+// are written. The source mode is applied at creation to mirror fs.copyFile.
+const copyFileWithProgress = (sourcePath, destinationPath, mode, onBytes) =>
+  new Promise((resolve, reject) => {
+    const readStream = fsSync.createReadStream(sourcePath);
+    const writeStream = fsSync.createWriteStream(
+      destinationPath,
+      mode != null ? { mode } : undefined
+    );
+
+    const fail = (error) => {
+      readStream.destroy();
+      writeStream.destroy();
+      reject(error);
+    };
+
+    readStream.on('error', fail);
+    writeStream.on('error', fail);
+    if (typeof onBytes === 'function') {
+      readStream.on('data', (chunk) => onBytes(chunk.length));
+    }
+    writeStream.on('finish', resolve);
+    readStream.pipe(writeStream);
+  });
+
+// Recursively copy a file/dir, reporting copied bytes. Symlinks are recreated.
+const copyEntryWithProgress = async (sourcePath, destinationPath, isDirectory, onBytes) => {
+  if (!isDirectory) {
+    const stats = await fs.lstat(sourcePath);
+    if (stats.isSymbolicLink()) {
+      const linkTarget = await fs.readlink(sourcePath);
+      await fs.symlink(linkTarget, destinationPath);
+      return;
+    }
+    await copyFileWithProgress(sourcePath, destinationPath, stats.mode, onBytes);
+    return;
+  }
+
+  await ensureDir(destinationPath);
+  const entries = await fs.readdir(sourcePath, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = path.join(sourcePath, entry.name);
+    const dest = path.join(destinationPath, entry.name);
+    // eslint-disable-next-line no-await-in-loop
+    await copyEntryWithProgress(src, dest, entry.isDirectory(), onBytes);
   }
 };
 
-const moveEntry = async (sourcePath, destinationPath, isDirectory) => {
+// Move an entry, reporting progress. A same-filesystem rename is atomic and
+// instant, so the entry's whole size is reported at once; a cross-device move
+// (EXDEV) falls back to a byte-tracked copy followed by removal of the source.
+const moveEntryWithProgress = async (sourcePath, destinationPath, isDirectory, size, onBytes) => {
   try {
     await fs.rename(sourcePath, destinationPath);
+    if (typeof onBytes === 'function' && size > 0) {
+      onBytes(size);
+    }
   } catch (error) {
     if (error.code === 'EXDEV') {
-      await copyEntry(sourcePath, destinationPath, isDirectory);
+      await copyEntryWithProgress(sourcePath, destinationPath, isDirectory, onBytes);
       await fs.rm(sourcePath, { recursive: isDirectory, force: true });
     } else {
       throw error;
@@ -46,7 +124,11 @@ const moveEntry = async (sourcePath, destinationPath, isDirectory) => {
   }
 };
 
-const transferItems = async (items, destination, operation, options = {}) => {
+// Phase 1: authorize + resolve every item, stat it, and pre-compute the total
+// byte count so the client can render a determinate progress bar. Throws on any
+// validation/authorization failure — the route runs this BEFORE it commits to a
+// streaming response, so these surface as a normal HTTP error (status + code).
+const prepareTransfer = async (items, destination, operation, options = {}) => {
   if (!Array.isArray(items) || items.length === 0) {
     throw new Error('At least one item is required.');
   }
@@ -76,9 +158,8 @@ const transferItems = async (items, destination, operation, options = {}) => {
 
   const { absolutePath: destinationAbsolute } = destResolved;
 
-  await ensureDir(destinationAbsolute);
-
-  const results = [];
+  const plans = [];
+  let totalBytes = 0;
 
   for (const item of items) {
     const sourceCombined = combineRelativePath(item.path || '', item.name);
@@ -86,6 +167,7 @@ const transferItems = async (items, destination, operation, options = {}) => {
       allowed: srcAllowed,
       accessInfo: srcAccess,
       resolved: srcResolved,
+      // eslint-disable-next-line no-await-in-loop
     } = await authorizeAndResolve(context, sourceCombined, ACTIONS.read);
     if (!srcAllowed || !srcResolved) {
       throw new Error(srcAccess?.denialReason || `Source path not accessible: ${sourceCombined}`);
@@ -93,46 +175,121 @@ const transferItems = async (items, destination, operation, options = {}) => {
 
     const { relativePath: sourceRelative, absolutePath: sourceAbsolute } = srcResolved;
 
+    // eslint-disable-next-line no-await-in-loop
     if (!(await pathExists(sourceAbsolute))) {
       throw new Error(`Source path not found: ${sourceRelative}`);
     }
 
     if (operation === 'move') {
-      const { allowed: deleteAllowed, accessInfo: deleteAccess } = await authorizePath(
-        context,
-        sourceCombined,
-        ACTIONS.delete
-      );
+      const { allowed: deleteAllowed, accessInfo: deleteAccess } =
+        // eslint-disable-next-line no-await-in-loop
+        await authorizePath(context, sourceCombined, ACTIONS.delete);
       if (!deleteAllowed) {
         throw new Error(deleteAccess?.denialReason || 'Cannot move items from this path.');
       }
     }
 
+    // eslint-disable-next-line no-await-in-loop
     const stats = await fs.stat(sourceAbsolute);
+    const isDirectory = stats.isDirectory();
     const sourceParent = normalizeRelativePath(path.dirname(sourceRelative));
 
     if (operation === 'move' && destinationRelative === sourceParent) {
-      results.push({ from: sourceRelative, to: sourceRelative, skipped: true });
+      plans.push({ sourceRelative, skipped: true });
       continue;
     }
 
-    const desiredName = item.newName || item.name;
-    const availableName = await findAvailableName(destinationAbsolute, desiredName);
+    // eslint-disable-next-line no-await-in-loop
+    const size = await computeEntrySize(sourceAbsolute, isDirectory);
+    totalBytes += size;
+
+    plans.push({
+      sourceAbsolute,
+      sourceRelative,
+      isDirectory,
+      size,
+      desiredName: item.newName || item.name,
+    });
+  }
+
+  return {
+    destinationRelative,
+    destinationAbsolute,
+    plans,
+    totalBytes,
+    totalItems: plans.filter((plan) => !plan.skipped).length,
+  };
+};
+
+// Phase 2: perform the copy/move for each prepared plan, reporting progress via
+// onProgress({ copiedBytes, totalBytes, currentName }). Runs after the response
+// has switched to streaming mode, so an error here is surfaced in the stream.
+const executeTransfer = async (prep, operation, onProgress) => {
+  const { destinationRelative, destinationAbsolute, plans, totalBytes } = prep;
+
+  await ensureDir(destinationAbsolute);
+
+  const results = [];
+  let copiedBytes = 0;
+  let lastEmit = 0;
+  let currentName = '';
+
+  const emit = (force = false) => {
+    if (typeof onProgress !== 'function') return;
+    const now = Date.now();
+    if (!force && now - lastEmit < PROGRESS_THROTTLE_MS) return;
+    lastEmit = now;
+    onProgress({ copiedBytes, totalBytes, currentName });
+  };
+
+  const onBytes = (delta) => {
+    copiedBytes += delta;
+    emit(false);
+  };
+
+  for (const plan of plans) {
+    if (plan.skipped) {
+      results.push({ from: plan.sourceRelative, to: plan.sourceRelative, skipped: true });
+      continue;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const availableName = await findAvailableName(destinationAbsolute, plan.desiredName);
     const targetAbsolute = path.join(destinationAbsolute, availableName);
     const targetRelative = combineRelativePath(destinationRelative, availableName);
+    currentName = availableName;
+    emit(true);
 
     if (operation === 'copy') {
-      await copyEntry(sourceAbsolute, targetAbsolute, stats.isDirectory());
+      // eslint-disable-next-line no-await-in-loop
+      await copyEntryWithProgress(plan.sourceAbsolute, targetAbsolute, plan.isDirectory, onBytes);
     } else if (operation === 'move') {
-      await moveEntry(sourceAbsolute, targetAbsolute, stats.isDirectory());
+      // eslint-disable-next-line no-await-in-loop
+      await moveEntryWithProgress(
+        plan.sourceAbsolute,
+        targetAbsolute,
+        plan.isDirectory,
+        plan.size,
+        onBytes
+      );
     } else {
       throw new Error(`Unsupported operation: ${operation}`);
     }
 
-    results.push({ from: sourceRelative, to: targetRelative });
+    results.push({ from: plan.sourceRelative, to: targetRelative });
   }
 
+  // Snap to 100% once every entry is done (covers rounding and any skipped work).
+  copiedBytes = totalBytes;
+  emit(true);
+
   return { destination: destinationRelative, items: results };
+};
+
+// One-shot API preserved for callers that do not need progress reporting.
+const transferItems = async (items, destination, operation, options = {}) => {
+  const prep = await prepareTransfer(items, destination, operation, options);
+  return executeTransfer(prep, operation, options.onProgress);
 };
 
 const getShareSourceTarget = (resolved, includeChildren = false) => {
@@ -245,6 +402,8 @@ const deleteItems = async (items = [], options = {}) => {
 };
 
 module.exports = {
+  prepareTransfer,
+  executeTransfer,
   transferItems,
   getDeleteImpact,
   deleteItems,

--- a/backend/tests/services/file-transfer-cancel.test.js
+++ b/backend/tests/services/file-transfer-cancel.test.js
@@ -1,0 +1,61 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+let envContext;
+
+beforeAll(async () => {
+  envContext = await setupTestEnv({
+    tag: 'file-transfer-cancel-test-',
+    modules: ['src/services/fileTransferService'],
+  });
+});
+
+afterAll(async () => {
+  await envContext.cleanup();
+});
+
+describe('Transfer cancellation', () => {
+  it('removes the partial target and keeps the source when a copy is cancelled', async () => {
+    const { executeTransfer } = envContext.requireFresh('src/services/fileTransferService');
+    const sourceDir = path.join(envContext.tmpRoot, 'source');
+    const destinationDir = path.join(envContext.tmpRoot, 'destination');
+    const sourcePath = path.join(sourceDir, 'large.bin');
+    const destinationPath = path.join(destinationDir, 'large.bin');
+
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(sourcePath, Buffer.alloc(4 * 1024 * 1024, 7));
+    await fs.mkdir(destinationDir, { recursive: true });
+
+    const controller = new AbortController();
+    const prep = {
+      destinationRelative: 'destination',
+      destinationAbsolute: destinationDir,
+      totalBytes: 4 * 1024 * 1024,
+      plans: [
+        {
+          sourceAbsolute: sourcePath,
+          sourceRelative: 'source/large.bin',
+          isDirectory: false,
+          size: 4 * 1024 * 1024,
+          desiredName: 'large.bin',
+        },
+      ],
+    };
+
+    await expect(
+      executeTransfer(
+        prep,
+        'copy',
+        ({ copiedBytes }) => {
+          if (copiedBytes > 0) controller.abort();
+        },
+        { signal: controller.signal }
+      )
+    ).rejects.toMatchObject({ code: 'OPERATION_CANCELLED' });
+
+    await expect(fs.stat(sourcePath)).resolves.toMatchObject({ size: 4 * 1024 * 1024 });
+    await expect(fs.stat(destinationPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -1,4 +1,4 @@
-import { requestJson, requestRaw, normalizePath, encodePath, buildUrl } from './http';
+import { requestJson, requestRaw, requestStream, normalizePath, encodePath, buildUrl } from './http';
 
 const DELETE_BATCH_SIZE = 100;
 
@@ -19,17 +19,19 @@ async function getUsage(path = '') {
   return requestJson(`/api/usage/${encodedPath}`, { method: 'GET' });
 }
 
-async function copyItems(items, destination) {
-  return requestJson('/api/files/copy', {
+async function copyItems(items, destination, options = {}) {
+  return requestStream('/api/files/copy', {
     method: 'POST',
     body: JSON.stringify({ items, destination }),
+    onEvent: options.onEvent,
   });
 }
 
-async function moveItems(items, destination) {
-  return requestJson('/api/files/move', {
+async function moveItems(items, destination, options = {}) {
+  return requestStream('/api/files/move', {
     method: 'POST',
     body: JSON.stringify({ items, destination }),
+    onEvent: options.onEvent,
   });
 }
 

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -1,4 +1,11 @@
-import { requestJson, requestRaw, requestStream, normalizePath, encodePath, buildUrl } from './http';
+import {
+  requestJson,
+  requestRaw,
+  requestStream,
+  normalizePath,
+  encodePath,
+  buildUrl,
+} from './http';
 
 const DELETE_BATCH_SIZE = 100;
 
@@ -24,6 +31,7 @@ async function copyItems(items, destination, options = {}) {
     method: 'POST',
     body: JSON.stringify({ items, destination }),
     onEvent: options.onEvent,
+    signal: options.signal,
   });
 }
 
@@ -32,6 +40,7 @@ async function moveItems(items, destination, options = {}) {
     method: 'POST',
     body: JSON.stringify({ items, destination }),
     onEvent: options.onEvent,
+    signal: options.signal,
   });
 }
 
@@ -56,6 +65,15 @@ async function deleteItems(items) {
   }
 
   return { success: true, items: deletedItems };
+}
+
+async function deleteItemsStream(items, options = {}) {
+  return requestStream('/api/files/delete-stream', {
+    method: 'POST',
+    body: JSON.stringify({ items: Array.isArray(items) ? items : [] }),
+    onEvent: options.onEvent,
+    signal: options.signal,
+  });
 }
 
 async function getDeleteImpact(items) {
@@ -264,6 +282,7 @@ export {
   copyItems,
   moveItems,
   deleteItems,
+  deleteItemsStream,
   getDeleteImpact,
   createFolder,
   renameItem,

--- a/frontend/src/api/http.js
+++ b/frontend/src/api/http.js
@@ -100,4 +100,82 @@ const requestJson = async (endpoint, options = {}) => {
   return response.json();
 };
 
-export { apiBase, buildUrl, encodePath, normalizePath, requestJson, requestRaw };
+// Consume a newline-delimited JSON (NDJSON) response, invoking `onEvent` for
+// each streamed event and resolving with the final `{type:'done', ...}` payload.
+// A `{type:'error', ...}` line is turned into a thrown Error routed through the
+// global error handler, matching requestJson's behaviour. Pre-flight failures
+// (non-2xx) are still handled by requestRaw before streaming begins.
+const requestStream = async (endpoint, { onEvent, ...options } = {}) => {
+  const response = await requestRaw(endpoint, options);
+
+  const reader = response.body?.getReader?.();
+  if (!reader) {
+    // No readable stream available: fall back to a single JSON parse.
+    return response.json().catch(() => null);
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let result = null;
+  let streamError = null;
+
+  const handleLine = (rawLine) => {
+    const line = rawLine.trim();
+    if (!line) return;
+
+    let event;
+    try {
+      event = JSON.parse(line);
+    } catch (_) {
+      return;
+    }
+
+    if (event.type === 'error') {
+      streamError = event;
+    } else if (event.type === 'done') {
+      result = event;
+    } else if (typeof onEvent === 'function') {
+      onEvent(event);
+    }
+  };
+
+  for (;;) {
+    // eslint-disable-next-line no-await-in-loop
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let newlineIndex;
+    while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+      handleLine(buffer.slice(0, newlineIndex));
+      buffer = buffer.slice(newlineIndex + 1);
+    }
+  }
+  buffer += decoder.decode();
+  handleLine(buffer);
+
+  if (streamError) {
+    const errorInfo = {
+      statusCode: streamError.statusCode || 500,
+      message: streamError.message || 'Request failed',
+      code: streamError.code,
+    };
+    const translatedMessage = options.suppressErrorHandler
+      ? errorInfo.message
+      : errorHandler?.(errorInfo) || errorInfo.message;
+    const error = new Error(translatedMessage);
+    if (streamError.code) error.code = streamError.code;
+    throw error;
+  }
+
+  return result;
+};
+
+export {
+  apiBase,
+  buildUrl,
+  encodePath,
+  normalizePath,
+  requestJson,
+  requestRaw,
+  requestStream,
+};

--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -98,7 +98,6 @@
   }
 
   /* Drag and drop image with badge */
-  /* Drag and drop image with badge */
   .file-drag-image {
     position: absolute;
     top: -1000px;
@@ -153,6 +152,32 @@
     min-width: 1.5rem;
     text-align: center;
     z-index: 50;
+  }
+
+  .file-drag-copy-badge {
+    display: grid;
+    width: 1.5rem;
+    height: 1.5rem;
+    place-items: center;
+    background-color: rgb(22 163 74); /* green-600 */
+    color: white;
+    border-radius: 9999px;
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1;
+    box-shadow:
+      0 4px 6px -1px rgb(0 0 0 / 0.1),
+      0 2px 4px -2px rgb(0 0 0 / 0.1);
+    z-index: 50;
+  }
+
+  .file-drag-copy-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 10000;
+    pointer-events: none;
+    will-change: transform;
   }
 }
 

--- a/frontend/src/assets/base.css
+++ b/frontend/src/assets/base.css
@@ -154,31 +154,6 @@
     z-index: 50;
   }
 
-  .file-drag-copy-badge {
-    display: grid;
-    width: 1.5rem;
-    height: 1.5rem;
-    place-items: center;
-    background-color: rgb(22 163 74); /* green-600 */
-    color: white;
-    border-radius: 9999px;
-    font-size: 1rem;
-    font-weight: 700;
-    line-height: 1;
-    box-shadow:
-      0 4px 6px -1px rgb(0 0 0 / 0.1),
-      0 2px 4px -2px rgb(0 0 0 / 0.1);
-    z-index: 50;
-  }
-
-  .file-drag-copy-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 10000;
-    pointer-events: none;
-    will-change: transform;
-  }
 }
 
 @theme {

--- a/frontend/src/components/ClipboardProgress.vue
+++ b/frontend/src/components/ClipboardProgress.vue
@@ -2,8 +2,10 @@
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ChevronDownIcon, QueueListIcon, XMarkIcon } from '@heroicons/vue/24/outline';
+import { useFileStore } from '@/stores/fileStore';
 import { useOperationTasksStore } from '@/stores/operationTasks';
 
+const fileStore = useFileStore();
 const operationTasksStore = useOperationTasksStore();
 const { t } = useI18n();
 const isListOpen = ref(false);
@@ -46,6 +48,7 @@ const titleFor = (value) => {
 const percent = computed(() => percentFor(operation.value));
 const progressLabel = computed(() => progressLabelFor(operation.value));
 const destination = computed(() => operation.value?.destination ?? '');
+const isTransfer = computed(() => ['copy', 'move'].includes(operation.value?.type));
 
 const selectOperation = (id) => {
   operationTasksStore.selectOperation(id);
@@ -154,6 +157,18 @@ const cancelTask = (id) => {
     <div class="mt-2 text-xs text-zinc-600 dark:text-zinc-300 tabular-nums">
       {{ operation.cancelling ? t('common.loading') : progressLabel }}
     </div>
+
+    <label
+      v-if="isTransfer"
+      class="mt-3 flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-300 cursor-pointer select-none"
+    >
+      <input
+        v-model="fileStore.repositionAfterTransfer"
+        type="checkbox"
+        class="h-3.5 w-3.5 rounded border-zinc-300 text-indigo-600 focus:ring-indigo-500"
+      />
+      {{ t('clipboard.reposition') }}
+    </label>
   </div>
 </template>
 

--- a/frontend/src/components/ClipboardProgress.vue
+++ b/frontend/src/components/ClipboardProgress.vue
@@ -2,11 +2,29 @@
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useFileStore } from '@/stores/fileStore';
+import { formatBytes } from '@/utils';
 
 const fileStore = useFileStore();
 const { t } = useI18n();
 
 const operation = computed(() => fileStore.deleteOperation || fileStore.clipboardOperation);
+
+const totalBytes = computed(() => Number(operation.value?.totalBytes) || 0);
+const copiedBytes = computed(() =>
+  Math.min(Number(operation.value?.copiedBytes) || 0, totalBytes.value || Number.POSITIVE_INFINITY)
+);
+
+// Determinate only when the backend reported a byte total (copy / cross-device
+// move). Same-filesystem moves and deletes keep the indeterminate animation.
+const hasProgress = computed(() => totalBytes.value > 0);
+const percent = computed(() =>
+  hasProgress.value ? Math.min(100, Math.round((copiedBytes.value / totalBytes.value) * 100)) : 0
+);
+const progressLabel = computed(() =>
+  hasProgress.value
+    ? `${formatBytes(copiedBytes.value)} / ${formatBytes(totalBytes.value)} · ${percent.value}%`
+    : t('clipboard.working')
+);
 
 const title = computed(() => {
   const op = operation.value;
@@ -47,12 +65,17 @@ const destination = computed(() => operation.value?.destination ?? '');
       <div
         class="w-full h-2 rounded-full overflow-hidden border border-zinc-200/70 dark:border-zinc-700/50 bg-zinc-100/80 dark:bg-zinc-800/70"
       >
-        <div class="h-full rounded-full clipboard-bar clipboard-bar--animated" />
+        <div
+          v-if="hasProgress"
+          class="h-full rounded-full clipboard-bar clipboard-bar--determinate"
+          :style="{ width: `${percent}%` }"
+        />
+        <div v-else class="h-full rounded-full clipboard-bar clipboard-bar--animated" />
       </div>
     </div>
 
-    <div class="mt-2 text-xs text-zinc-600 dark:text-zinc-300">
-      {{ t('clipboard.working') }}
+    <div class="mt-2 text-xs text-zinc-600 dark:text-zinc-300 tabular-nums">
+      {{ progressLabel }}
     </div>
   </div>
 </template>
@@ -70,6 +93,12 @@ const destination = computed(() => operation.value?.destination ?? '');
 
 .clipboard-bar--animated {
   animation: clipboardSlide 1.35s ease-in-out infinite;
+}
+
+/* Determinate bar: width is driven by the copied/total ratio; the inline width
+   set in the template overrides the base 42% used by the animated variant. */
+.clipboard-bar--determinate {
+  transition: width 0.2s ease;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/components/ClipboardProgress.vue
+++ b/frontend/src/components/ClipboardProgress.vue
@@ -43,6 +43,13 @@ const title = computed(() => {
 });
 
 const destination = computed(() => operation.value?.destination ?? '');
+
+// The reposition toggle only applies to copy/move (clipboard) operations, never
+// to deletes.
+const isTransfer = computed(() => {
+  const type = operation.value?.type;
+  return type === 'copy' || type === 'move';
+});
 </script>
 
 <template>
@@ -77,6 +84,18 @@ const destination = computed(() => operation.value?.destination ?? '');
     <div class="mt-2 text-xs text-zinc-600 dark:text-zinc-300 tabular-nums">
       {{ progressLabel }}
     </div>
+
+    <label
+      v-if="isTransfer"
+      class="mt-3 flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-300 cursor-pointer select-none"
+    >
+      <input
+        v-model="fileStore.repositionAfterTransfer"
+        type="checkbox"
+        class="h-3.5 w-3.5 rounded border-zinc-300 text-indigo-600 focus:ring-indigo-500"
+      />
+      {{ t('clipboard.reposition') }}
+    </label>
   </div>
 </template>
 

--- a/frontend/src/components/ClipboardProgress.vue
+++ b/frontend/src/components/ClipboardProgress.vue
@@ -1,55 +1,64 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { useFileStore } from '@/stores/fileStore';
-import { formatBytes } from '@/utils';
+import { ChevronDownIcon, QueueListIcon, XMarkIcon } from '@heroicons/vue/24/outline';
+import { useOperationTasksStore } from '@/stores/operationTasks';
 
-const fileStore = useFileStore();
+const operationTasksStore = useOperationTasksStore();
 const { t } = useI18n();
+const isListOpen = ref(false);
 
-const operation = computed(() => fileStore.deleteOperation || fileStore.clipboardOperation);
+const operation = computed(() => operationTasksStore.activeOperation);
+const operations = computed(() => operationTasksStore.operations);
+const operationCount = computed(() => operationTasksStore.operationCount);
 
-const totalBytes = computed(() => Number(operation.value?.totalBytes) || 0);
-const copiedBytes = computed(() =>
-  Math.min(Number(operation.value?.copiedBytes) || 0, totalBytes.value || Number.POSITIVE_INFINITY)
-);
+watch(operationCount, (count) => {
+  if (count < 2) isListOpen.value = false;
+});
 
-// Determinate only when the backend reported a byte total (copy / cross-device
-// move). Same-filesystem moves and deletes keep the indeterminate animation.
-const hasProgress = computed(() => totalBytes.value > 0);
-const percent = computed(() =>
-  hasProgress.value ? Math.min(100, Math.round((copiedBytes.value / totalBytes.value) * 100)) : 0
-);
-const progressLabel = computed(() =>
-  hasProgress.value
-    ? `${formatBytes(copiedBytes.value)} / ${formatBytes(totalBytes.value)} · ${percent.value}%`
-    : t('clipboard.working')
-);
+const percentFor = (value) => {
+  const streamed = value?.percent;
+  return Number.isFinite(streamed) ? Math.min(100, Math.max(0, streamed)) : null;
+};
+const progressLabelFor = (value) => {
+  const percent = percentFor(value);
+  return percent !== null ? `${percent}%` : t('clipboard.working');
+};
+const titleFor = (value) => {
+  if (!value) return '';
 
-const title = computed(() => {
-  const op = operation.value;
-  if (!op) return '';
+  if (value.type === 'extract') return t('clipboard.extracting', { name: value.name || '' });
+  if (value.type === 'compress') return t('clipboard.compressing', { name: value.name || '' });
 
-  const count = Number(op.itemCount) || 0;
-  const itemsLabel = count === 1 ? t('common.item') : t('common.items');
-
-  if (op.type === 'delete') {
-    return `${t('common.deleting')} ${count} ${itemsLabel}`;
+  const count = Number(value.itemCount);
+  if (!Number.isInteger(count) || count < 1) {
+    return value.type === 'move' ? t('clipboard.movingUnknown') : t('clipboard.copyingUnknown');
   }
 
-  return op.type === 'move'
+  const itemsLabel = count === 1 ? t('common.item') : t('common.items');
+  if (value.type === 'delete') return `${t('common.deleting')} ${count} ${itemsLabel}`;
+
+  return value.type === 'move'
     ? t('clipboard.moving', { count, items: itemsLabel })
     : t('clipboard.copying', { count, items: itemsLabel });
-});
+};
 
+const percent = computed(() => percentFor(operation.value));
+const progressLabel = computed(() => progressLabelFor(operation.value));
 const destination = computed(() => operation.value?.destination ?? '');
 
-// The reposition toggle only applies to copy/move (clipboard) operations, never
-// to deletes.
-const isTransfer = computed(() => {
-  const type = operation.value?.type;
-  return type === 'copy' || type === 'move';
-});
+const selectOperation = (id) => {
+  operationTasksStore.selectOperation(id);
+  isListOpen.value = false;
+};
+
+const cancelOperation = () => {
+  if (operation.value?.id) operationTasksStore.cancelOperation(operation.value.id);
+};
+
+const cancelTask = (id) => {
+  operationTasksStore.cancelOperation(id);
+};
 </script>
 
 <template>
@@ -59,13 +68,74 @@ const isTransfer = computed(() => {
     role="status"
     aria-live="polite"
   >
-    <h3 class="text-lg font-semibold tracking-tight">
-      {{ title }}
-    </h3>
+    <div class="flex items-start gap-3">
+      <div class="min-w-0 grow">
+        <h3 class="text-lg font-semibold tracking-tight">
+          {{ titleFor(operation) }}
+        </h3>
+        <div v-if="destination" class="mt-1 text-sm text-zinc-600 dark:text-zinc-300">
+          {{ t('common.to') }}
+          <span class="text-indigo-600 dark:text-indigo-300 font-medium">{{ destination }}</span>
+        </div>
+      </div>
 
-    <div v-if="destination" class="mt-1 text-sm text-zinc-600 dark:text-zinc-300">
-      {{ t('common.to') }}
-      <span class="text-indigo-600 dark:text-indigo-300 font-medium">{{ destination }}</span>
+      <button
+        v-if="operationCount > 1"
+        type="button"
+        class="shrink-0 inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-200 dark:hover:bg-zinc-600"
+        :aria-expanded="isListOpen"
+        :title="t('clipboard.activeTasks', { count: operationCount })"
+        @click="isListOpen = !isListOpen"
+      >
+        <QueueListIcon class="h-4 w-4" />
+        {{ operationCount }}
+        <ChevronDownIcon
+          class="h-3.5 w-3.5 transition-transform"
+          :class="{ 'rotate-180': isListOpen }"
+        />
+      </button>
+      <button
+        v-if="operation.cancellable"
+        type="button"
+        class="shrink-0 rounded-md p-1.5 text-zinc-600 transition hover:bg-rose-50 hover:text-rose-700 disabled:cursor-wait disabled:opacity-60 dark:text-zinc-200 dark:hover:bg-rose-950/50 dark:hover:text-rose-300"
+        :disabled="operation.cancelling"
+        :title="t('common.cancel')"
+        :aria-label="t('common.cancel')"
+        @click="cancelOperation"
+      >
+        <XMarkIcon class="h-5 w-5" />
+      </button>
+    </div>
+
+    <div v-if="isListOpen" class="mt-3 border-y border-zinc-200/70 py-2 dark:border-zinc-600">
+      <div
+        v-for="task in operations"
+        :key="task.id"
+        class="flex items-center gap-1 rounded-md"
+        :class="{ 'bg-zinc-100 dark:bg-zinc-600': task.id === operation.id }"
+      >
+        <button
+          type="button"
+          class="flex min-w-0 grow items-center justify-between gap-3 rounded-md px-2 py-2 text-left text-sm hover:bg-zinc-100 dark:hover:bg-zinc-600"
+          @click="selectOperation(task.id)"
+        >
+          <span class="min-w-0 truncate font-medium">{{ titleFor(task) }}</span>
+          <span class="shrink-0 text-xs tabular-nums text-zinc-500 dark:text-zinc-300">
+            {{ progressLabelFor(task) }}
+          </span>
+        </button>
+        <button
+          v-if="task.cancellable"
+          type="button"
+          class="mr-1 shrink-0 rounded-md p-1 text-zinc-500 transition hover:bg-rose-50 hover:text-rose-700 disabled:cursor-wait disabled:opacity-60 dark:text-zinc-300 dark:hover:bg-rose-950/50 dark:hover:text-rose-300"
+          :disabled="task.cancelling"
+          :title="t('common.cancel')"
+          :aria-label="t('common.cancel')"
+          @click="cancelTask(task.id)"
+        >
+          <XMarkIcon class="h-4 w-4" />
+        </button>
+      </div>
     </div>
 
     <div class="mt-3">
@@ -73,7 +143,7 @@ const isTransfer = computed(() => {
         class="w-full h-2 rounded-full overflow-hidden border border-zinc-200/70 dark:border-zinc-700/50 bg-zinc-100/80 dark:bg-zinc-800/70"
       >
         <div
-          v-if="hasProgress"
+          v-if="percent !== null"
           class="h-full rounded-full clipboard-bar clipboard-bar--determinate"
           :style="{ width: `${percent}%` }"
         />
@@ -82,20 +152,8 @@ const isTransfer = computed(() => {
     </div>
 
     <div class="mt-2 text-xs text-zinc-600 dark:text-zinc-300 tabular-nums">
-      {{ progressLabel }}
+      {{ operation.cancelling ? t('common.loading') : progressLabel }}
     </div>
-
-    <label
-      v-if="isTransfer"
-      class="mt-3 flex items-center gap-2 text-xs text-zinc-600 dark:text-zinc-300 cursor-pointer select-none"
-    >
-      <input
-        v-model="fileStore.repositionAfterTransfer"
-        type="checkbox"
-        class="h-3.5 w-3.5 rounded border-zinc-300 text-indigo-600 focus:ring-indigo-500"
-      />
-      {{ t('clipboard.reposition') }}
-    </label>
   </div>
 </template>
 
@@ -114,8 +172,6 @@ const isTransfer = computed(() => {
   animation: clipboardSlide 1.35s ease-in-out infinite;
 }
 
-/* Determinate bar: width is driven by the copied/total ratio; the inline width
-   set in the template overrides the base 42% used by the animated variant. */
 .clipboard-bar--determinate {
   transition: width 0.2s ease;
 }

--- a/frontend/src/components/FavMenu.vue
+++ b/frontend/src/components/FavMenu.vue
@@ -18,7 +18,6 @@ const {
   PencilSquareIcon,
   XMarkIcon,
   Bars3Icon,
-  PlusIcon,
 } = OutlineIcons;
 
 const rootEl = ref(null);
@@ -242,12 +241,6 @@ onBeforeUnmount(() => {
                       :style="{ color: favorite.color || 'currentColor' }"
                     />
                     <span class="truncate">{{ getFavoriteLabel(favorite) }}</span>
-                    <span
-                      v-if="isFavoriteCopyTarget(favorite)"
-                      class="ml-auto grid h-5 w-5 place-items-center rounded-full bg-emerald-500 text-white shadow-sm"
-                    >
-                      <PlusIcon class="h-3.5 w-3.5" />
-                    </span>
                   </button>
                   <template v-if="isEditMode">
                     <button

--- a/frontend/src/components/FavMenu.vue
+++ b/frontend/src/components/FavMenu.vue
@@ -208,10 +208,7 @@ onBeforeUnmount(() => {
               @end="handleReorderEnd"
             >
               <template #item="{ element: favorite }">
-                <div
-                  class="group/item relative mb-3 flex items-center gap-2 favorite-drag-handle"
-                  :class="isFavoriteDragTarget(favorite) ? 'rounded-lg ring-2 ring-offset-1 dark:ring-offset-zinc-900' : ''"
-                >
+                <div class="group/item relative mb-3 flex items-center gap-2 favorite-drag-handle">
                   <Bars3Icon
                     v-if="isEditMode"
                     class="h-4 w-4 shrink-0 cursor-grab text-neutral-400 group-hover/item:text-white dark:text-neutral-500 dark:group-hover/item:text-neutral-100 transition-colors duration-150"
@@ -229,9 +226,9 @@ onBeforeUnmount(() => {
                         ? 'text-neutral-950 dark:text-white'
                         : 'text-neutral-950 dark:text-neutral-300/90',
                       isFavoriteCopyTarget(favorite)
-                        ? 'bg-emerald-50 dark:bg-emerald-950/40 ring-emerald-500 dark:ring-emerald-400'
+                        ? 'bg-emerald-50 dark:bg-emerald-950/40 ring-2 ring-inset ring-emerald-500 dark:ring-emerald-400'
                         : isFavoriteDragTarget(favorite)
-                          ? 'bg-blue-50 dark:bg-blue-950/40 ring-blue-500 dark:ring-blue-400'
+                          ? 'bg-blue-50 dark:bg-blue-950/40 ring-2 ring-inset ring-blue-500 dark:ring-blue-400'
                           : '',
                     ]"
                   >

--- a/frontend/src/components/FavMenu.vue
+++ b/frontend/src/components/FavMenu.vue
@@ -10,6 +10,7 @@ import { useNavigation } from '@/composables/navigation';
 import { normalizePath } from '@/api';
 import { useI18n } from 'vue-i18n';
 import { useFavoriteEditor } from '@/composables/useFavoriteEditor';
+import { useFileDragDrop } from '@/composables/useFileDragDrop';
 
 const {
   ChevronDownIcon,
@@ -17,6 +18,7 @@ const {
   PencilSquareIcon,
   XMarkIcon,
   Bars3Icon,
+  PlusIcon,
 } = OutlineIcons;
 
 const rootEl = ref(null);
@@ -27,6 +29,8 @@ const { favorites } = storeToRefs(favoritesStore);
 const route = useRoute();
 const { openBreadcrumb } = useNavigation();
 const { openEditorForFavorite } = useFavoriteEditor();
+const { handleDragOver, handleDragLeave, handleDrop, isDragTarget, isCopyDragTarget } =
+  useFileDragDrop();
 
 const ICON_VARIANTS = {
   outline: OutlineIcons,
@@ -86,6 +90,19 @@ const handleOpenFavorite = (favorite) => {
   }
   openBreadcrumb(favorite.path);
 };
+
+const favoriteDropTarget = (favorite = {}) => {
+  const destinationPath = normalizePath(favorite.path || '');
+  const segments = destinationPath.split('/').filter(Boolean);
+  return {
+    name: segments.at(-1) || '',
+    path: segments.slice(0, -1).join('/'),
+    destinationPath,
+  };
+};
+
+const isFavoriteDragTarget = (favorite) => isDragTarget(favoriteDropTarget(favorite));
+const isFavoriteCopyTarget = (favorite) => isCopyDragTarget(favoriteDropTarget(favorite));
 
 const toggleEditMode = () => {
   if (!favorites.value.length) return;
@@ -192,7 +209,10 @@ onBeforeUnmount(() => {
               @end="handleReorderEnd"
             >
               <template #item="{ element: favorite }">
-                <div class="group/item mb-3 flex items-center gap-2 favorite-drag-handle">
+                <div
+                  class="group/item relative mb-3 flex items-center gap-2 favorite-drag-handle"
+                  :class="isFavoriteDragTarget(favorite) ? 'rounded-lg ring-2 ring-offset-1 dark:ring-offset-zinc-900' : ''"
+                >
                   <Bars3Icon
                     v-if="isEditMode"
                     class="h-4 w-4 shrink-0 cursor-grab text-neutral-400 group-hover/item:text-white dark:text-neutral-500 dark:group-hover/item:text-neutral-100 transition-colors duration-150"
@@ -200,12 +220,20 @@ onBeforeUnmount(() => {
                   <button
                     type="button"
                     @click="handleOpenFavorite(favorite)"
+                    @dragover="handleDragOver($event, favoriteDropTarget(favorite))"
+                    @dragleave="handleDragLeave($event, favoriteDropTarget(favorite))"
+                    @drop="handleDrop($event, favoriteDropTarget(favorite))"
                     class="truncate"
                     :class="[
-                      'cursor-pointer flex w-full items-center gap-3 rounded-lg text-sm',
+                      'cursor-pointer flex w-full items-center gap-3 rounded-lg text-sm transition-colors',
                       isActiveFav(favorite.path)
                         ? 'text-neutral-950 dark:text-white'
                         : 'text-neutral-950 dark:text-neutral-300/90',
+                      isFavoriteCopyTarget(favorite)
+                        ? 'bg-emerald-50 dark:bg-emerald-950/40 ring-emerald-500 dark:ring-emerald-400'
+                        : isFavoriteDragTarget(favorite)
+                          ? 'bg-blue-50 dark:bg-blue-950/40 ring-blue-500 dark:ring-blue-400'
+                          : '',
                     ]"
                   >
                     <component
@@ -214,6 +242,12 @@ onBeforeUnmount(() => {
                       :style="{ color: favorite.color || 'currentColor' }"
                     />
                     <span class="truncate">{{ getFavoriteLabel(favorite) }}</span>
+                    <span
+                      v-if="isFavoriteCopyTarget(favorite)"
+                      class="ml-auto grid h-5 w-5 place-items-center rounded-full bg-emerald-500 text-white shadow-sm"
+                    >
+                      <PlusIcon class="h-3.5 w-3.5" />
+                    </span>
                   </button>
                   <template v-if="isEditMode">
                     <button

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -28,7 +28,7 @@ const { openItem } = useNavigation();
 const { handleSelection, isSelected, toggleSelection } = useSelection();
 const fileStore = useFileStore();
 const { renameState, selectionMode } = storeToRefs(fileStore);
-const { canDragDrop, handleDragStart } = useFileDragDrop();
+const { canDragDrop, handleDragStart, handleDragEnd } = useFileDragDrop();
 const contextMenu = useExplorerContextMenu();
 const { isTouchDevice } = useInputMode();
 
@@ -222,6 +222,7 @@ if (isTouchDevice.value) {
       @dblclick="handleDblClick"
       @contextmenu.prevent.stop="handleContextMenu"
       @dragstart="(e) => handleDragStart(e, item)"
+      @dragend="handleDragEnd"
       :draggable="canDragDrop() && !isRenaming"
       class="photo-cell relative w-full rounded-md overflow-hidden cursor-pointer select-none bg-neutral-100 dark:bg-zinc-800/60 hover:brightness-105"
       :class="{
@@ -256,6 +257,7 @@ if (isTouchDevice.value) {
       @dblclick="handleDblClick"
       @contextmenu.prevent.stop="handleContextMenu"
       @dragstart="(e) => handleDragStart(e, item)"
+      @dragend="handleDragEnd"
       :draggable="canDragDrop() && !isRenaming"
       class="relative flex flex-col items-center gap-2 p-2 rounded-xl cursor-pointer select-none"
       :class="[
@@ -313,6 +315,7 @@ if (isTouchDevice.value) {
       @dblclick="handleDblClick"
       @contextmenu.prevent.stop="handleContextMenu"
       @dragstart="(e) => handleDragStart(e, item)"
+      @dragend="handleDragEnd"
       :draggable="canDragDrop() && !isRenaming"
       class="relative flex items-center gap-2 p-4 rounded-md cursor-pointer select-none"
       :class="[
@@ -374,6 +377,7 @@ if (isTouchDevice.value) {
       @dblclick="handleDblClick"
       @contextmenu.prevent.stop="handleContextMenu"
       @dragstart="(e) => handleDragStart(e, item)"
+      @dragend="handleDragEnd"
       :draggable="canDragDrop() && !isRenaming"
       :class="[
         'grid select-none items-center',

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -15,10 +15,14 @@ import { DragSelectOption } from '@coleqiu/vue-drag-select';
 import MiddleEllipsis from '@/components/MiddleEllipsis.vue';
 import { ellipses } from '@/utils/ellipses';
 import { useInputMode } from '@/composables/useInputMode';
-import { CheckIcon } from '@heroicons/vue/20/solid';
+import { CheckIcon, PlusIcon } from '@heroicons/vue/20/solid';
 import { useFileDragDrop } from '@/composables/useFileDragDrop';
 
-const props = defineProps(['item', 'view']);
+const props = defineProps({
+  item: { type: Object, required: true },
+  view: { type: String, required: true },
+  showCopyDropIndicator: { type: Boolean, default: false },
+});
 const settings = useSettingsStore();
 
 const { openItem } = useNavigation();
@@ -207,7 +211,7 @@ if (isTouchDevice.value) {
 
 <template>
   <DragSelectOption
-    class="group/item"
+    :class="['group/item', { relative: showCopyDropIndicator }]"
     v-if="(view === 'photos' && isPhotoItem) || view != 'photos'"
     :value="props.item"
   >
@@ -441,6 +445,12 @@ if (isTouchDevice.value) {
         {{ formatDate(item.dateModified) }}
       </div>
     </div>
+    <span
+      v-if="showCopyDropIndicator"
+      class="pointer-events-none absolute right-2 top-2 z-40 grid h-6 w-6 place-items-center rounded-full bg-emerald-500 text-white shadow-md ring-2 ring-white dark:ring-zinc-900"
+    >
+      <PlusIcon class="h-4 w-4" />
+    </span>
   </DragSelectOption>
 </template>
 

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -15,13 +15,12 @@ import { DragSelectOption } from '@coleqiu/vue-drag-select';
 import MiddleEllipsis from '@/components/MiddleEllipsis.vue';
 import { ellipses } from '@/utils/ellipses';
 import { useInputMode } from '@/composables/useInputMode';
-import { CheckIcon, PlusIcon } from '@heroicons/vue/20/solid';
+import { CheckIcon } from '@heroicons/vue/20/solid';
 import { useFileDragDrop } from '@/composables/useFileDragDrop';
 
 const props = defineProps({
   item: { type: Object, required: true },
   view: { type: String, required: true },
-  showCopyDropIndicator: { type: Boolean, default: false },
 });
 const settings = useSettingsStore();
 
@@ -211,7 +210,7 @@ if (isTouchDevice.value) {
 
 <template>
   <DragSelectOption
-    :class="['group/item', { relative: showCopyDropIndicator }]"
+    class="group/item"
     v-if="(view === 'photos' && isPhotoItem) || view != 'photos'"
     :value="props.item"
   >
@@ -445,12 +444,6 @@ if (isTouchDevice.value) {
         {{ formatDate(item.dateModified) }}
       </div>
     </div>
-    <span
-      v-if="showCopyDropIndicator"
-      class="pointer-events-none absolute right-2 top-2 z-40 grid h-6 w-6 place-items-center rounded-full bg-emerald-500 text-white shadow-md ring-2 ring-white dark:ring-zinc-900"
-    >
-      <PlusIcon class="h-4 w-4" />
-    </span>
   </DragSelectOption>
 </template>
 

--- a/frontend/src/composables/useFileDragDrop.js
+++ b/frontend/src/composables/useFileDragDrop.js
@@ -220,11 +220,10 @@ export function useFileDragDrop() {
       return;
     }
 
-    // setDragImage(-10, 10) places the preview at x + 10, y - 10. Its count
-    // bubble sits at the upper-right corner; this positions the copy badge
-    // immediately to its left without replacing the native preview.
+    // The native preview is composited above page elements. Keep the dynamic
+    // badge just outside it so the browser never partially masks the +.
     const previewWidth = Number(activeDragImage?.previewWidth) || 200;
-    activeCopyBadge.style.transform = `translate3d(${x + previewWidth - 46}px, ${y - 14}px, 0)`;
+    activeCopyBadge.style.transform = `translate3d(${x + previewWidth + 10}px, ${y - 2}px, 0)`;
   };
 
   const updateCopyBadge = (event, copy) => {
@@ -250,7 +249,9 @@ export function useFileDragDrop() {
 
   const handleDragMove = (event) => {
     if (!canDragDrop() || !activeDragImage) return;
-    updateDragPreviewOperation(event, isCopyModifierPressed(event));
+    // Chromium may report altKey as false on source-side drag events. The
+    // operation itself is therefore updated only by destination dragover.
+    if (activeDragImage.copy) positionCopyBadge(event);
   };
 
   /**

--- a/frontend/src/composables/useFileDragDrop.js
+++ b/frontend/src/composables/useFileDragDrop.js
@@ -10,8 +10,7 @@ import { useOperationTasksStore } from '@/stores/operationTasks';
 // composable instance handles dragover. Keep the preview state module-wide so
 // Option/Alt can still update the same drag image in either destination.
 let activeDragImage = null;
-let activeDragOverlay = null;
-let dragDropHandled = false;
+let activeCopyBadge = null;
 
 /**
  * Composable for handling file and folder drag and drop operations.
@@ -113,23 +112,22 @@ export function useFileDragDrop() {
       sourceEl: event.currentTarget,
       copy,
     };
-    dragDropHandled = false;
 
-    // The browser only applies setDragImage during dragstart. Use a transparent
-    // native image, then keep the visible preview under our own control so the
-    // copy badge can change immediately when Option/Alt is pressed.
-    setNativeDragPlaceholder(event);
-    renderDragOverlay(activeDragImage, event);
+    // Keep the native preview. Besides matching the familiar cursor placement,
+    // it lets the browser animate the preview back to its source on a cancelled
+    // drag, which is smoother than recreating the complete card ourselves.
+    createNativeDragImage(event, activeDragImage);
+    updateDragPreviewOperation(event, copy);
   };
 
   /**
-   * Build the visible drag preview with operation and item-count badges.
+   * Build the native drag preview with its item-count badge.
    * @param {Object} state - Source items, primary item and active operation
    */
   const buildDragPreview = (state) => {
     if (!state) return null;
 
-    const { items, primaryItem, sourceEl, copy } = state;
+    const { items, primaryItem, sourceEl } = state;
     const count = items.length;
     const dragImage = document.createElement('div');
     dragImage.className = 'file-drag-image';
@@ -184,67 +182,70 @@ export function useFileDragDrop() {
     }
 
     dragImage.appendChild(stack);
-    const badges = document.createElement('div');
-    badges.className = 'file-drag-badges';
-    if (copy) {
-      const copyBadge = document.createElement('div');
-      copyBadge.className = 'file-drag-copy-badge';
-      copyBadge.textContent = '+';
-      badges.appendChild(copyBadge);
-    }
     const badge = document.createElement('div');
     badge.className = 'file-drag-badge';
     badge.textContent = count.toString();
-    badges.appendChild(badge);
-    dragImage.appendChild(badges);
+    dragImage.appendChild(badge);
     return dragImage;
   };
 
-  const clearDragOverlay = () => {
-    activeDragOverlay?.remove();
-    activeDragOverlay = null;
+  const createNativeDragImage = (event, state) => {
+    if (typeof event?.dataTransfer?.setDragImage !== 'function' || !state) return;
+
+    const dragImage = buildDragPreview(state);
+    if (!dragImage) return;
+    document.body.appendChild(dragImage);
+
+    // Preserve the original native cursor anchor.
+    event.dataTransfer.setDragImage(dragImage, -10, 10);
+
+    const previewWidth = dragImage.getBoundingClientRect().width;
+    activeDragImage = {
+      ...activeDragImage,
+      previewWidth: previewWidth > 0 ? previewWidth : 200,
+    };
+
+    window.setTimeout(() => dragImage.remove(), 100);
   };
 
-  const positionDragOverlay = (event) => {
+  const clearCopyBadge = () => {
+    activeCopyBadge?.remove();
+    activeCopyBadge = null;
+  };
+
+  const positionCopyBadge = (event) => {
     const x = Number(event?.clientX);
     const y = Number(event?.clientY);
-    // Some browsers emit a final drag event with 0,0. Do not reveal the
-    // preview there or it flashes in the top-left corner of the viewport.
-    if (!activeDragOverlay || !Number.isFinite(x) || !Number.isFinite(y) || (x === 0 && y === 0)) {
+    if (!activeCopyBadge || !Number.isFinite(x) || !Number.isFinite(y) || (x === 0 && y === 0)) {
       return;
     }
-    // Match the former native drag-image anchor: the pointer stays aligned
-    // with the preview rather than leaving it noticeably below the cursor.
-    activeDragOverlay.style.transform = `translate3d(${x + 10}px, ${y - 10}px, 0)`;
-    activeDragOverlay.style.visibility = 'visible';
+
+    // setDragImage(-10, 10) places the preview at x + 10, y - 10. Its count
+    // bubble sits at the upper-right corner; this positions the copy badge
+    // immediately to its left without replacing the native preview.
+    const previewWidth = Number(activeDragImage?.previewWidth) || 200;
+    activeCopyBadge.style.transform = `translate3d(${x + previewWidth - 46}px, ${y - 14}px, 0)`;
   };
 
-  const renderDragOverlay = (state, event) => {
-    clearDragOverlay();
-    activeDragOverlay = buildDragPreview(state);
-    if (!activeDragOverlay) return;
-    activeDragOverlay.style.visibility = 'hidden';
-    document.body.appendChild(activeDragOverlay);
-    positionDragOverlay(event);
-  };
+  const updateCopyBadge = (event, copy) => {
+    if (!copy) {
+      clearCopyBadge();
+      return;
+    }
 
-  const setNativeDragPlaceholder = (event) => {
-    if (typeof event?.dataTransfer?.setDragImage !== 'function') return;
-    const placeholder = document.createElement('div');
-    placeholder.className = 'file-drag-native-placeholder';
-    document.body.appendChild(placeholder);
-    event.dataTransfer.setDragImage(placeholder, 0, 0);
-    setTimeout(() => placeholder.remove(), 0);
+    if (!activeCopyBadge) {
+      activeCopyBadge = document.createElement('div');
+      activeCopyBadge.className = 'file-drag-copy-badge file-drag-copy-overlay';
+      activeCopyBadge.textContent = '+';
+      document.body.appendChild(activeCopyBadge);
+    }
+    positionCopyBadge(event);
   };
 
   const updateDragPreviewOperation = (event, copy) => {
     if (!activeDragImage) return;
-    if (activeDragImage.copy === copy) {
-      positionDragOverlay(event);
-      return;
-    }
     activeDragImage = { ...activeDragImage, copy };
-    renderDragOverlay(activeDragImage, event);
+    updateCopyBadge(event, copy);
   };
 
   const handleDragMove = (event) => {
@@ -316,10 +317,11 @@ export function useFileDragDrop() {
     event.preventDefault();
     event.stopPropagation();
 
-    const copy = isCopyModifierPressed(event);
+    // Chrome can omit altKey from the terminal drop event. Keep the state that
+    // was observed during dragover so Option/Alt reliably selects copy.
+    const copy = activeDragImage?.copy === true || isCopyModifierPressed(event);
     updateDragPreviewOperation(event, copy);
-    dragDropHandled = true;
-    clearDragOverlay();
+    clearCopyBadge();
     activeDragImage = null;
     isDraggingOver.value = false;
     dragOverTarget.value = null;
@@ -430,22 +432,8 @@ export function useFileDragDrop() {
   };
 
   const handleDragEnd = () => {
-    if (!dragDropHandled && activeDragOverlay && activeDragImage?.sourceEl) {
-      const overlay = activeDragOverlay;
-      const sourceRect = activeDragImage.sourceEl.getBoundingClientRect();
-      overlay.style.transition = 'transform 140ms ease-out, opacity 140ms ease-out';
-      window.requestAnimationFrame(() => {
-        overlay.style.transform = `translate3d(${sourceRect.left}px, ${sourceRect.top}px, 0) scale(0.85)`;
-        overlay.style.opacity = '0';
-      });
-      window.setTimeout(() => {
-        if (activeDragOverlay === overlay) clearDragOverlay();
-      }, 150);
-    } else {
-      clearDragOverlay();
-    }
+    clearCopyBadge();
     activeDragImage = null;
-    dragDropHandled = false;
     isDraggingOver.value = false;
     dragOverTarget.value = null;
     dragOperation.value = 'move';

--- a/frontend/src/composables/useFileDragDrop.js
+++ b/frontend/src/composables/useFileDragDrop.js
@@ -10,7 +10,6 @@ import { useOperationTasksStore } from '@/stores/operationTasks';
 // composable instance handles dragover. Keep the preview state module-wide so
 // Option/Alt can still update the same drag image in either destination.
 let activeDragImage = null;
-let activeCopyBadge = null;
 
 /**
  * Composable for handling file and folder drag and drop operations.
@@ -101,9 +100,9 @@ export function useFileDragDrop() {
     event.dataTransfer.setData('application/json', dragData);
     // Safari is inconsistent about exposing custom types during dragover/drop, so add a fallback.
     event.dataTransfer.setData('text/plain', dragData);
-    // Keep the native cursor in move mode. The actual copy behavior is decided
-    // by Option/Alt when dropping, while the application preview shows the +.
-    event.dataTransfer.effectAllowed = 'move';
+    // Let the browser negotiate the copy operation too. This is the only
+    // reliable way to keep macOS and the terminal drop event in agreement.
+    event.dataTransfer.effectAllowed = 'copyMove';
 
     const copy = isCopyModifierPressed(event);
     activeDragImage = {
@@ -117,7 +116,7 @@ export function useFileDragDrop() {
     // it lets the browser animate the preview back to its source on a cancelled
     // drag, which is smoother than recreating the complete card ourselves.
     createNativeDragImage(event, activeDragImage);
-    updateDragPreviewOperation(event, copy);
+    activeDragImage = { ...activeDragImage, copy };
   };
 
   /**
@@ -199,59 +198,12 @@ export function useFileDragDrop() {
     // Preserve the original native cursor anchor.
     event.dataTransfer.setDragImage(dragImage, -10, 10);
 
-    const previewWidth = dragImage.getBoundingClientRect().width;
-    activeDragImage = {
-      ...activeDragImage,
-      previewWidth: previewWidth > 0 ? previewWidth : 200,
-    };
-
     window.setTimeout(() => dragImage.remove(), 100);
   };
 
-  const clearCopyBadge = () => {
-    activeCopyBadge?.remove();
-    activeCopyBadge = null;
-  };
-
-  const positionCopyBadge = (event) => {
-    const x = Number(event?.clientX);
-    const y = Number(event?.clientY);
-    if (!activeCopyBadge || !Number.isFinite(x) || !Number.isFinite(y) || (x === 0 && y === 0)) {
-      return;
-    }
-
-    // The native preview is composited above page elements. Keep the dynamic
-    // badge just outside it so the browser never partially masks the +.
-    const previewWidth = Number(activeDragImage?.previewWidth) || 200;
-    activeCopyBadge.style.transform = `translate3d(${x + previewWidth + 10}px, ${y - 2}px, 0)`;
-  };
-
-  const updateCopyBadge = (event, copy) => {
-    if (!copy) {
-      clearCopyBadge();
-      return;
-    }
-
-    if (!activeCopyBadge) {
-      activeCopyBadge = document.createElement('div');
-      activeCopyBadge.className = 'file-drag-copy-badge file-drag-copy-overlay';
-      activeCopyBadge.textContent = '+';
-      document.body.appendChild(activeCopyBadge);
-    }
-    positionCopyBadge(event);
-  };
-
-  const updateDragPreviewOperation = (event, copy) => {
+  const updateDragOperation = (copy) => {
     if (!activeDragImage) return;
     activeDragImage = { ...activeDragImage, copy };
-    updateCopyBadge(event, copy);
-  };
-
-  const handleDragMove = (event) => {
-    if (!canDragDrop() || !activeDragImage) return;
-    // Chromium may report altKey as false on source-side drag events. The
-    // operation itself is therefore updated only by destination dragover.
-    if (activeDragImage.copy) positionCopyBadge(event);
   };
 
   /**
@@ -267,10 +219,8 @@ export function useFileDragDrop() {
 
     event.preventDefault();
     const copy = isCopyModifierPressed(event);
-    // Avoid the macOS copy cursor. The green badge in the preview remains the
-    // sole operation indicator and the drop still performs a copy when Alt is held.
-    event.dataTransfer.dropEffect = 'move';
-    updateDragPreviewOperation(event, copy);
+    event.dataTransfer.dropEffect = copy ? 'copy' : 'move';
+    updateDragOperation(copy);
 
     // Store the target folder for drag leave/drop handling
     dragOverTarget.value = targetFolder;
@@ -318,11 +268,12 @@ export function useFileDragDrop() {
     event.preventDefault();
     event.stopPropagation();
 
-    // Chrome can omit altKey from the terminal drop event. Keep the state that
-    // was observed during dragover so Option/Alt reliably selects copy.
-    const copy = activeDragImage?.copy === true || isCopyModifierPressed(event);
-    updateDragPreviewOperation(event, copy);
-    clearCopyBadge();
+    // Chromium can omit altKey from the terminal drop event. Prefer the native
+    // negotiated operation, then the operation seen during dragover.
+    const copy =
+      event.dataTransfer.dropEffect === 'copy' ||
+      activeDragImage?.copy === true ||
+      isCopyModifierPressed(event);
     activeDragImage = null;
     isDraggingOver.value = false;
     dragOverTarget.value = null;
@@ -433,7 +384,6 @@ export function useFileDragDrop() {
   };
 
   const handleDragEnd = () => {
-    clearCopyBadge();
     activeDragImage = null;
     isDraggingOver.value = false;
     dragOverTarget.value = null;
@@ -456,7 +406,6 @@ export function useFileDragDrop() {
     isDraggingOver,
     canDragDrop,
     handleDragStart,
-    handleDragMove,
     handleDragOver,
     handleDragLeave,
     handleDrop,

--- a/frontend/src/composables/useFileDragDrop.js
+++ b/frontend/src/composables/useFileDragDrop.js
@@ -1,7 +1,10 @@
 import { ref } from 'vue';
 import { useFileStore } from '@/stores/fileStore';
-import { moveItems, normalizePath } from '@/api';
+import { useVolumeUsageStore } from '@/stores/volumeUsage';
+import { useFolderSizeStore } from '@/stores/folderSize';
+import { copyItems, moveItems, normalizePath } from '@/api';
 import { useInputMode } from '@/composables/useInputMode';
+import { useOperationTasksStore } from '@/stores/operationTasks';
 
 /**
  * Composable for handling file and folder drag and drop operations.
@@ -9,9 +12,13 @@ import { useInputMode } from '@/composables/useInputMode';
  */
 export function useFileDragDrop() {
   const fileStore = useFileStore();
+  const volumeUsageStore = useVolumeUsageStore();
+  const folderSizeStore = useFolderSizeStore();
+  const operationTasksStore = useOperationTasksStore();
   const { isTouchDevice } = useInputMode();
   const isDraggingOver = ref(false);
   const dragOverTarget = ref(null);
+  const dragOperation = ref('move');
 
   const isExternalFileDrag = (event) => {
     const types = event?.dataTransfer?.types;
@@ -23,7 +30,9 @@ export function useFileDragDrop() {
     const types = event?.dataTransfer?.types;
     if (!types) return false;
     // Our internal drags set application/json and a text/plain fallback for Safari.
-    return Array.from(types).includes('application/json') || Array.from(types).includes('text/plain');
+    return (
+      Array.from(types).includes('application/json') || Array.from(types).includes('text/plain')
+    );
   };
 
   const serializeItems = (items) =>
@@ -36,6 +45,10 @@ export function useFileDragDrop() {
       }));
 
   const resolveFolderDestination = (targetFolder) => {
+    if (targetFolder?.destinationPath) {
+      return normalizePath(targetFolder.destinationPath);
+    }
+
     if (!targetFolder || !targetFolder.name) {
       return normalizePath(fileStore.currentPath || '');
     }
@@ -51,6 +64,10 @@ export function useFileDragDrop() {
   const canDragDrop = () => {
     return !isTouchDevice.value;
   };
+
+  // Option on macOS and Alt on Windows/Linux both set altKey. Copy is kept as
+  // a modifier rather than a persistent mode, matching Finder and Explorer.
+  const isCopyModifierPressed = (event) => Boolean(event?.altKey);
 
   /**
    * Handle drag start on a file/folder item
@@ -78,13 +95,12 @@ export function useFileDragDrop() {
     event.dataTransfer.setData('application/json', dragData);
     // Safari is inconsistent about exposing custom types during dragover/drop, so add a fallback.
     event.dataTransfer.setData('text/plain', dragData);
-    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.effectAllowed = 'copyMove';
 
     // Create custom drag image with badge
     createDragImage(event, itemsToDrag, item);
   };
 
-  /**
   /**
    * Create a custom drag image with a badge showing the number of items
    * @param {DragEvent} event - The drag event
@@ -172,10 +188,12 @@ export function useFileDragDrop() {
     if (!isInternalMoveDrag(event)) return;
 
     event.preventDefault();
-    event.dataTransfer.dropEffect = 'move';
+    const copy = isCopyModifierPressed(event);
+    event.dataTransfer.dropEffect = copy ? 'copy' : 'move';
 
     // Store the target folder for drag leave/drop handling
     dragOverTarget.value = targetFolder;
+    dragOperation.value = copy ? 'copy' : 'move';
     isDraggingOver.value = true;
   };
 
@@ -196,8 +214,9 @@ export function useFileDragDrop() {
     const y = event.clientY;
 
     if (x < rect.left || x >= rect.right || y < rect.top || y >= rect.bottom) {
-      if (dragOverTarget.value === targetFolder) {
+      if (isDragTarget(targetFolder)) {
         dragOverTarget.value = null;
+        dragOperation.value = 'move';
         isDraggingOver.value = false;
       }
     }
@@ -218,14 +237,22 @@ export function useFileDragDrop() {
     event.preventDefault();
     event.stopPropagation();
 
+    const copy = isCopyModifierPressed(event) || event.dataTransfer.dropEffect === 'copy';
     isDraggingOver.value = false;
     dragOverTarget.value = null;
+    dragOperation.value = 'move';
 
     // Get the dragged items from dataTransfer
-    const dragData = event.dataTransfer.getData('application/json');
+    const dragData =
+      event.dataTransfer.getData('application/json') || event.dataTransfer.getData('text/plain');
     if (!dragData) return;
 
-    const draggedItems = JSON.parse(dragData);
+    let draggedItems;
+    try {
+      draggedItems = JSON.parse(dragData);
+    } catch {
+      return;
+    }
     if (!Array.isArray(draggedItems) || draggedItems.length === 0) return;
 
     // Get the destination path (target folder's full relative path)
@@ -255,18 +282,67 @@ export function useFileDragDrop() {
     }
 
     try {
-      // Prepare payload for moveItems API
-      const movePayload = serializeItems(draggedItems);
-      if (movePayload.length === 0) return;
+      const transferPayload = serializeItems(draggedItems);
+      if (transferPayload.length === 0) return;
 
-      // Call the moveItems API
-      await moveItems(movePayload, destination);
+      const controller = new AbortController();
+      const operationId = operationTasksStore.startOperation({
+        type: copy ? 'copy' : 'move',
+        destination,
+        itemCount: transferPayload.length,
+        cancellable: true,
+        cancel: () => controller.abort(),
+      });
+
+      const onTransferEvent = (streamEvent) => {
+        if (!streamEvent) return;
+        if (streamEvent.type === 'start') {
+          operationTasksStore.updateOperation(operationId, {
+            totalBytes: Number(streamEvent.totalBytes) || 0,
+            copiedBytes: 0,
+          });
+        } else if (streamEvent.type === 'progress') {
+          operationTasksStore.updateOperation(operationId, {
+            ...(streamEvent.totalBytes != null
+              ? { totalBytes: Number(streamEvent.totalBytes) || 0 }
+              : {}),
+            copiedBytes: Number(streamEvent.copiedBytes) || 0,
+            ...(streamEvent.percent != null
+              ? { percent: Number(streamEvent.percent) || 0 }
+              : {}),
+          });
+        }
+      };
+
+      try {
+        const transfer = copy ? copyItems : moveItems;
+        await transfer(transferPayload, destination, {
+          signal: controller.signal,
+          onEvent: onTransferEvent,
+        });
+      } finally {
+        operationTasksStore.finishOperation(operationId);
+      }
 
       // Refresh the current path to show the changes
       await fileStore.fetchPathItems(fileStore.currentPath);
+      volumeUsageStore.scheduleRefresh();
+      folderSizeStore.scheduleRefresh();
     } catch (error) {
-      console.error('Failed to move items:', error);
+      if (error?.name === 'AbortError' || /aborted/i.test(error?.message || '')) {
+        await fileStore.fetchPathItems(fileStore.currentPath);
+        volumeUsageStore.scheduleRefresh();
+        folderSizeStore.scheduleRefresh();
+        return;
+      }
+      console.error(`Failed to ${copy ? 'copy' : 'move'} items:`, error);
     }
+  };
+
+  const handleDragEnd = () => {
+    isDraggingOver.value = false;
+    dragOverTarget.value = null;
+    dragOperation.value = 'move';
   };
 
   /**
@@ -276,8 +352,10 @@ export function useFileDragDrop() {
    */
   const isDragTarget = (folder) => {
     if (!dragOverTarget.value) return false;
-    return dragOverTarget.value.name === folder.name && dragOverTarget.value.path === folder.path;
+    return resolveFolderDestination(dragOverTarget.value) === resolveFolderDestination(folder);
   };
+
+  const isCopyDragTarget = (folder) => isDragTarget(folder) && dragOperation.value === 'copy';
 
   return {
     isDraggingOver,
@@ -286,6 +364,8 @@ export function useFileDragDrop() {
     handleDragOver,
     handleDragLeave,
     handleDrop,
+    handleDragEnd,
     isDragTarget,
+    isCopyDragTarget,
   };
 }

--- a/frontend/src/composables/useFileDragDrop.js
+++ b/frontend/src/composables/useFileDragDrop.js
@@ -1,7 +1,5 @@
 import { ref } from 'vue';
 import { useFileStore } from '@/stores/fileStore';
-import { useVolumeUsageStore } from '@/stores/volumeUsage';
-import { useFolderSizeStore } from '@/stores/folderSize';
 import { copyItems, moveItems, normalizePath } from '@/api';
 import { useInputMode } from '@/composables/useInputMode';
 import { useOperationTasksStore } from '@/stores/operationTasks';
@@ -17,8 +15,6 @@ let activeDragImage = null;
  */
 export function useFileDragDrop() {
   const fileStore = useFileStore();
-  const volumeUsageStore = useVolumeUsageStore();
-  const folderSizeStore = useFolderSizeStore();
   const operationTasksStore = useOperationTasksStore();
   const { isTouchDevice } = useInputMode();
   const isDraggingOver = ref(false);
@@ -370,13 +366,9 @@ export function useFileDragDrop() {
 
       // Refresh the current path to show the changes
       await fileStore.fetchPathItems(fileStore.currentPath);
-      volumeUsageStore.scheduleRefresh();
-      folderSizeStore.scheduleRefresh();
     } catch (error) {
       if (error?.name === 'AbortError' || /aborted/i.test(error?.message || '')) {
         await fileStore.fetchPathItems(fileStore.currentPath);
-        volumeUsageStore.scheduleRefresh();
-        folderSizeStore.scheduleRefresh();
         return;
       }
       console.error(`Failed to ${copy ? 'copy' : 'move'} items:`, error);

--- a/frontend/src/composables/useFileDragDrop.js
+++ b/frontend/src/composables/useFileDragDrop.js
@@ -6,6 +6,13 @@ import { copyItems, moveItems, normalizePath } from '@/api';
 import { useInputMode } from '@/composables/useInputMode';
 import { useOperationTasksStore } from '@/stores/operationTasks';
 
+// A drag can cross from the file view into the sidebar, where a different
+// composable instance handles dragover. Keep the preview state module-wide so
+// Option/Alt can still update the same drag image in either destination.
+let activeDragImage = null;
+let activeDragOverlay = null;
+let dragDropHandled = false;
+
 /**
  * Composable for handling file and folder drag and drop operations.
  * Desktop only - will not work on touch devices.
@@ -95,19 +102,34 @@ export function useFileDragDrop() {
     event.dataTransfer.setData('application/json', dragData);
     // Safari is inconsistent about exposing custom types during dragover/drop, so add a fallback.
     event.dataTransfer.setData('text/plain', dragData);
-    event.dataTransfer.effectAllowed = 'copyMove';
+    // Keep the native cursor in move mode. The actual copy behavior is decided
+    // by Option/Alt when dropping, while the application preview shows the +.
+    event.dataTransfer.effectAllowed = 'move';
 
-    // Create custom drag image with badge
-    createDragImage(event, itemsToDrag, item);
+    const copy = isCopyModifierPressed(event);
+    activeDragImage = {
+      items: itemsToDrag,
+      primaryItem: item,
+      sourceEl: event.currentTarget,
+      copy,
+    };
+    dragDropHandled = false;
+
+    // The browser only applies setDragImage during dragstart. Use a transparent
+    // native image, then keep the visible preview under our own control so the
+    // copy badge can change immediately when Option/Alt is pressed.
+    setNativeDragPlaceholder(event);
+    renderDragOverlay(activeDragImage, event);
   };
 
   /**
-   * Create a custom drag image with a badge showing the number of items
-   * @param {DragEvent} event - The drag event
-   * @param {Array} items - Items being dragged
-   * @param {Object} primaryItem - The main item being dragged (under cursor)
+   * Build the visible drag preview with operation and item-count badges.
+   * @param {Object} state - Source items, primary item and active operation
    */
-  const createDragImage = (event, items, primaryItem) => {
+  const buildDragPreview = (state) => {
+    if (!state) return null;
+
+    const { items, primaryItem, sourceEl, copy } = state;
     const count = items.length;
     const dragImage = document.createElement('div');
     dragImage.className = 'file-drag-image';
@@ -117,9 +139,12 @@ export function useFileDragDrop() {
     const stackDepth = Math.min(count, 3);
 
     let iconNode = null;
-    const sourceEl = event.currentTarget;
     if (sourceEl) {
-      const foundIcon = sourceEl.querySelector('svg') || sourceEl.querySelector('.bg-contain');
+      const foundIcon =
+        sourceEl.querySelector('.block.aspect-square svg') ||
+        sourceEl.querySelector('.block.aspect-square') ||
+        sourceEl.querySelector('svg') ||
+        sourceEl.querySelector('.bg-contain');
       if (foundIcon) {
         iconNode = foundIcon.cloneNode(true);
         iconNode.style.width = '24px';
@@ -159,21 +184,72 @@ export function useFileDragDrop() {
     }
 
     dragImage.appendChild(stack);
+    const badges = document.createElement('div');
+    badges.className = 'file-drag-badges';
+    if (copy) {
+      const copyBadge = document.createElement('div');
+      copyBadge.className = 'file-drag-copy-badge';
+      copyBadge.textContent = '+';
+      badges.appendChild(copyBadge);
+    }
     const badge = document.createElement('div');
     badge.className = 'file-drag-badge';
     badge.textContent = count.toString();
+    badges.appendChild(badge);
+    dragImage.appendChild(badges);
+    return dragImage;
+  };
 
-    dragImage.appendChild(badge);
-    document.body.appendChild(dragImage);
+  const clearDragOverlay = () => {
+    activeDragOverlay?.remove();
+    activeDragOverlay = null;
+  };
 
-    const xOffset = -10;
-    const yOffset = 10;
+  const positionDragOverlay = (event) => {
+    const x = Number(event?.clientX);
+    const y = Number(event?.clientY);
+    // Some browsers emit a final drag event with 0,0. Do not reveal the
+    // preview there or it flashes in the top-left corner of the viewport.
+    if (!activeDragOverlay || !Number.isFinite(x) || !Number.isFinite(y) || (x === 0 && y === 0)) {
+      return;
+    }
+    // Match the former native drag-image anchor: the pointer stays aligned
+    // with the preview rather than leaving it noticeably below the cursor.
+    activeDragOverlay.style.transform = `translate3d(${x + 10}px, ${y - 10}px, 0)`;
+    activeDragOverlay.style.visibility = 'visible';
+  };
 
-    event.dataTransfer.setDragImage(dragImage, xOffset, yOffset);
+  const renderDragOverlay = (state, event) => {
+    clearDragOverlay();
+    activeDragOverlay = buildDragPreview(state);
+    if (!activeDragOverlay) return;
+    activeDragOverlay.style.visibility = 'hidden';
+    document.body.appendChild(activeDragOverlay);
+    positionDragOverlay(event);
+  };
 
-    setTimeout(() => {
-      document.body.removeChild(dragImage);
-    }, 100);
+  const setNativeDragPlaceholder = (event) => {
+    if (typeof event?.dataTransfer?.setDragImage !== 'function') return;
+    const placeholder = document.createElement('div');
+    placeholder.className = 'file-drag-native-placeholder';
+    document.body.appendChild(placeholder);
+    event.dataTransfer.setDragImage(placeholder, 0, 0);
+    setTimeout(() => placeholder.remove(), 0);
+  };
+
+  const updateDragPreviewOperation = (event, copy) => {
+    if (!activeDragImage) return;
+    if (activeDragImage.copy === copy) {
+      positionDragOverlay(event);
+      return;
+    }
+    activeDragImage = { ...activeDragImage, copy };
+    renderDragOverlay(activeDragImage, event);
+  };
+
+  const handleDragMove = (event) => {
+    if (!canDragDrop() || !activeDragImage) return;
+    updateDragPreviewOperation(event, isCopyModifierPressed(event));
   };
 
   /**
@@ -189,7 +265,10 @@ export function useFileDragDrop() {
 
     event.preventDefault();
     const copy = isCopyModifierPressed(event);
-    event.dataTransfer.dropEffect = copy ? 'copy' : 'move';
+    // Avoid the macOS copy cursor. The green badge in the preview remains the
+    // sole operation indicator and the drop still performs a copy when Alt is held.
+    event.dataTransfer.dropEffect = 'move';
+    updateDragPreviewOperation(event, copy);
 
     // Store the target folder for drag leave/drop handling
     dragOverTarget.value = targetFolder;
@@ -237,7 +316,11 @@ export function useFileDragDrop() {
     event.preventDefault();
     event.stopPropagation();
 
-    const copy = isCopyModifierPressed(event) || event.dataTransfer.dropEffect === 'copy';
+    const copy = isCopyModifierPressed(event);
+    updateDragPreviewOperation(event, copy);
+    dragDropHandled = true;
+    clearDragOverlay();
+    activeDragImage = null;
     isDraggingOver.value = false;
     dragOverTarget.value = null;
     dragOperation.value = 'move';
@@ -257,6 +340,13 @@ export function useFileDragDrop() {
 
     // Get the destination path (target folder's full relative path)
     const destination = resolveFolderDestination(targetFolder);
+
+    // Moving an item into its own parent does nothing. Copying there is useful
+    // though: it creates the usual "(1)", "(2)" duplicate in the current folder.
+    const isCurrentFolderDestination = draggedItems.every(
+      (item) => normalizePath(item.path || '') === destination
+    );
+    if (isCurrentFolderDestination && !copy) return;
 
     // Validate: prevent dropping a folder into itself
     const isSelfDrop = draggedItems.some(
@@ -340,6 +430,22 @@ export function useFileDragDrop() {
   };
 
   const handleDragEnd = () => {
+    if (!dragDropHandled && activeDragOverlay && activeDragImage?.sourceEl) {
+      const overlay = activeDragOverlay;
+      const sourceRect = activeDragImage.sourceEl.getBoundingClientRect();
+      overlay.style.transition = 'transform 140ms ease-out, opacity 140ms ease-out';
+      window.requestAnimationFrame(() => {
+        overlay.style.transform = `translate3d(${sourceRect.left}px, ${sourceRect.top}px, 0) scale(0.85)`;
+        overlay.style.opacity = '0';
+      });
+      window.setTimeout(() => {
+        if (activeDragOverlay === overlay) clearDragOverlay();
+      }, 150);
+    } else {
+      clearDragOverlay();
+    }
+    activeDragImage = null;
+    dragDropHandled = false;
     isDraggingOver.value = false;
     dragOverTarget.value = null;
     dragOperation.value = 'move';
@@ -361,6 +467,7 @@ export function useFileDragDrop() {
     isDraggingOver,
     canDragDrop,
     handleDragStart,
+    handleDragMove,
     handleDragOver,
     handleDragLeave,
     handleDrop,

--- a/frontend/src/composables/useFileDragDrop.spec.js
+++ b/frontend/src/composables/useFileDragDrop.spec.js
@@ -126,7 +126,7 @@ describe('useFileDragDrop', () => {
     );
   });
 
-  it('keeps the copy badge attached to the application drag preview', () => {
+  it('keeps the copy badge aligned with the native drag preview', () => {
     vi.useFakeTimers();
     const dragDrop = useFileDragDrop();
     const source = document.createElement('div');
@@ -155,14 +155,14 @@ describe('useFileDragDrop', () => {
       target
     );
 
-    const preview = document.querySelector('.file-drag-image');
-    const badges = preview?.querySelector('.file-drag-badges');
+    const copyBadge = document.querySelector('.file-drag-copy-overlay');
     expect(dataTransfer.setDragImage).toHaveBeenCalledTimes(1);
-    expect(badges?.textContent).toBe('+1');
-    expect(preview?.style.transform).toBe('translate3d(150px, 250px, 0)');
+    expect(copyBadge?.textContent).toBe('+');
+    expect(copyBadge?.style.transform).toBe('translate3d(294px, 246px, 0)');
 
     dragDrop.handleDragEnd();
-    vi.advanceTimersByTime(150);
+    expect(document.querySelector('.file-drag-copy-overlay')).toBeNull();
+    vi.advanceTimersByTime(100);
     expect(document.querySelector('.file-drag-image')).toBeNull();
     vi.useRealTimers();
     source.remove();
@@ -180,5 +180,37 @@ describe('useFileDragDrop', () => {
       expect.any(Object)
     );
     expect(moveItems).not.toHaveBeenCalled();
+  });
+
+  it('keeps the copy operation when the terminal drop event omits Option/Alt', async () => {
+    const dragDrop = useFileDragDrop();
+    const source = document.createElement('div');
+    const dataTransfer = {
+      setData: vi.fn(),
+      setDragImage: vi.fn(),
+      effectAllowed: '',
+      types: ['application/json', 'text/plain'],
+      dropEffect: 'move',
+      getData: vi.fn((type) =>
+        type === 'application/json' ? JSON.stringify([item]) : ''
+      ),
+    };
+
+    document.body.appendChild(source);
+    dragDrop.handleDragStart({ altKey: false, currentTarget: source, dataTransfer }, item);
+    dragDrop.handleDragOver({ altKey: true, preventDefault: vi.fn(), dataTransfer }, target);
+
+    await dragDrop.handleDrop(
+      { altKey: false, preventDefault: vi.fn(), stopPropagation: vi.fn(), dataTransfer },
+      target
+    );
+
+    expect(copyItems).toHaveBeenCalledWith(
+      [{ name: 'report.txt', path: 'Source', kind: 'file' }],
+      'Volume/Target',
+      expect.any(Object)
+    );
+    expect(moveItems).not.toHaveBeenCalled();
+    source.remove();
   });
 });

--- a/frontend/src/composables/useFileDragDrop.spec.js
+++ b/frontend/src/composables/useFileDragDrop.spec.js
@@ -4,8 +4,6 @@ import { ref } from 'vue';
 const copyItems = vi.fn();
 const moveItems = vi.fn();
 const fetchPathItems = vi.fn();
-const scheduleUsageRefresh = vi.fn();
-const scheduleFolderRefresh = vi.fn();
 const startOperation = vi.fn(() => 'operation-test');
 const updateOperation = vi.fn();
 const finishOperation = vi.fn();
@@ -23,12 +21,6 @@ vi.mock('@/api', () => ({
 }));
 
 vi.mock('@/stores/fileStore', () => ({ useFileStore: () => fileStore }));
-vi.mock('@/stores/volumeUsage', () => ({
-  useVolumeUsageStore: () => ({ scheduleRefresh: scheduleUsageRefresh }),
-}));
-vi.mock('@/stores/folderSize', () => ({
-  useFolderSizeStore: () => ({ scheduleRefresh: scheduleFolderRefresh }),
-}));
 vi.mock('@/stores/operationTasks', () => ({
   useOperationTasksStore: () => ({ startOperation, updateOperation, finishOperation }),
 }));
@@ -64,8 +56,6 @@ describe('useFileDragDrop', () => {
     copyItems.mockReset();
     moveItems.mockReset();
     fetchPathItems.mockReset();
-    scheduleUsageRefresh.mockReset();
-    scheduleFolderRefresh.mockReset();
     startOperation.mockClear();
     updateOperation.mockReset();
     finishOperation.mockReset();

--- a/frontend/src/composables/useFileDragDrop.spec.js
+++ b/frontend/src/composables/useFileDragDrop.spec.js
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+
+const copyItems = vi.fn();
+const moveItems = vi.fn();
+const fetchPathItems = vi.fn();
+const scheduleUsageRefresh = vi.fn();
+const scheduleFolderRefresh = vi.fn();
+const startOperation = vi.fn(() => 'operation-test');
+const updateOperation = vi.fn();
+const finishOperation = vi.fn();
+
+const fileStore = {
+  currentPath: 'Source',
+  selectedItems: [],
+  fetchPathItems,
+};
+
+vi.mock('@/api', () => ({
+  copyItems: (...args) => copyItems(...args),
+  moveItems: (...args) => moveItems(...args),
+  normalizePath: (value = '') => value.replace(/^\/+|\/+$/g, ''),
+}));
+
+vi.mock('@/stores/fileStore', () => ({ useFileStore: () => fileStore }));
+vi.mock('@/stores/volumeUsage', () => ({
+  useVolumeUsageStore: () => ({ scheduleRefresh: scheduleUsageRefresh }),
+}));
+vi.mock('@/stores/folderSize', () => ({
+  useFolderSizeStore: () => ({ scheduleRefresh: scheduleFolderRefresh }),
+}));
+vi.mock('@/stores/operationTasks', () => ({
+  useOperationTasksStore: () => ({ startOperation, updateOperation, finishOperation }),
+}));
+vi.mock('@/composables/useInputMode', () => ({
+  useInputMode: () => ({ isTouchDevice: ref(false) }),
+}));
+
+import { useFileDragDrop } from '@/composables/useFileDragDrop';
+
+const item = { name: 'report.txt', path: 'Source', kind: 'file' };
+const target = { name: 'Target', path: 'Volume', kind: 'directory' };
+
+const transferEvent = (overrides = {}) => {
+  const payload = JSON.stringify([item]);
+  const dataTransfer = {
+    types: ['application/json', 'text/plain'],
+    dropEffect: 'move',
+    getData: vi.fn((type) => (type === 'application/json' ? payload : '')),
+    ...overrides.dataTransfer,
+  };
+
+  return {
+    altKey: false,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    dataTransfer,
+    ...overrides,
+  };
+};
+
+describe('useFileDragDrop', () => {
+  beforeEach(() => {
+    copyItems.mockReset();
+    moveItems.mockReset();
+    fetchPathItems.mockReset();
+    scheduleUsageRefresh.mockReset();
+    scheduleFolderRefresh.mockReset();
+    startOperation.mockClear();
+    updateOperation.mockReset();
+    finishOperation.mockReset();
+    copyItems.mockResolvedValue({});
+    moveItems.mockResolvedValue({});
+  });
+
+  it('uses copy for an Option/Alt drop and exposes the copy target state', async () => {
+    const dragDrop = useFileDragDrop();
+    const event = transferEvent({ altKey: true });
+
+    dragDrop.handleDragOver(event, target);
+    expect(event.dataTransfer.dropEffect).toBe('copy');
+    expect(dragDrop.isCopyDragTarget(target)).toBe(true);
+
+    await dragDrop.handleDrop(event, target);
+
+    expect(copyItems).toHaveBeenCalledWith(
+      [{ name: 'report.txt', path: 'Source', kind: 'file' }],
+      'Volume/Target',
+      expect.objectContaining({ onEvent: expect.any(Function), signal: expect.any(AbortSignal) })
+    );
+    expect(moveItems).not.toHaveBeenCalled();
+    expect(startOperation).toHaveBeenCalledWith(expect.objectContaining({ type: 'copy' }));
+    expect(finishOperation).toHaveBeenCalledWith('operation-test');
+  });
+
+  it('moves by default', async () => {
+    const dragDrop = useFileDragDrop();
+    const event = transferEvent();
+
+    await dragDrop.handleDrop(event, target);
+
+    expect(moveItems).toHaveBeenCalledWith(
+      [{ name: 'report.txt', path: 'Source', kind: 'file' }],
+      'Volume/Target',
+      expect.objectContaining({ onEvent: expect.any(Function), signal: expect.any(AbortSignal) })
+    );
+    expect(copyItems).not.toHaveBeenCalled();
+    expect(startOperation).toHaveBeenCalledWith(expect.objectContaining({ type: 'move' }));
+  });
+
+  it('uses a favorite destination path instead of its display label', async () => {
+    const dragDrop = useFileDragDrop();
+    const event = transferEvent();
+    const favoriteTarget = {
+      name: 'Inbox',
+      path: 'Volume',
+      destinationPath: 'Volume/Incoming',
+    };
+
+    await dragDrop.handleDrop(event, favoriteTarget);
+
+    expect(moveItems).toHaveBeenCalledWith(
+      [{ name: 'report.txt', path: 'Source', kind: 'file' }],
+      'Volume/Incoming',
+      expect.any(Object)
+    );
+  });
+});

--- a/frontend/src/composables/useFileDragDrop.spec.js
+++ b/frontend/src/composables/useFileDragDrop.spec.js
@@ -158,7 +158,7 @@ describe('useFileDragDrop', () => {
     const copyBadge = document.querySelector('.file-drag-copy-overlay');
     expect(dataTransfer.setDragImage).toHaveBeenCalledTimes(1);
     expect(copyBadge?.textContent).toBe('+');
-    expect(copyBadge?.style.transform).toBe('translate3d(294px, 246px, 0)');
+    expect(copyBadge?.style.transform).toBe('translate3d(350px, 258px, 0)');
 
     dragDrop.handleDragEnd();
     expect(document.querySelector('.file-drag-copy-overlay')).toBeNull();
@@ -210,6 +210,35 @@ describe('useFileDragDrop', () => {
       'Volume/Target',
       expect.any(Object)
     );
+    expect(moveItems).not.toHaveBeenCalled();
+    source.remove();
+  });
+
+  it('does not let a source drag event cancel the copy selected over a destination', async () => {
+    const dragDrop = useFileDragDrop();
+    const source = document.createElement('div');
+    const dataTransfer = {
+      setData: vi.fn(),
+      setDragImage: vi.fn(),
+      effectAllowed: '',
+      types: ['application/json', 'text/plain'],
+      dropEffect: 'move',
+      getData: vi.fn((type) =>
+        type === 'application/json' ? JSON.stringify([item]) : ''
+      ),
+    };
+
+    document.body.appendChild(source);
+    dragDrop.handleDragStart({ altKey: false, currentTarget: source, dataTransfer }, item);
+    dragDrop.handleDragOver({ altKey: true, preventDefault: vi.fn(), dataTransfer }, target);
+    dragDrop.handleDragMove({ altKey: false, clientX: 120, clientY: 160 });
+
+    await dragDrop.handleDrop(
+      { altKey: false, preventDefault: vi.fn(), stopPropagation: vi.fn(), dataTransfer },
+      target
+    );
+
+    expect(copyItems).toHaveBeenCalledTimes(1);
     expect(moveItems).not.toHaveBeenCalled();
     source.remove();
   });

--- a/frontend/src/composables/useFileDragDrop.spec.js
+++ b/frontend/src/composables/useFileDragDrop.spec.js
@@ -78,7 +78,7 @@ describe('useFileDragDrop', () => {
     const event = transferEvent({ altKey: true });
 
     dragDrop.handleDragOver(event, target);
-    expect(event.dataTransfer.dropEffect).toBe('move');
+    expect(event.dataTransfer.dropEffect).toBe('copy');
     expect(dragDrop.isCopyDragTarget(target)).toBe(true);
 
     await dragDrop.handleDrop(event, target);
@@ -126,7 +126,7 @@ describe('useFileDragDrop', () => {
     );
   });
 
-  it('keeps the copy badge aligned with the native drag preview', () => {
+  it('uses a native copy operation while keeping the native drag preview', () => {
     vi.useFakeTimers();
     const dragDrop = useFileDragDrop();
     const source = document.createElement('div');
@@ -155,13 +155,11 @@ describe('useFileDragDrop', () => {
       target
     );
 
-    const copyBadge = document.querySelector('.file-drag-copy-overlay');
     expect(dataTransfer.setDragImage).toHaveBeenCalledTimes(1);
-    expect(copyBadge?.textContent).toBe('+');
-    expect(copyBadge?.style.transform).toBe('translate3d(350px, 258px, 0)');
+    expect(dataTransfer.effectAllowed).toBe('copyMove');
+    expect(dataTransfer.dropEffect).toBe('copy');
 
     dragDrop.handleDragEnd();
-    expect(document.querySelector('.file-drag-copy-overlay')).toBeNull();
     vi.advanceTimersByTime(100);
     expect(document.querySelector('.file-drag-image')).toBeNull();
     vi.useRealTimers();
@@ -214,32 +212,4 @@ describe('useFileDragDrop', () => {
     source.remove();
   });
 
-  it('does not let a source drag event cancel the copy selected over a destination', async () => {
-    const dragDrop = useFileDragDrop();
-    const source = document.createElement('div');
-    const dataTransfer = {
-      setData: vi.fn(),
-      setDragImage: vi.fn(),
-      effectAllowed: '',
-      types: ['application/json', 'text/plain'],
-      dropEffect: 'move',
-      getData: vi.fn((type) =>
-        type === 'application/json' ? JSON.stringify([item]) : ''
-      ),
-    };
-
-    document.body.appendChild(source);
-    dragDrop.handleDragStart({ altKey: false, currentTarget: source, dataTransfer }, item);
-    dragDrop.handleDragOver({ altKey: true, preventDefault: vi.fn(), dataTransfer }, target);
-    dragDrop.handleDragMove({ altKey: false, clientX: 120, clientY: 160 });
-
-    await dragDrop.handleDrop(
-      { altKey: false, preventDefault: vi.fn(), stopPropagation: vi.fn(), dataTransfer },
-      target
-    );
-
-    expect(copyItems).toHaveBeenCalledTimes(1);
-    expect(moveItems).not.toHaveBeenCalled();
-    source.remove();
-  });
 });

--- a/frontend/src/composables/useFileDragDrop.spec.js
+++ b/frontend/src/composables/useFileDragDrop.spec.js
@@ -78,7 +78,7 @@ describe('useFileDragDrop', () => {
     const event = transferEvent({ altKey: true });
 
     dragDrop.handleDragOver(event, target);
-    expect(event.dataTransfer.dropEffect).toBe('copy');
+    expect(event.dataTransfer.dropEffect).toBe('move');
     expect(dragDrop.isCopyDragTarget(target)).toBe(true);
 
     await dragDrop.handleDrop(event, target);
@@ -124,5 +124,61 @@ describe('useFileDragDrop', () => {
       'Volume/Incoming',
       expect.any(Object)
     );
+  });
+
+  it('keeps the copy badge attached to the application drag preview', () => {
+    vi.useFakeTimers();
+    const dragDrop = useFileDragDrop();
+    const source = document.createElement('div');
+    source.innerHTML = '<span class="block aspect-square"><svg></svg></span>';
+    document.body.appendChild(source);
+    const dataTransfer = {
+      setData: vi.fn(),
+      setDragImage: vi.fn(),
+      effectAllowed: '',
+      types: ['application/json'],
+      dropEffect: 'move',
+    };
+
+    dragDrop.handleDragStart(
+      { altKey: false, clientX: 100, clientY: 200, currentTarget: source, dataTransfer },
+      item
+    );
+    dragDrop.handleDragOver(
+      {
+        altKey: true,
+        clientX: 140,
+        clientY: 260,
+        preventDefault: vi.fn(),
+        dataTransfer,
+      },
+      target
+    );
+
+    const preview = document.querySelector('.file-drag-image');
+    const badges = preview?.querySelector('.file-drag-badges');
+    expect(dataTransfer.setDragImage).toHaveBeenCalledTimes(1);
+    expect(badges?.textContent).toBe('+1');
+    expect(preview?.style.transform).toBe('translate3d(150px, 250px, 0)');
+
+    dragDrop.handleDragEnd();
+    vi.advanceTimersByTime(150);
+    expect(document.querySelector('.file-drag-image')).toBeNull();
+    vi.useRealTimers();
+    source.remove();
+  });
+
+  it('copies into the current folder when Option/Alt is held', async () => {
+    const dragDrop = useFileDragDrop();
+    const event = transferEvent({ altKey: true });
+
+    await dragDrop.handleDrop(event, { destinationPath: 'Source', kind: 'directory' });
+
+    expect(copyItems).toHaveBeenCalledWith(
+      [{ name: 'report.txt', path: 'Source', kind: 'file' }],
+      'Source',
+      expect.any(Object)
+    );
+    expect(moveItems).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Kopieren von {count} {items}…",
     "moving": "Verschieben von {count} {items}…",
-    "working": "Wird verarbeitet…"
+    "working": "Wird verarbeitet…",
+    "reposition": "Nach Abschluss zum Element zurückkehren"
   },
   "upload": {
     "toggleDetailsShow": "Details anzeigen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -96,7 +96,7 @@
     "rename": "Rename",
     "download": "Download",
     "downloadFolder": "Download folder",
-    "extractZip": "Extract ZIP",
+    "extractArchive": "Extract archive",
     "compressToZip": "Compress to ZIP",
     "search": "Search",
     "sortBy": "Sort by",
@@ -302,7 +302,11 @@
     "copying": "Copying {count} {items}…",
     "moving": "Moving {count} {items}…",
     "working": "Working…",
-    "reposition": "Return to the item when done"
+    "copyingUnknown": "Copying…",
+    "movingUnknown": "Moving…",
+    "activeTasks": "{count} operations in progress",
+    "extracting": "Extracting {name}…",
+    "compressing": "Compressing {name}…"
   },
   "upload": {
     "toggleDetailsShow": "Show details",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -301,7 +301,8 @@
   "clipboard": {
     "copying": "Copying {count} {items}…",
     "moving": "Moving {count} {items}…",
-    "working": "Working…"
+    "working": "Working…",
+    "reposition": "Return to the item when done"
   },
   "upload": {
     "toggleDetailsShow": "Show details",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Copiando {count} {items}…",
     "moving": "Moviendo {count} {items}…",
-    "working": "Procesando…"
+    "working": "Procesando…",
+    "reposition": "Volver al elemento al terminar"
   },
   "upload": {
     "toggleDetailsShow": "Mostrar detalles",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -96,7 +96,7 @@
     "rename": "Renommer",
     "download": "Télécharger",
     "downloadFolder": "Télécharger le dossier",
-    "extractZip": "Extraire ZIP",
+    "extractArchive": "Extraire l'archive",
     "compressToZip": "Compresser en ZIP",
     "search": "Rechercher",
     "sortBy": "Trier par",
@@ -302,7 +302,11 @@
     "copying": "Copie de {count} {items}…",
     "moving": "Déplacement de {count} {items}…",
     "working": "Traitement…",
-    "reposition": "Revenir sur l'élément à la fin"
+    "copyingUnknown": "Copie en cours…",
+    "movingUnknown": "Déplacement en cours…",
+    "activeTasks": "{count} opérations en cours",
+    "extracting": "Extraction de {name}…",
+    "compressing": "Compression de {name}…"
   },
   "upload": {
     "toggleDetailsShow": "Afficher les détails",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -301,7 +301,8 @@
   "clipboard": {
     "copying": "Copie de {count} {items}…",
     "moving": "Déplacement de {count} {items}…",
-    "working": "Traitement…"
+    "working": "Traitement…",
+    "reposition": "Revenir sur l'élément à la fin"
   },
   "upload": {
     "toggleDetailsShow": "Afficher les détails",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "{count} {items} कॉपी किए जा रहे हैं…",
     "moving": "{count} {items} स्थानांतरित किए जा रहे हैं…",
-    "working": "प्रक्रिया जारी है…"
+    "working": "प्रक्रिया जारी है…",
+    "reposition": "पूरा होने पर आइटम पर लौटें"
   },
   "upload": {
     "toggleDetailsShow": "विवरण दिखाएँ",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Copia di {count} {items}…",
     "moving": "Spostamento di {count} {items}…",
-    "working": "In corso…"
+    "working": "In corso…",
+    "reposition": "Torna all'elemento al termine"
   },
   "upload": {
     "toggleDetailsShow": "Mostra dettagli",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "{count}개 {items} 복사 중…",
     "moving": "{count}개 {items} 이동 중…",
-    "working": "처리 중…"
+    "working": "처리 중…",
+    "reposition": "완료 후 항목으로 돌아가기"
   },
   "upload": {
     "toggleDetailsShow": "상세 정보 보기",

--- a/frontend/src/i18n/locales/pl.json
+++ b/frontend/src/i18n/locales/pl.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Kopiowanie {count} {items}…",
     "moving": "Przenoszenie {count} {items}…",
-    "working": "Przetwarzanie…"
+    "working": "Przetwarzanie…",
+    "reposition": "Wróć do elementu po zakończeniu"
   },
   "upload": {
     "toggleDetailsShow": "Pokaż szczegóły",

--- a/frontend/src/i18n/locales/ro.json
+++ b/frontend/src/i18n/locales/ro.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Se copiază {count} {items}…",
     "moving": "Se mută {count} {items}…",
-    "working": "În lucru…"
+    "working": "În lucru…",
+    "reposition": "Revino la element la final"
   },
   "upload": {
     "toggleDetailsShow": "Afișează detalii",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Копирование {count} {items}…",
     "moving": "Перемещение {count} {items}…",
-    "working": "Обработка…"
+    "working": "Обработка…",
+    "reposition": "Вернуться к объекту по завершении"
   },
   "upload": {
     "toggleDetailsShow": "Показать детали",

--- a/frontend/src/i18n/locales/sv.json
+++ b/frontend/src/i18n/locales/sv.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "Kopierar {count} {items}…",
     "moving": "Flyttar {count} {items}…",
-    "working": "Arbetar…"
+    "working": "Arbetar…",
+    "reposition": "Återgå till objektet när det är klart"
   },
   "upload": {
     "toggleDetailsShow": "Visa detaljer",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "正在复制 {count} 个{items}…",
     "moving": "正在移动 {count} 个{items}…",
-    "working": "处理中…"
+    "working": "处理中…",
+    "reposition": "完成后返回该项目"
   },
   "upload": {
     "toggleDetailsShow": "显示详细信息",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -294,7 +294,8 @@
   "clipboard": {
     "copying": "正在複製 {count} 個{items}…",
     "moving": "正在移動 {count} 個{items}…",
-    "working": "處理中…"
+    "working": "處理中…",
+    "reposition": "完成後返回該項目"
   },
   "upload": {
     "toggleDetailsShow": "顯示詳細資訊",

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -1,7 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { useStorage } from '@vueuse/core';
-import router from '@/router';
 import {
   browse,
   copyItems,
@@ -19,6 +18,7 @@ import {
 import { useSettingsStore } from '@/stores/settings';
 import { useAppSettings } from '@/stores/appSettings';
 import { useFavoritesStore } from '@/stores/favorites';
+import { useOperationTasksStore } from '@/stores/operationTasks';
 
 export const useFileStore = defineStore('fileStore', () => {
   // State
@@ -29,17 +29,11 @@ export const useFileStore = defineStore('fileStore', () => {
   const selectionMode = ref(false);
   const renameState = ref(null);
 
-  const clipboardOperation = ref(null);
-  const deleteOperation = ref(null);
   const favoritesStore = useFavoritesStore();
+  const operationTasksStore = useOperationTasksStore();
 
   const copiedItems = useStorage('nextExplorer_clipboard_copied', []);
   const cutItems = useStorage('nextExplorer_clipboard_cut', []);
-  // When true, a finished copy/move re-focuses the pasted entry in its destination
-  // folder (navigating there via the router so the address bar stays in sync).
-  // When false, the current view is left untouched — handy for launching a long
-  // transfer and continuing to browse elsewhere. Persisted across sessions.
-  const repositionAfterTransfer = useStorage('nextExplorer_paste_reposition', true);
   const thumbnailRequests = new Map();
 
   const hasSelection = computed(() => selectedItems.value.length > 0);
@@ -119,131 +113,42 @@ export const useFileStore = defineStore('fileStore', () => {
     cutItems.value = selectedItems.value.map((item) => ({ ...item }));
   };
 
-  // Final name of a copied/moved entry, from its destination-relative path.
-  const transferredBaseName = (relativePath) => {
-    const normalized = normalizePath(relativePath || '');
-    const idx = normalized.lastIndexOf('/');
-    return idx >= 0 ? normalized.slice(idx + 1) : normalized;
-  };
-
-  // Collect the final entry names from a streamed transfer result ({ items:[{ to }] }).
-  const collectTransferredNames = (result, out) => {
-    const items = Array.isArray(result?.items) ? result.items : [];
-    for (const entry of items) {
-      const name = transferredBaseName(entry?.to);
-      if (name) out.push(name);
-    }
-  };
-
-  const selectItemsByName = (names) => {
-    const wanted = new Set((names || []).filter(Boolean));
-    if (wanted.size === 0) return;
-    const matches = currentPathItems.value.filter((it) => it && wanted.has(it.name));
-    if (matches.length > 0) {
-      selectedItems.value = matches;
-    }
-  };
-
-  // Refresh the view (and optionally reposition) once a copy/move settles. The
-  // address bar is driven by the router, so "repositioning" navigates through the
-  // router to keep the URL/breadcrumb in sync with the listing. When repositioning
-  // is disabled we only refresh the folder the user is *currently* viewing (which
-  // always matches the route), so navigating away mid-transfer is never disrupted.
-  const settleAfterTransfer = async (finalDestination, moveSourceParents, pastedNames) => {
-    const userLocation = normalizePath(currentPath.value || '');
-    const onDestination = userLocation === finalDestination;
-
-    if (repositionAfterTransfer.value) {
-      if (onDestination || !finalDestination) {
-        // Already at the destination (or destination is the root, which has no
-        // routable path): refresh in place and highlight the result. The address
-        // bar is already correct, so no navigation is needed.
-        await fetchPathItems(userLocation);
-        selectItemsByName(pastedNames);
-      } else {
-        // Elsewhere (navigated away, or pasted into another folder): navigate to
-        // the destination and select the entry, which also updates the address bar.
-        const firstName = pastedNames[0];
-        router
-          .push({
-            name: 'FolderView',
-            params: { path: finalDestination },
-            ...(firstName ? { query: { select: firstName } } : {}),
-          })
-          .catch(() => {});
-      }
-      return;
-    }
-
-    // Repositioning disabled: leave the user where they are. Refresh only when the
-    // current folder was actually affected (it is the destination, or a move source
-    // that just lost entries) so its listing stays accurate without any view jump.
-    if (onDestination || moveSourceParents.has(userLocation)) {
-      await fetchPathItems(userLocation);
-    }
-  };
-
   const paste = async (targetPath) => {
     const hasTarget = typeof targetPath === 'string' && targetPath.trim().length > 0;
     const destination = normalizePath(hasTarget ? targetPath : currentPath.value || '');
+    const refreshTarget = normalizePath(currentPath.value || '');
 
     const copyPayload = serializeItems(copiedItems.value);
     const movePayload = serializeItems(cutItems.value);
-    const moveSourceParents = new Set(
-      movePayload.map((item) => normalizePath(item.path || ''))
-    );
     const totalCount = copyPayload.length + movePayload.length;
 
-    if (totalCount > 0) {
-      clipboardOperation.value = {
-        type: movePayload.length > 0 && copyPayload.length === 0 ? 'move' : 'copy',
-        destination,
-        itemCount: totalCount,
-        startedAt: Date.now(),
-        totalBytes: 0,
-        copiedBytes: 0,
-      };
-    }
-
-    // Fold streamed transfer events into the reactive operation so the progress
-    // bar tracks real bytes copied against the pre-computed total.
-    const onTransferEvent = (event) => {
-      const op = clipboardOperation.value;
-      if (!op || !event) return;
-      if (event.type === 'start') {
-        op.totalBytes = Number(event.totalBytes) || 0;
-        op.copiedBytes = 0;
-      } else if (event.type === 'progress') {
-        if (event.totalBytes != null) op.totalBytes = Number(event.totalBytes) || 0;
-        op.copiedBytes = Number(event.copiedBytes) || 0;
-      }
-    };
+    const operationId =
+      totalCount > 0
+        ? operationTasksStore.startOperation({
+            type: movePayload.length > 0 && copyPayload.length === 0 ? 'move' : 'copy',
+            destination,
+            itemCount: totalCount,
+          })
+        : null;
 
     try {
-      const pastedNames = [];
-      let finalDestination = destination;
-
       if (copiedItems.value.length > 0) {
         if (copyPayload.length > 0) {
-          const result = await copyItems(copyPayload, destination, { onEvent: onTransferEvent });
-          collectTransferredNames(result, pastedNames);
-          if (result?.destination != null) finalDestination = normalizePath(result.destination);
+          await copyItems(copyPayload, destination);
         }
         copiedItems.value = [];
       }
 
       if (cutItems.value.length > 0) {
         if (movePayload.length > 0) {
-          const result = await moveItems(movePayload, destination, { onEvent: onTransferEvent });
-          collectTransferredNames(result, pastedNames);
-          if (result?.destination != null) finalDestination = normalizePath(result.destination);
+          await moveItems(movePayload, destination);
         }
         cutItems.value = [];
       }
 
-      await settleAfterTransfer(finalDestination, moveSourceParents, pastedNames);
+      await fetchPathItems(refreshTarget);
     } finally {
-      clipboardOperation.value = null;
+      if (operationId) operationTasksStore.finishOperation(operationId);
     }
   };
 
@@ -251,11 +156,10 @@ export const useFileStore = defineStore('fileStore', () => {
     const payload = serializeItems(selectedItems.value);
     if (payload.length === 0) return;
 
-    deleteOperation.value = {
+    const operationId = operationTasksStore.startOperation({
       type: 'delete',
       itemCount: payload.length,
-      startedAt: Date.now(),
-    };
+    });
 
     try {
       await deleteItems(payload);
@@ -263,7 +167,7 @@ export const useFileStore = defineStore('fileStore', () => {
       await favoritesStore.loadFavorites();
       await fetchPathItems(currentPath.value);
     } finally {
-      deleteOperation.value = null;
+      operationTasksStore.finishOperation(operationId);
     }
   };
 
@@ -331,7 +235,25 @@ export const useFileStore = defineStore('fileStore', () => {
     const normalized = normalizePath(relativePath || '');
     if (!normalized) return null;
 
-    const response = await extractZipApi(normalized);
+    const archiveName = normalized.split('/').pop() || normalized;
+    const operationId = operationTasksStore.startOperation({
+      type: 'extract',
+      name: archiveName,
+      itemCount: 1,
+    });
+
+    let response;
+    try {
+      response = await extractZipApi(normalized, {
+        onEvent: (event) => {
+          if (event?.type === 'progress' && Number.isFinite(event.percent)) {
+            operationTasksStore.updateOperation(operationId, { percent: event.percent });
+          }
+        },
+      });
+    } finally {
+      operationTasksStore.finishOperation(operationId);
+    }
 
     const parent = (() => {
       const idx = normalized.lastIndexOf('/');
@@ -357,7 +279,27 @@ export const useFileStore = defineStore('fileStore', () => {
     const payload = serializeItems(selectedItems.value);
     if (payload.length === 0) return null;
 
-    const response = await compressToZipApi(payload, destination, name);
+    const operationId = operationTasksStore.startOperation({
+      type: 'compress',
+      name: typeof name === 'string' && name.trim() ? name.trim() : '',
+      itemCount: payload.length,
+    });
+
+    let response;
+    try {
+      response = await compressToZipApi(payload, destination, name, {
+        onEvent: (event) => {
+          if (event?.type === 'start' && event.name) {
+            operationTasksStore.updateOperation(operationId, { name: event.name });
+          } else if (event?.type === 'progress' && Number.isFinite(event.percent)) {
+            operationTasksStore.updateOperation(operationId, { percent: event.percent });
+          }
+        },
+      });
+    } finally {
+      operationTasksStore.finishOperation(operationId);
+    }
+
     const createdName = response?.item?.name;
 
     await fetchPathItems(destination);
@@ -631,9 +573,6 @@ export const useFileStore = defineStore('fileStore', () => {
     setSelectionMode,
     toggleSelectionMode,
     clearSelection,
-    clipboardOperation,
-    deleteOperation,
-    repositionAfterTransfer,
     copiedItems,
     cutItems,
     hasSelection,

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -128,20 +128,36 @@ export const useFileStore = defineStore('fileStore', () => {
         destination,
         itemCount: totalCount,
         startedAt: Date.now(),
+        totalBytes: 0,
+        copiedBytes: 0,
       };
     }
+
+    // Fold streamed transfer events into the reactive operation so the progress
+    // bar tracks real bytes copied against the pre-computed total.
+    const onTransferEvent = (event) => {
+      const op = clipboardOperation.value;
+      if (!op || !event) return;
+      if (event.type === 'start') {
+        op.totalBytes = Number(event.totalBytes) || 0;
+        op.copiedBytes = 0;
+      } else if (event.type === 'progress') {
+        if (event.totalBytes != null) op.totalBytes = Number(event.totalBytes) || 0;
+        op.copiedBytes = Number(event.copiedBytes) || 0;
+      }
+    };
 
     try {
       if (copiedItems.value.length > 0) {
         if (copyPayload.length > 0) {
-          await copyItems(copyPayload, destination);
+          await copyItems(copyPayload, destination, { onEvent: onTransferEvent });
         }
         copiedItems.value = [];
       }
 
       if (cutItems.value.length > 0) {
         if (movePayload.length > 0) {
-          await moveItems(movePayload, destination);
+          await moveItems(movePayload, destination, { onEvent: onTransferEvent });
         }
         cutItems.value = [];
       }

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -5,7 +5,7 @@ import {
   browse,
   copyItems,
   moveItems,
-  deleteItems,
+  deleteItemsStream,
   normalizePath,
   createFolder as createFolderApi,
   renameItem as renameItemApi,
@@ -32,8 +32,15 @@ export const useFileStore = defineStore('fileStore', () => {
   const favoritesStore = useFavoritesStore();
   const operationTasksStore = useOperationTasksStore();
 
+  const isAbortError = (error) =>
+    error?.name === 'AbortError' ||
+    error?.code === 'OPERATION_CANCELLED' ||
+    (typeof DOMException !== 'undefined' && error?.code === DOMException.ABORT_ERR) ||
+    /aborted/i.test(error?.message || '');
+
   const copiedItems = useStorage('nextExplorer_clipboard_copied', []);
   const cutItems = useStorage('nextExplorer_clipboard_cut', []);
+  const repositionAfterTransfer = useStorage('nextExplorer_paste_reposition', true);
   const thumbnailRequests = new Map();
 
   const hasSelection = computed(() => selectedItems.value.length > 0);
@@ -101,6 +108,50 @@ export const useFileStore = defineStore('fileStore', () => {
     cutItems.value = [];
   };
 
+  const transferredBaseName = (relativePath) => {
+    const normalized = normalizePath(relativePath || '');
+    const index = normalized.lastIndexOf('/');
+    return index >= 0 ? normalized.slice(index + 1) : normalized;
+  };
+
+  const collectTransferredNames = (result, output) => {
+    for (const entry of Array.isArray(result?.items) ? result.items : []) {
+      const name = transferredBaseName(entry?.to);
+      if (name) output.push(name);
+    }
+  };
+
+  const selectItemsByName = (names) => {
+    const wanted = new Set((names || []).filter(Boolean));
+    if (wanted.size === 0) return;
+    const matches = currentPathItems.value.filter((item) => wanted.has(item.name));
+    if (matches.length > 0) selectedItems.value = matches;
+  };
+
+  const settleAfterTransfer = async (destination, moveSourceParents, pastedNames) => {
+    const current = normalizePath(currentPath.value || '');
+    const onDestination = current === destination;
+
+    if (repositionAfterTransfer.value) {
+      if (onDestination || !destination) {
+        await fetchPathItems(current);
+        selectItemsByName(pastedNames);
+      } else {
+        const firstName = pastedNames[0];
+        router
+          .push({
+            name: 'FolderView',
+            params: { path: destination },
+            ...(firstName ? { query: { select: firstName } } : {}),
+          })
+          .catch(() => {});
+      }
+      return;
+    }
+
+    if (onDestination || moveSourceParents.has(current)) await fetchPathItems(current);
+  };
+
   const copy = () => {
     if (!hasSelection.value) return;
     cutItems.value = [];
@@ -116,11 +167,11 @@ export const useFileStore = defineStore('fileStore', () => {
   const paste = async (targetPath) => {
     const hasTarget = typeof targetPath === 'string' && targetPath.trim().length > 0;
     const destination = normalizePath(hasTarget ? targetPath : currentPath.value || '');
-    const refreshTarget = normalizePath(currentPath.value || '');
-
     const copyPayload = serializeItems(copiedItems.value);
     const movePayload = serializeItems(cutItems.value);
+    const moveSourceParents = new Set(movePayload.map((item) => normalizePath(item.path || '')));
     const totalCount = copyPayload.length + movePayload.length;
+    const controller = new AbortController();
 
     const operationId =
       totalCount > 0
@@ -128,25 +179,58 @@ export const useFileStore = defineStore('fileStore', () => {
             type: movePayload.length > 0 && copyPayload.length === 0 ? 'move' : 'copy',
             destination,
             itemCount: totalCount,
+            cancellable: true,
+            cancel: () => controller.abort(),
           })
         : null;
 
     try {
+      const pastedNames = [];
+      let finalDestination = destination;
+
       if (copiedItems.value.length > 0) {
         if (copyPayload.length > 0) {
-          await copyItems(copyPayload, destination);
+          const result = await copyItems(copyPayload, destination, {
+            signal: controller.signal,
+            onEvent: (event) => {
+              if (event?.type === 'start' || event?.type === 'progress') {
+                operationTasksStore.updateOperation(operationId, {
+                  totalBytes: Number(event.totalBytes) || 0,
+                  copiedBytes: Number(event.copiedBytes) || 0,
+                  ...(Number.isFinite(event.percent) ? { percent: event.percent } : {}),
+                });
+              }
+            },
+          });
+          collectTransferredNames(result, pastedNames);
+          if (result?.destination != null) finalDestination = normalizePath(result.destination);
         }
         copiedItems.value = [];
       }
 
       if (cutItems.value.length > 0) {
         if (movePayload.length > 0) {
-          await moveItems(movePayload, destination);
+          const result = await moveItems(movePayload, destination, {
+            signal: controller.signal,
+            onEvent: (event) => {
+              if (event?.type === 'start' || event?.type === 'progress') {
+                operationTasksStore.updateOperation(operationId, {
+                  totalBytes: Number(event.totalBytes) || 0,
+                  copiedBytes: Number(event.copiedBytes) || 0,
+                  ...(Number.isFinite(event.percent) ? { percent: event.percent } : {}),
+                });
+              }
+            },
+          });
+          collectTransferredNames(result, pastedNames);
+          if (result?.destination != null) finalDestination = normalizePath(result.destination);
         }
         cutItems.value = [];
       }
 
-      await fetchPathItems(refreshTarget);
+      await settleAfterTransfer(finalDestination, moveSourceParents, pastedNames);
+    } catch (error) {
+      if (!isAbortError(error)) throw error;
     } finally {
       if (operationId) operationTasksStore.finishOperation(operationId);
     }
@@ -156,14 +240,32 @@ export const useFileStore = defineStore('fileStore', () => {
     const payload = serializeItems(selectedItems.value);
     if (payload.length === 0) return;
 
+    const controller = new AbortController();
     const operationId = operationTasksStore.startOperation({
       type: 'delete',
       itemCount: payload.length,
+      cancellable: true,
+      cancel: () => controller.abort(),
     });
 
     try {
-      await deleteItems(payload);
+      await deleteItemsStream(payload, {
+        signal: controller.signal,
+        onEvent: (event) => {
+          if (event?.type === 'progress') {
+            operationTasksStore.updateOperation(operationId, {
+              percent: Number(event.percent) || 0,
+              completedItems: Number(event.completedItems) || 0,
+              currentName: event.currentName || '',
+            });
+          }
+        },
+      });
       clearSelection();
+      await favoritesStore.loadFavorites();
+      await fetchPathItems(currentPath.value);
+    } catch (error) {
+      if (!isAbortError(error)) throw error;
       await favoritesStore.loadFavorites();
       await fetchPathItems(currentPath.value);
     } finally {
@@ -575,6 +677,7 @@ export const useFileStore = defineStore('fileStore', () => {
     clearSelection,
     copiedItems,
     cutItems,
+    repositionAfterTransfer,
     hasSelection,
     hasClipboardItems,
     copy,

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { useStorage } from '@vueuse/core';
+import router from '@/router';
 import {
   browse,
   copyItems,
@@ -34,6 +35,11 @@ export const useFileStore = defineStore('fileStore', () => {
 
   const copiedItems = useStorage('nextExplorer_clipboard_copied', []);
   const cutItems = useStorage('nextExplorer_clipboard_cut', []);
+  // When true, a finished copy/move re-focuses the pasted entry in its destination
+  // folder (navigating there via the router so the address bar stays in sync).
+  // When false, the current view is left untouched — handy for launching a long
+  // transfer and continuing to browse elsewhere. Persisted across sessions.
+  const repositionAfterTransfer = useStorage('nextExplorer_paste_reposition', true);
   const thumbnailRequests = new Map();
 
   const hasSelection = computed(() => selectedItems.value.length > 0);
@@ -113,13 +119,79 @@ export const useFileStore = defineStore('fileStore', () => {
     cutItems.value = selectedItems.value.map((item) => ({ ...item }));
   };
 
+  // Final name of a copied/moved entry, from its destination-relative path.
+  const transferredBaseName = (relativePath) => {
+    const normalized = normalizePath(relativePath || '');
+    const idx = normalized.lastIndexOf('/');
+    return idx >= 0 ? normalized.slice(idx + 1) : normalized;
+  };
+
+  // Collect the final entry names from a streamed transfer result ({ items:[{ to }] }).
+  const collectTransferredNames = (result, out) => {
+    const items = Array.isArray(result?.items) ? result.items : [];
+    for (const entry of items) {
+      const name = transferredBaseName(entry?.to);
+      if (name) out.push(name);
+    }
+  };
+
+  const selectItemsByName = (names) => {
+    const wanted = new Set((names || []).filter(Boolean));
+    if (wanted.size === 0) return;
+    const matches = currentPathItems.value.filter((it) => it && wanted.has(it.name));
+    if (matches.length > 0) {
+      selectedItems.value = matches;
+    }
+  };
+
+  // Refresh the view (and optionally reposition) once a copy/move settles. The
+  // address bar is driven by the router, so "repositioning" navigates through the
+  // router to keep the URL/breadcrumb in sync with the listing. When repositioning
+  // is disabled we only refresh the folder the user is *currently* viewing (which
+  // always matches the route), so navigating away mid-transfer is never disrupted.
+  const settleAfterTransfer = async (finalDestination, moveSourceParents, pastedNames) => {
+    const userLocation = normalizePath(currentPath.value || '');
+    const onDestination = userLocation === finalDestination;
+
+    if (repositionAfterTransfer.value) {
+      if (onDestination || !finalDestination) {
+        // Already at the destination (or destination is the root, which has no
+        // routable path): refresh in place and highlight the result. The address
+        // bar is already correct, so no navigation is needed.
+        await fetchPathItems(userLocation);
+        selectItemsByName(pastedNames);
+      } else {
+        // Elsewhere (navigated away, or pasted into another folder): navigate to
+        // the destination and select the entry, which also updates the address bar.
+        const firstName = pastedNames[0];
+        router
+          .push({
+            name: 'FolderView',
+            params: { path: finalDestination },
+            ...(firstName ? { query: { select: firstName } } : {}),
+          })
+          .catch(() => {});
+      }
+      return;
+    }
+
+    // Repositioning disabled: leave the user where they are. Refresh only when the
+    // current folder was actually affected (it is the destination, or a move source
+    // that just lost entries) so its listing stays accurate without any view jump.
+    if (onDestination || moveSourceParents.has(userLocation)) {
+      await fetchPathItems(userLocation);
+    }
+  };
+
   const paste = async (targetPath) => {
     const hasTarget = typeof targetPath === 'string' && targetPath.trim().length > 0;
     const destination = normalizePath(hasTarget ? targetPath : currentPath.value || '');
-    const refreshTarget = normalizePath(currentPath.value || '');
 
     const copyPayload = serializeItems(copiedItems.value);
     const movePayload = serializeItems(cutItems.value);
+    const moveSourceParents = new Set(
+      movePayload.map((item) => normalizePath(item.path || ''))
+    );
     const totalCount = copyPayload.length + movePayload.length;
 
     if (totalCount > 0) {
@@ -148,21 +220,28 @@ export const useFileStore = defineStore('fileStore', () => {
     };
 
     try {
+      const pastedNames = [];
+      let finalDestination = destination;
+
       if (copiedItems.value.length > 0) {
         if (copyPayload.length > 0) {
-          await copyItems(copyPayload, destination, { onEvent: onTransferEvent });
+          const result = await copyItems(copyPayload, destination, { onEvent: onTransferEvent });
+          collectTransferredNames(result, pastedNames);
+          if (result?.destination != null) finalDestination = normalizePath(result.destination);
         }
         copiedItems.value = [];
       }
 
       if (cutItems.value.length > 0) {
         if (movePayload.length > 0) {
-          await moveItems(movePayload, destination, { onEvent: onTransferEvent });
+          const result = await moveItems(movePayload, destination, { onEvent: onTransferEvent });
+          collectTransferredNames(result, pastedNames);
+          if (result?.destination != null) finalDestination = normalizePath(result.destination);
         }
         cutItems.value = [];
       }
 
-      await fetchPathItems(refreshTarget);
+      await settleAfterTransfer(finalDestination, moveSourceParents, pastedNames);
     } finally {
       clipboardOperation.value = null;
     }
@@ -554,6 +633,7 @@ export const useFileStore = defineStore('fileStore', () => {
     clearSelection,
     clipboardOperation,
     deleteOperation,
+    repositionAfterTransfer,
     copiedItems,
     cutItems,
     hasSelection,

--- a/frontend/src/stores/operationTasks.js
+++ b/frontend/src/stores/operationTasks.js
@@ -1,0 +1,79 @@
+import { computed, ref } from 'vue';
+import { defineStore } from 'pinia';
+
+// File operations can run concurrently (for example an extraction while a ZIP
+// is being created). Keep each operation isolated so a new stream never
+// replaces the progress state of an earlier one.
+export const useOperationTasksStore = defineStore('operationTasks', () => {
+  const operations = ref([]);
+  const activeOperationId = ref(null);
+  let nextOperationId = 0;
+
+  const activeOperation = computed(() => {
+    const selected = operations.value.find((operation) => operation.id === activeOperationId.value);
+    return selected || operations.value.at(-1) || null;
+  });
+
+  const operationCount = computed(() => operations.value.length);
+
+  const startOperation = (operation) => {
+    nextOperationId += 1;
+    const id = `operation-${Date.now()}-${nextOperationId}`;
+    const next = {
+      id,
+      startedAt: Date.now(),
+      totalBytes: 0,
+      copiedBytes: 0,
+      percent: null,
+      ...operation,
+    };
+
+    operations.value = [...operations.value, next];
+    activeOperationId.value = id;
+    return id;
+  };
+
+  const updateOperation = (id, updates) => {
+    const index = operations.value.findIndex((operation) => operation.id === id);
+    if (index < 0) return;
+
+    const next = [...operations.value];
+    next[index] = { ...next[index], ...updates };
+    operations.value = next;
+  };
+
+  const cancelOperation = (id) => {
+    const operation = operations.value.find((entry) => entry.id === id);
+    if (!operation?.cancellable || operation.cancelling) return;
+
+    updateOperation(id, { cancelling: true });
+    operation.cancel?.();
+  };
+
+  const selectOperation = (id) => {
+    if (operations.value.some((operation) => operation.id === id)) {
+      activeOperationId.value = id;
+    }
+  };
+
+  const finishOperation = (id) => {
+    const wasSelected = activeOperationId.value === id;
+    operations.value = operations.value.filter((operation) => operation.id !== id);
+
+    if (wasSelected) {
+      activeOperationId.value = operations.value.at(-1)?.id || null;
+    }
+  };
+
+  return {
+    operations,
+    activeOperationId,
+    activeOperation,
+    operationCount,
+    startOperation,
+    updateOperation,
+    cancelOperation,
+    selectOperation,
+    finishOperation,
+  };
+});

--- a/frontend/src/stores/operationTasks.spec.js
+++ b/frontend/src/stores/operationTasks.spec.js
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useOperationTasksStore } from '@/stores/operationTasks';
+
+describe('operation task store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('keeps concurrent operations separate and returns to the remaining one', () => {
+    const store = useOperationTasksStore();
+    const copyId = store.startOperation({ type: 'copy', itemCount: 4 });
+    const extractId = store.startOperation({ type: 'extract', name: 'archive.zip' });
+
+    store.updateOperation(copyId, { totalBytes: 100, copiedBytes: 60 });
+
+    expect(store.operationCount).toBe(2);
+    expect(store.activeOperation.id).toBe(extractId);
+    expect(store.operations.find((operation) => operation.id === copyId)).toMatchObject({
+      copiedBytes: 60,
+      totalBytes: 100,
+    });
+
+    store.finishOperation(extractId);
+
+    expect(store.operationCount).toBe(1);
+    expect(store.activeOperation.id).toBe(copyId);
+    expect(store.activeOperation.copiedBytes).toBe(60);
+  });
+
+  it('keeps the selected operation visible while other operations finish', () => {
+    const store = useOperationTasksStore();
+    const copyId = store.startOperation({ type: 'copy', itemCount: 1 });
+    const compressId = store.startOperation({ type: 'compress', name: 'backup.zip' });
+
+    store.selectOperation(copyId);
+    store.finishOperation(compressId);
+
+    expect(store.activeOperation.id).toBe(copyId);
+  });
+});

--- a/frontend/src/stores/operationTasks.spec.js
+++ b/frontend/src/stores/operationTasks.spec.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { useOperationTasksStore } from '@/stores/operationTasks';
 
@@ -37,5 +37,17 @@ describe('operation task store', () => {
     store.finishOperation(compressId);
 
     expect(store.activeOperation.id).toBe(copyId);
+  });
+
+  it('cancels an operation once and marks it as cancelling', () => {
+    const store = useOperationTasksStore();
+    const cancel = vi.fn();
+    const id = store.startOperation({ type: 'copy', itemCount: 1, cancellable: true, cancel });
+
+    store.cancelOperation(id);
+    store.cancelOperation(id);
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(store.activeOperation.cancelling).toBe(true);
   });
 });

--- a/frontend/src/stores/paste.reposition.spec.js
+++ b/frontend/src/stores/paste.reposition.spec.js
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const routerPush = vi.fn(() => Promise.resolve());
+const copyItems = vi.fn();
+const moveItems = vi.fn();
+const browse = vi.fn();
+
+vi.mock('@/router', () => ({
+  default: { push: (...args) => routerPush(...args) },
+}));
+
+vi.mock('@/api', () => ({
+  browse: (...args) => browse(...args),
+  copyItems: (...args) => copyItems(...args),
+  moveItems: (...args) => moveItems(...args),
+  deleteItems: vi.fn(),
+  // Kept identical to the real helper: strips leading/trailing slashes.
+  normalizePath: (p) => (p || '').replace(/^\/+|\/+$/g, ''),
+  createFolder: vi.fn(),
+  renameItem: vi.fn(),
+  saveFileContent: vi.fn(),
+  fetchThumbnail: vi.fn(),
+  extractZip: vi.fn(),
+  compressToZip: vi.fn(),
+  browseShare: vi.fn(),
+}));
+
+vi.mock('@/stores/settings', () => ({
+  useSettingsStore: () => ({ sortBy: { by: 'name', order: 'asc' } }),
+}));
+vi.mock('@/stores/appSettings', () => ({
+  useAppSettings: () => ({ thumbnailsEnabledForSession: true }),
+}));
+vi.mock('@/stores/favorites', () => ({
+  useFavoritesStore: () => ({ loadFavorites: vi.fn() }),
+}));
+vi.mock('@/stores/volumeUsage', () => ({
+  useVolumeUsageStore: () => ({ scheduleRefresh: vi.fn() }),
+}));
+vi.mock('@/stores/folderSize', () => ({
+  useFolderSizeStore: () => ({ scheduleRefresh: vi.fn(), sizeFor: () => null }),
+}));
+
+import { useFileStore } from '@/stores/fileStore';
+
+// browse() returns a listing containing the pasted entry so that, after an
+// in-place refresh, the store can re-select it by name.
+const listingWith = (name, parent) => ({
+  items: [{ name, path: parent, kind: 'file' }],
+  path: parent,
+});
+
+describe('fileStore paste repositioning', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    routerPush.mockClear();
+    copyItems.mockReset();
+    moveItems.mockReset();
+    browse.mockReset();
+  });
+
+  it('reposition ON, still on destination: refreshes in place and selects the pasted entry (no navigation)', async () => {
+    copyItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+    browse.mockResolvedValue(listingWith('f.bin', 'Usb/temp'));
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = true;
+    store.setCurrentPath('Usb/temp'); // user is viewing the destination
+    store.copiedItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste();
+
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(browse).toHaveBeenCalledWith('Usb/temp');
+    expect(store.selectedItems.map((i) => i.name)).toEqual(['f.bin']);
+    expect(store.copiedItems).toEqual([]);
+  });
+
+  it('reposition ON, navigated away: navigates to the destination with a select query (updates the address bar)', async () => {
+    copyItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = true;
+    store.setCurrentPath('some/other/folder'); // user browsed elsewhere during the copy
+    store.copiedItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste('Usb/temp');
+
+    expect(routerPush).toHaveBeenCalledTimes(1);
+    expect(routerPush).toHaveBeenCalledWith({
+      name: 'FolderView',
+      params: { path: 'Usb/temp' },
+      query: { select: 'f.bin' },
+    });
+    // The router-driven remount performs the fetch; the store must not refresh directly.
+    expect(browse).not.toHaveBeenCalled();
+  });
+
+  it('reposition OFF, still on destination: refreshes in place without navigating', async () => {
+    copyItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+    browse.mockResolvedValue(listingWith('f.bin', 'Usb/temp'));
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = false;
+    store.setCurrentPath('Usb/temp');
+    store.copiedItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste();
+
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(browse).toHaveBeenCalledWith('Usb/temp');
+  });
+
+  it('reposition OFF, navigated to an unaffected folder: leaves the view untouched (no fetch, no navigation)', async () => {
+    copyItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = false;
+    store.setCurrentPath('unrelated/place');
+    store.copiedItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste('Usb/temp');
+
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(browse).not.toHaveBeenCalled();
+  });
+
+  it('reposition OFF, viewing a move source: refreshes it so removed entries disappear', async () => {
+    moveItems.mockResolvedValue({
+      items: [{ from: 'src/f.bin', to: 'Usb/temp/f.bin' }],
+      destination: 'Usb/temp',
+    });
+    browse.mockResolvedValue({ items: [], path: 'src' });
+
+    const store = useFileStore();
+    store.repositionAfterTransfer = false;
+    store.setCurrentPath('src'); // viewing the folder the item is being moved out of
+    store.cutItems = [{ name: 'f.bin', path: 'src', kind: 'file' }];
+
+    await store.paste('Usb/temp');
+
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(browse).toHaveBeenCalledWith('src');
+    expect(store.cutItems).toEqual([]);
+  });
+});

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -497,8 +497,8 @@ onBeforeUnmount(() => {
               'relative',
               item.kind === 'directory' && isDragTarget(item)
                 ? isCopyDragTarget(item)
-                  ? 'ring-2 ring-emerald-500 dark:ring-emerald-400 ring-offset-2 dark:ring-offset-zinc-800 rounded-lg'
-                  : 'ring-2 ring-blue-500 dark:ring-blue-400 ring-offset-2 dark:ring-offset-zinc-800 rounded-lg'
+                  ? 'z-10 ring-2 ring-emerald-500 dark:ring-emerald-400 ring-offset-2 dark:ring-offset-zinc-800 rounded-lg'
+                  : 'z-10 ring-2 ring-blue-500 dark:ring-blue-400 ring-offset-2 dark:ring-offset-zinc-800 rounded-lg'
                 : '',
             ]"
             @dragover="(e) => item.kind === 'directory' && handleDragOver(e, item)"

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -50,6 +50,23 @@ const {
 } =
   useFileDragDrop();
 
+const currentFolderDropTarget = computed(() => ({
+  destinationPath: normalizePath(fileStore.currentPath || ''),
+  kind: 'directory',
+}));
+
+const handleCurrentFolderDragOver = (event) => {
+  handleDragOver(event, currentFolderDropTarget.value);
+};
+
+const handleCurrentFolderDragLeave = (event) => {
+  handleDragLeave(event, currentFolderDropTarget.value);
+};
+
+const handleCurrentFolderDrop = (event) => {
+  handleDrop(event, currentFolderDropTarget.value);
+};
+
 const INITIAL_VISIBLE_ITEMS = 500;
 const VISIBLE_ITEMS_INCREMENT = 500;
 const VIRTUAL_LIST_THRESHOLD = 1000;
@@ -411,6 +428,9 @@ onBeforeUnmount(() => {
         <div
           :class="[gridClasses, 'min-h-full', settings.view === 'list' ? 'overflow-x-auto' : '']"
           :style="gridStyle"
+          @dragover.self="handleCurrentFolderDragOver"
+          @dragleave.self="handleCurrentFolderDragLeave"
+          @drop.self="handleCurrentFolderDrop"
         >
           <!-- Detail view header -->
           <div
@@ -473,7 +493,6 @@ onBeforeUnmount(() => {
             :key="(item.path || '') + '::' + item.name"
             :item="item"
             :view="settings.view"
-            :show-copy-drop-indicator="item.kind === 'directory' && isCopyDragTarget(item)"
             :class="[
               'relative',
               item.kind === 'directory' && isDragTarget(item)

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -40,7 +40,15 @@ const dropTargetRef = ref(null);
 useUppyDropTarget(dropTargetRef);
 
 const { isTouchDevice } = useInputMode();
-const { handleDragOver, handleDragLeave, handleDrop, isDragTarget } = useFileDragDrop();
+const {
+  handleDragOver,
+  handleDragLeave,
+  handleDrop,
+  handleDragEnd,
+  isDragTarget,
+  isCopyDragTarget,
+} =
+  useFileDragDrop();
 
 const INITIAL_VISIBLE_ITEMS = 500;
 const VISIBLE_ITEMS_INCREMENT = 500;
@@ -465,15 +473,19 @@ onBeforeUnmount(() => {
             :key="(item.path || '') + '::' + item.name"
             :item="item"
             :view="settings.view"
+            :show-copy-drop-indicator="item.kind === 'directory' && isCopyDragTarget(item)"
             :class="[
               'relative',
               item.kind === 'directory' && isDragTarget(item)
-                ? 'ring-2 ring-blue-500 dark:ring-blue-400 ring-offset-2 dark:ring-offset-zinc-800 rounded-lg'
+                ? isCopyDragTarget(item)
+                  ? 'ring-2 ring-emerald-500 dark:ring-emerald-400 ring-offset-2 dark:ring-offset-zinc-800 rounded-lg'
+                  : 'ring-2 ring-blue-500 dark:ring-blue-400 ring-offset-2 dark:ring-offset-zinc-800 rounded-lg'
                 : '',
             ]"
             @dragover="(e) => item.kind === 'directory' && handleDragOver(e, item)"
             @dragleave="(e) => item.kind === 'directory' && handleDragLeave(e, item)"
             @drop="(e) => item.kind === 'directory' && handleDrop(e, item)"
+            @dragend="handleDragEnd"
           />
 
           <div


### PR DESCRIPTION
## Summary

- Add drag-and-drop copy using the native copy operation: hold Option on macOS or Alt on Windows/Linux while dropping.
- Keep the default operation as move.
- Support dropping files and folders onto regular folders, the current folder, and favorite folders.
- Preserve the native drag preview and cancellation animation, with an inset target outline that is not clipped.
- Reuse cancellable transfer tasks and refresh the current view after completion or cancellation.
- Copying into the same folder uses the normal duplicate-name handling (`(1)`, `(2)`, ...).

## Merge order

This is intentionally stacked on the native transfer/task work from PR #338. Merge in this order to avoid duplicated changes and conflicts:

1. PR #320 (folder sizes and volume usage), if still required by the owner’s current queue.
2. PR #332 (copy/move progress), if still required by the owner’s current queue.
3. PR #338 (native cancellable transfers and multi-task tracking).
4. This PR, then rebase it on the resulting `main` if GitHub reports a stale base.

The drag-specific code does not import the folder-size stores, so once #338 is merged this branch has no additional hidden dependency on #320.

## Validation

- Drag/drop unit tests: 6 passed.
- Frontend production build: passed.
- 
https://github.com/nxzai/NextExplorer/pull/332 and https://github.com/nxzai/NextExplorer/pull/338 before this !
