### PR TITLE
Add clean direct share file URLs

### DIFF
--- a/backend/src/routes/shares.js
+++ b/backend/src/routes/shares.js
@@ -163,7 +163,7 @@ const buildDirectFilePath = (shareToken, innerPath = '', mode = 'auto') => {
   const query = normalizedMode === 'auto' ? '' : `?mode=${encodeURIComponent(normalizedMode)}`;
   const pathPart = encodedInnerPath
     ? `/api/share/${encodedToken}/file/${encodedInnerPath}`
-    : `/api/share/${encodedToken}/file`;
+    : `/api/share/${encodedToken}`;
   return `${pathPart}${query}`;
 };
 
@@ -412,6 +412,16 @@ router.get(
 router.get(
   '/:id',
   asyncHandler(async (req, res) => {
+    // This router is mounted under both /api/shares (management) and
+    // /api/share (public links). The exact public token URL must be handled
+    // here before the management endpoint can interpret the token as a share
+    // ID. Named public routes have an additional path segment and do not match
+    // this route.
+    if (req.baseUrl === '/api/share') {
+      req.params.token = req.params.id;
+      return handleDirectFileRequest(req, res);
+    }
+
     if (!req.user || !req.user.id) {
       throw new UnauthorizedError('Authentication required');
     }
@@ -807,8 +817,10 @@ const handleDirectFileRequest = async (req, res) => {
 /**
  * GET /api/share/:token/file/* - Open a shared file directly.
  *
- * This keeps the same share rules as the Web UI but streams the target file
- * itself, letting the browser preview supported formats or download others.
+ * The exact /api/share/:token alias is handled by the mounted router's
+ * management route above. It intentionally calls this same handler so token,
+ * expiry, password, guest-session and permission checks cannot drift apart.
+ * Keep /file routes for existing external integrations.
  */
 router.get('/:token/file', asyncHandler(handleDirectFileRequest));
 router.get('/:token/file/*', asyncHandler(handleDirectFileRequest));

--- a/backend/tests/routes/shares.test.js
+++ b/backend/tests/routes/shares.test.js
@@ -335,10 +335,11 @@ describe('Shares Routes', () => {
       });
 
       expect(create.status).toBe(201);
-      expect(create.body.directFileUrl).toContain(`/api/share/${create.body.shareToken}/file`);
+      expect(create.body.directFileUrl).toContain(`/api/share/${create.body.shareToken}`);
+      expect(create.body.directFileUrl).not.toContain('/file');
 
       const publicApp = buildApp();
-      const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}/file`);
+      const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}`);
 
       expect(direct.status).toBe(200);
       expect(direct.headers['content-disposition']).toContain('inline');
@@ -346,12 +347,22 @@ describe('Shares Routes', () => {
       expect(direct.text).toBe('hello direct link');
 
       const download = await request(publicApp).get(
-        `/api/share/${create.body.shareToken}/file?mode=download`
+        `/api/share/${create.body.shareToken}?mode=download`
       );
 
       expect(download.status).toBe(200);
       expect(download.headers['content-disposition']).toContain('attachment');
       expect(download.headers['content-disposition']).toContain('hello.txt');
+
+      const raw = await request(publicApp).get(`/api/share/${create.body.shareToken}?mode=raw`);
+      expect(raw.status).toBe(200);
+      expect(raw.text).toBe('hello direct link');
+
+      const legacyDirect = await request(publicApp).get(
+        `/api/share/${create.body.shareToken}/file`
+      );
+      expect(legacyDirect.status).toBe(200);
+      expect(legacyDirect.text).toBe('hello direct link');
     });
 
     it('should redirect a password-protected direct file until the password is verified', async () => {
@@ -389,7 +400,7 @@ describe('Shares Routes', () => {
 
       const publicApp = buildApp();
       const directBeforePassword = await request(publicApp).get(
-        `/api/share/${create.body.shareToken}/file`
+        `/api/share/${create.body.shareToken}`
       );
       expect(directBeforePassword.status).toBe(302);
       expect(directBeforePassword.headers.location).toContain(`/share/${create.body.shareToken}`);
@@ -403,7 +414,7 @@ describe('Shares Routes', () => {
       expect(verify.body.guestSessionId).toBeDefined();
 
       const directAfterPassword = await request(publicApp)
-        .get(`/api/share/${create.body.shareToken}/file`)
+        .get(`/api/share/${create.body.shareToken}`)
         .set('X-Guest-Session', verify.body.guestSessionId);
 
       expect(directAfterPassword.status).toBe(200);
@@ -441,10 +452,11 @@ describe('Shares Routes', () => {
       });
 
       expect(create.status).toBe(201);
-      expect(create.body.directFileUrl).toContain(`/api/share/${create.body.shareToken}/file`);
+      expect(create.body.directFileUrl).toContain(`/api/share/${create.body.shareToken}`);
+      expect(create.body.directFileUrl).not.toContain('/file');
 
       const publicApp = buildApp();
-      const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}/file`);
+      const direct = await request(publicApp).get(`/api/share/${create.body.shareToken}`);
 
       expect(direct.status).toBe(200);
       expect(direct.headers['content-type']).toContain('application/zip');

--- a/frontend/src/api/shares.api.js
+++ b/frontend/src/api/shares.api.js
@@ -160,7 +160,7 @@ function getDirectShareFileUrl(shareToken, innerPath = '', mode = 'auto') {
   const encodedInnerPath = encodePath(normalizedInnerPath);
   const url = encodedInnerPath
     ? `${baseUrl}/api/share/${encodedToken}/file/${encodedInnerPath}`
-    : `${baseUrl}/api/share/${encodedToken}/file`;
+    : `${baseUrl}/api/share/${encodedToken}`;
   const normalizedMode = normalizeDirectShareFileMode(mode);
   return normalizedMode === 'auto' ? url : `${url}?mode=${encodeURIComponent(normalizedMode)}`;
 }


### PR DESCRIPTION
## Summary

- Add canonical direct-file URLs at /api/share/:token, with optional mode query parameters.
- Keep the existing /api/share/:token/file URLs fully supported for backward compatibility.
- Generate the clean URL in the sharing interface while preserving the existing raw, inline and download behavior.

## Security and compatibility

- Both URL forms execute the same direct-file handler and therefore the same expiry, password, recipient and access checks.
- Existing API consumers and stored links continue to work unchanged.

## Verification

- Existing direct-share route coverage remains in backend/tests/routes/shares.test.js.
- Frontend production build passed.

## Dependency

None. This is a backward-compatible extension of the direct-share links merged in PR #313.