### PR TITLE
Add keyboard navigation to folder browsing

### DIFF
--- a/.github/workflows/package-keyboard-folder-navigation-test.yml
+++ b/.github/workflows/package-keyboard-folder-navigation-test.yml
@@ -1,0 +1,59 @@
+name: Package keyboard navigation test image
+
+on:
+  push:
+    branches:
+      - agent/keyboard-folder-navigation-test
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: explorer
+  IMAGE_TAG: keyboard-folder-navigation-test
+
+concurrency:
+  group: package-keyboard-folder-navigation-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and publish keyboard navigation test image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          pull: true
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            REPO_URL=https://github.com/${{ github.repository }}
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/frontend/src/components/FolderViewToolbar.vue
+++ b/frontend/src/components/FolderViewToolbar.vue
@@ -70,7 +70,7 @@ const downloadCurrentFolder = () => {
 </script>
 
 <template>
-  <div class="sticky top-0 z-[60] bg-white/90 p-3 backdrop-blur dark:bg-default/90">
+  <div class="sticky top-0 z-40 bg-white/90 p-3 backdrop-blur dark:bg-default/90">
     <div class="flex flex-wrap items-center shrink-0">
       <button
         type="button"

--- a/frontend/src/components/FolderViewToolbar.vue
+++ b/frontend/src/components/FolderViewToolbar.vue
@@ -70,7 +70,7 @@ const downloadCurrentFolder = () => {
 </script>
 
 <template>
-  <div class="sticky top-0 z-40 bg-white/90 p-3 backdrop-blur dark:bg-default/90">
+  <div class="sticky top-0 z-[60] bg-white/90 p-3 backdrop-blur dark:bg-default/90">
     <div class="flex flex-wrap items-center shrink-0">
       <button
         type="button"

--- a/frontend/src/composables/fileActions.js
+++ b/frontend/src/composables/fileActions.js
@@ -24,6 +24,7 @@ export function useFileActions() {
   const hasSelection = computed(() => fileStore.hasSelection);
   const isSingleItemSelected = computed(() => selectedItems.value.length === 1);
   const primaryItem = computed(() => selectedItems.value[0] ?? null);
+  const renameTarget = computed(() => fileStore.keyboardActionItem || primaryItem.value);
 
   const locationCanWrite = computed(() => fileStore.currentPathData?.canWrite ?? true);
   const locationCanUpload = computed(() => fileStore.currentPathData?.canUpload ?? true);
@@ -62,7 +63,9 @@ export function useFileActions() {
   const canDelete = computed(() => hasSelection.value && locationCanDelete.value);
   const canRename = computed(
     () =>
-      isSingleItemSelected.value && primaryItem.value?.kind !== 'volume' && locationCanWrite.value
+      Boolean(renameTarget.value) &&
+      renameTarget.value?.kind !== 'volume' &&
+      locationCanWrite.value
   );
   const canExtractZip = computed(
     () => isZipSelected.value && locationCanWrite.value && primaryItem.value?.kind !== 'volume'
@@ -99,8 +102,8 @@ export function useFileActions() {
   const runPasteIntoCurrent = async () => runPasteToDestination('');
 
   const runRename = () => {
-    if (!canRename.value || !primaryItem.value) return;
-    fileStore.beginRename(primaryItem.value);
+    if (!canRename.value || !renameTarget.value) return;
+    fileStore.beginRename(renameTarget.value);
   };
 
   const runExtractZip = async () => {

--- a/frontend/src/composables/keyboardShortcuts.js
+++ b/frontend/src/composables/keyboardShortcuts.js
@@ -60,7 +60,7 @@ export function useKeyboardShortcuts(options = {}) {
       }
     });
 
-    const deletePressed = computed(() => keys.delete?.value || keys.backspace?.value);
+    const deletePressed = computed(() => keys.delete?.value);
     whenever(deletePressed, () => {
       if (shouldIgnore()) return;
       requestDelete();

--- a/frontend/src/layouts/BrowserLayout.vue
+++ b/frontend/src/layouts/BrowserLayout.vue
@@ -133,7 +133,7 @@ const handleGuestLogin = () => {
 </script>
 
 <template>
-  <div class="relative flex w-full min-h-dvh">
+  <div class="relative flex h-dvh w-full overflow-hidden">
     <aside
       class="flex flex-col bg-default-muted dark:bg-default-muted pt-4 pb-2 px-6 shrink-0 fixed inset-y-0 left-0 transition-transform duration-200 ease-in-out z-50 lg:sticky lg:top-0 lg:h-dvh lg:translate-x-0"
       :class="isSidebarOpen ? 'translate-x-0' : '-translate-x-full'"
@@ -188,7 +188,7 @@ const handleGuestLogin = () => {
       ></div>
     </div>
 
-    <main class="flex min-w-0 flex-col grow relative bg-default shadow-lg">
+    <main class="relative flex min-h-0 min-w-0 grow flex-col overflow-hidden bg-default shadow-lg">
       <FolderViewToolbar v-if="showBrowseToolbar" @toggle-sidebar="toggleSidebar" />
 
       <!-- Mobile-only toggle for non-browse views (keeps existing view layouts unchanged) -->
@@ -203,7 +203,7 @@ const handleGuestLogin = () => {
       </button>
 
       <ExplorerContextMenu>
-        <div class="flex min-h-0 flex-1 flex-col">
+        <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
           <RouterView v-slot="{ Component, route: viewRoute }">
             <component :is="Component" :key="viewRoute.fullPath" class="min-h-0 flex-1" />
           </RouterView>

--- a/frontend/src/stores/fileStore.js
+++ b/frontend/src/stores/fileStore.js
@@ -25,6 +25,7 @@ export const useFileStore = defineStore('fileStore', () => {
   const currentPathItems = ref([]);
   const currentPathData = ref(null);
   const selectedItems = ref([]);
+  const keyboardActionItemKey = ref('');
   const selectionMode = ref(false);
   const renameState = ref(null);
 
@@ -76,6 +77,18 @@ export const useFileStore = defineStore('fileStore', () => {
   };
 
   const findItemByKey = (key) => currentPathItems.value.find((item) => itemKey(item) === key);
+
+  const keyboardActionItem = computed(() =>
+    keyboardActionItemKey.value ? findItemByKey(keyboardActionItemKey.value) || null : null
+  );
+
+  const setKeyboardActionItem = (item) => {
+    keyboardActionItemKey.value = itemKey(item);
+  };
+
+  const clearKeyboardActionItem = () => {
+    keyboardActionItemKey.value = '';
+  };
 
   const resolveItemRelativePath = (item) => {
     if (!item || !item.name) {
@@ -287,6 +300,7 @@ export const useFileStore = defineStore('fileStore', () => {
     const target = existing || { ...item };
 
     selectedItems.value = [target];
+    clearKeyboardActionItem();
 
     renameState.value = {
       key,
@@ -531,6 +545,9 @@ export const useFileStore = defineStore('fileStore', () => {
     getCurrentPathItems,
     fetchPathItems,
     selectedItems,
+    keyboardActionItem,
+    setKeyboardActionItem,
+    clearKeyboardActionItem,
     selectedItemKeys,
     selectionMode,
     setSelectionMode,

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -232,6 +232,7 @@ const selectItemRange = async (anchorIndex, activeIndex) => {
   if (!activeItem) return;
 
   fileStore.selectedItems = items.slice(start, end + 1);
+  fileStore.setKeyboardActionItem(activeItem);
   keyboardActiveItemKey.value = getItemKey(activeItem);
   await scrollSelectionIntoView(activeItem, activeIndex);
 };
@@ -314,6 +315,7 @@ const selectRelativeItem = async (direction, extendSelection = false) => {
 
   keyboardSelectionAnchorKey.value = getItemKey(nextItem);
   keyboardActiveItemKey.value = getItemKey(nextItem);
+  fileStore.setKeyboardActionItem(nextItem);
   await scrollSelectionIntoView(nextItem, nextIndex);
 };
 
@@ -329,6 +331,7 @@ const toggleKeyboardSelection = async () => {
   toggleSelection(item);
   keyboardSelectionAnchorKey.value = getItemKey(item);
   keyboardActiveItemKey.value = getItemKey(item);
+  fileStore.setKeyboardActionItem(item);
   await scrollSelectionIntoView(item, itemIndex);
 };
 
@@ -336,6 +339,7 @@ const handleKeyboardItemClick = (item) => {
   const key = getItemKey(item);
   keyboardSelectionAnchorKey.value = key;
   keyboardActiveItemKey.value = key;
+  fileStore.clearKeyboardActionItem();
 };
 
 const normalizeTypeaheadText = (value) =>
@@ -376,6 +380,7 @@ const selectTypeaheadMatch = async (key) => {
   fileStore.selectedItems = [match];
   keyboardSelectionAnchorKey.value = getItemKey(match);
   keyboardActiveItemKey.value = getItemKey(match);
+  fileStore.setKeyboardActionItem(match);
   await scrollSelectionIntoView(match, matchIndex);
 };
 

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -23,6 +23,9 @@ import {
 import { useEventListener } from '@vueuse/core';
 import { useInputMode } from '@/composables/useInputMode';
 import { useFileDragDrop } from '@/composables/useFileDragDrop';
+import { useNavigation } from '@/composables/navigation';
+import { useFileActions } from '@/composables/fileActions';
+import { useDeleteConfirm } from '@/composables/useDeleteConfirm';
 
 const settings = useSettingsStore();
 const fileStore = useFileStore();
@@ -41,6 +44,9 @@ useUppyDropTarget(dropTargetRef);
 
 const { isTouchDevice } = useInputMode();
 const { handleDragOver, handleDragLeave, handleDrop, isDragTarget } = useFileDragDrop();
+const { openItem, goNext, goPrev, goUp } = useNavigation();
+const actions = useFileActions();
+const { isDeleteConfirmOpen } = useDeleteConfirm();
 
 const INITIAL_VISIBLE_ITEMS = 500;
 const VISIBLE_ITEMS_INCREMENT = 500;
@@ -184,6 +190,98 @@ const toggleSelectAll = () => {
   }
 
   fileStore.selectedItems = [...sortedItems.value];
+};
+
+const isKeyboardNavigationBlocked = () => {
+  if (loading.value || fileStore.renameState || isDeleteConfirmOpen.value) return true;
+  const active = document.activeElement;
+  return actions.isEditableElement ? actions.isEditableElement(active) : false;
+};
+
+const scrollSelectionIntoView = async (item, index) => {
+  if (!item || index < 0) return;
+
+  if (useVirtualList.value) {
+    getScrollTarget()?.scrollTo({ top: index * LIST_ROW_HEIGHT, behavior: 'auto' });
+  } else if (index >= visibleLimit.value) {
+    visibleLimit.value = Math.min(sortedItems.value.length, index + 1);
+  }
+
+  await nextTick();
+  const key = getItemKey(item);
+  const element = Array.from(document.querySelectorAll('[data-keyboard-item-key]')).find(
+    (candidate) => candidate.getAttribute('data-keyboard-item-key') === key
+  );
+  element?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+};
+
+const selectRelativeItem = async (direction) => {
+  const items = sortedItems.value;
+  if (!items.length) return;
+
+  const selected = fileStore.selectedItems[0];
+  const currentIndex = selected
+    ? items.findIndex((item) => getItemKey(item) === getItemKey(selected))
+    : -1;
+  const nextIndex =
+    currentIndex < 0
+      ? direction > 0
+        ? 0
+        : items.length - 1
+      : Math.min(items.length - 1, Math.max(0, currentIndex + direction));
+  const nextItem = items[nextIndex];
+  if (!nextItem) return;
+
+  fileStore.selectedItems = [nextItem];
+  await scrollSelectionIntoView(nextItem, nextIndex);
+};
+
+const handleFolderKeydown = (event) => {
+  if (event.defaultPrevented || isKeyboardNavigationBlocked()) return;
+
+  if (event.altKey && event.key === 'ArrowLeft') {
+    event.preventDefault();
+    goPrev();
+    return;
+  }
+
+  if (event.altKey && event.key === 'ArrowRight') {
+    event.preventDefault();
+    goNext();
+    return;
+  }
+
+  if (event.altKey && event.key === 'ArrowUp') {
+    event.preventDefault();
+    goUp();
+    return;
+  }
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    selectRelativeItem(1);
+    return;
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    selectRelativeItem(-1);
+    return;
+  }
+
+  const selected = fileStore.selectedItems.length === 1 ? fileStore.selectedItems[0] : null;
+  if (event.key === 'Enter' || (event.key === 'ArrowRight' && selected?.kind === 'directory')) {
+    if (!selected) return;
+    event.preventDefault();
+    openItem(selected);
+    return;
+  }
+
+  if (event.key === 'Backspace' || event.key === 'ArrowLeft') {
+    event.preventDefault();
+    goUp();
+    return;
+  }
 };
 
 const disconnectLoadMoreObserver = () => {
@@ -376,6 +474,7 @@ useEventListener(window, 'pointerup', stopResize);
 useEventListener(window, 'pointercancel', stopResize);
 useEventListener(window, 'resize', updateScrollState);
 useEventListener(window, 'scroll', updateScrollState, { passive: true });
+useEventListener(window, 'keydown', handleFolderKeydown);
 
 onBeforeUnmount(() => {
   stopResize();
@@ -465,6 +564,7 @@ onBeforeUnmount(() => {
             :key="(item.path || '') + '::' + item.name"
             :item="item"
             :view="settings.view"
+            :data-keyboard-item-key="getItemKey(item)"
             :class="[
               'relative',
               item.kind === 'directory' && isDragTarget(item)

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -37,7 +37,7 @@ const loadMoreTrigger = ref(null);
 const isScrollable = ref(false);
 const canScrollUp = ref(false);
 const canScrollDown = ref(false);
-const { clearSelection } = useSelection();
+const { clearSelection, toggleSelection } = useSelection();
 const contextMenu = useExplorerContextMenu();
 const dropTargetRef = ref(null);
 useUppyDropTarget(dropTargetRef);
@@ -56,6 +56,10 @@ const LIST_ROW_OVERSCAN = 20;
 let loadMoreObserver = null;
 const scrollTop = ref(0);
 const scrollViewportHeight = ref(0);
+const keyboardSelectionAnchorKey = ref('');
+const keyboardActiveItemKey = ref('');
+const keyboardTypeahead = ref('');
+let keyboardTypeaheadTimer = null;
 
 const getScrollTarget = () => {
   const localTarget = dropTargetRef.value;
@@ -198,6 +202,39 @@ const isKeyboardNavigationBlocked = () => {
   return actions.isEditableElement ? actions.isEditableElement(active) : false;
 };
 
+const getItemIndexByKey = (key) =>
+  sortedItems.value.findIndex((item) => getItemKey(item) === key);
+
+const getKeyboardActiveIndex = () => {
+  const activeIndex = getItemIndexByKey(keyboardActiveItemKey.value);
+  if (activeIndex >= 0) return activeIndex;
+
+  const selected = fileStore.selectedItems[fileStore.selectedItems.length - 1];
+  return selected ? getItemIndexByKey(getItemKey(selected)) : -1;
+};
+
+const getKeyboardSelectionAnchorIndex = () => {
+  const anchorIndex = getItemIndexByKey(keyboardSelectionAnchorKey.value);
+  if (anchorIndex >= 0 && fileStore.selectedItemKeys.has(keyboardSelectionAnchorKey.value)) {
+    return anchorIndex;
+  }
+
+  const selected = fileStore.selectedItems[0];
+  return selected ? getItemIndexByKey(getItemKey(selected)) : -1;
+};
+
+const selectItemRange = async (anchorIndex, activeIndex) => {
+  const items = sortedItems.value;
+  const [start, end] =
+    anchorIndex <= activeIndex ? [anchorIndex, activeIndex] : [activeIndex, anchorIndex];
+  const activeItem = items[activeIndex];
+  if (!activeItem) return;
+
+  fileStore.selectedItems = items.slice(start, end + 1);
+  keyboardActiveItemKey.value = getItemKey(activeItem);
+  await scrollSelectionIntoView(activeItem, activeIndex);
+};
+
 const scrollSelectionIntoView = async (item, index) => {
   if (!item || index < 0) return;
 
@@ -215,14 +252,11 @@ const scrollSelectionIntoView = async (item, index) => {
   element?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
 };
 
-const selectRelativeItem = async (direction) => {
+const selectRelativeItem = async (direction, extendSelection = false) => {
   const items = sortedItems.value;
   if (!items.length) return;
 
-  const selected = fileStore.selectedItems[0];
-  const currentIndex = selected
-    ? items.findIndex((item) => getItemKey(item) === getItemKey(selected))
-    : -1;
+  const currentIndex = getKeyboardActiveIndex();
   const nextIndex =
     currentIndex < 0
       ? direction > 0
@@ -232,8 +266,74 @@ const selectRelativeItem = async (direction) => {
   const nextItem = items[nextIndex];
   if (!nextItem) return;
 
+  if (extendSelection) {
+    const anchorIndex = getKeyboardSelectionAnchorIndex();
+    const resolvedAnchorIndex = anchorIndex >= 0 ? anchorIndex : nextIndex;
+    keyboardSelectionAnchorKey.value = getItemKey(items[resolvedAnchorIndex]);
+    await selectItemRange(resolvedAnchorIndex, nextIndex);
+    return;
+  }
+
   fileStore.selectedItems = [nextItem];
+  keyboardSelectionAnchorKey.value = getItemKey(nextItem);
+  keyboardActiveItemKey.value = getItemKey(nextItem);
   await scrollSelectionIntoView(nextItem, nextIndex);
+};
+
+const toggleKeyboardSelection = async () => {
+  const items = sortedItems.value;
+  if (!items.length) return;
+
+  const activeIndex = getKeyboardActiveIndex();
+  const itemIndex = activeIndex >= 0 ? activeIndex : 0;
+  const item = items[itemIndex];
+  if (!item) return;
+
+  toggleSelection(item);
+  keyboardSelectionAnchorKey.value = getItemKey(item);
+  keyboardActiveItemKey.value = getItemKey(item);
+  await scrollSelectionIntoView(item, itemIndex);
+};
+
+const normalizeTypeaheadText = (value) =>
+  String(value || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLocaleLowerCase();
+
+const selectTypeaheadMatch = async (key) => {
+  const items = sortedItems.value;
+  if (!items.length) return;
+
+  const normalizedKey = normalizeTypeaheadText(key);
+  keyboardTypeahead.value += normalizedKey;
+  window.clearTimeout(keyboardTypeaheadTimer);
+  keyboardTypeaheadTimer = window.setTimeout(() => {
+    keyboardTypeahead.value = '';
+    keyboardTypeaheadTimer = null;
+  }, 800);
+
+  const activeIndex = getKeyboardActiveIndex();
+  const orderedItems = [...items.slice(activeIndex + 1), ...items.slice(0, activeIndex + 1)];
+  let match = orderedItems.find((item) =>
+    normalizeTypeaheadText(item.name).startsWith(keyboardTypeahead.value)
+  );
+
+  if (!match && keyboardTypeahead.value.length > 1) {
+    keyboardTypeahead.value = normalizedKey;
+    match = orderedItems.find((item) =>
+      normalizeTypeaheadText(item.name).startsWith(keyboardTypeahead.value)
+    );
+  }
+
+  if (!match) return;
+  const matchIndex = getItemIndexByKey(getItemKey(match));
+  if (matchIndex < 0) return;
+
+  fileStore.selectedItems = [match];
+  keyboardSelectionAnchorKey.value = getItemKey(match);
+  keyboardActiveItemKey.value = getItemKey(match);
+  await scrollSelectionIntoView(match, matchIndex);
 };
 
 const handleFolderKeydown = (event) => {
@@ -259,13 +359,19 @@ const handleFolderKeydown = (event) => {
 
   if (event.key === 'ArrowDown') {
     event.preventDefault();
-    selectRelativeItem(1);
+    selectRelativeItem(1, event.shiftKey);
     return;
   }
 
   if (event.key === 'ArrowUp') {
     event.preventDefault();
-    selectRelativeItem(-1);
+    selectRelativeItem(-1, event.shiftKey);
+    return;
+  }
+
+  if (event.key === ' ') {
+    event.preventDefault();
+    toggleKeyboardSelection();
     return;
   }
 
@@ -281,6 +387,16 @@ const handleFolderKeydown = (event) => {
     event.preventDefault();
     goUp();
     return;
+  }
+
+  if (
+    event.key.length === 1 &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey
+  ) {
+    event.preventDefault();
+    selectTypeaheadMatch(event.key);
   }
 };
 
@@ -360,6 +476,11 @@ watch(
   () => route.params.path,
   () => {
     resetVisibleItems();
+    keyboardSelectionAnchorKey.value = '';
+    keyboardActiveItemKey.value = '';
+    keyboardTypeahead.value = '';
+    window.clearTimeout(keyboardTypeaheadTimer);
+    keyboardTypeaheadTimer = null;
   }
 );
 
@@ -478,6 +599,7 @@ useEventListener(window, 'keydown', handleFolderKeydown);
 
 onBeforeUnmount(() => {
   stopResize();
+  window.clearTimeout(keyboardTypeaheadTimer);
   disconnectLoadMoreObserver();
 });
 </script>

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -40,6 +40,7 @@ const canScrollDown = ref(false);
 const { clearSelection, toggleSelection } = useSelection();
 const contextMenu = useExplorerContextMenu();
 const dropTargetRef = ref(null);
+const listHeaderRef = ref(null);
 useUppyDropTarget(dropTargetRef);
 
 const { isTouchDevice } = useInputMode();
@@ -258,10 +259,18 @@ const scrollSelectionIntoView = async (item, index) => {
   if (!target) return;
 
   const itemRect = element.getBoundingClientRect();
-  const targetRect =
-    target === document.scrollingElement || target === document.documentElement
-      ? { top: 0, bottom: window.innerHeight }
-      : target.getBoundingClientRect();
+  const isDocumentScroller =
+    target === document.scrollingElement || target === document.documentElement;
+  const scrollContainerRect = dropTargetRef.value?.getBoundingClientRect?.();
+  const headerRect = listHeaderRef.value?.getBoundingClientRect?.();
+  const targetRect = isDocumentScroller
+    ? {
+        // The document can scroll behind the fixed toolbar. Use the folder viewport
+        // and sticky list header as the actual visible bounds for keyboard focus.
+        top: Math.max(scrollContainerRect?.top ?? 0, headerRect?.bottom ?? 0),
+        bottom: Math.min(scrollContainerRect?.bottom ?? window.innerHeight, window.innerHeight),
+      }
+    : target.getBoundingClientRect();
   const padding = 8;
   const topAdjustment = itemRect.top - (targetRect.top + padding);
   const bottomAdjustment = itemRect.bottom - (targetRect.bottom - padding);
@@ -639,6 +648,7 @@ onBeforeUnmount(() => {
   <div
     ref="dropTargetRef"
     class="upload-drop-target relative flex flex-col flex-1 min-h-0 overflow-y-auto"
+    :class="settings.view === 'list' ? 'overflow-x-auto' : ''"
     @click.self="clearSelection()"
     @scroll.passive="updateScrollState"
   >
@@ -653,14 +663,15 @@ onBeforeUnmount(() => {
         @contextmenu.prevent="handleBackgroundContextMenu"
       >
         <div
-          :class="[gridClasses, 'min-h-full', settings.view === 'list' ? 'overflow-x-auto' : '']"
+          :class="[gridClasses, 'min-h-full']"
           :style="gridStyle"
         >
           <!-- Detail view header -->
           <div
             v-if="settings.view === 'list'"
+            ref="listHeaderRef"
             :class="[
-              'grid items-center',
+              'sticky top-0 z-20 grid items-center',
               'px-4 py-2 text-xs',
               'text-neutral-600 dark:text-neutral-300',
               'uppercase tracking-wide select-none',

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -676,7 +676,7 @@ onBeforeUnmount(() => {
             v-if="settings.view === 'list'"
             ref="listHeaderRef"
             :class="[
-              'sticky top-0 z-20 grid items-center',
+              'sticky top-0 z-50 isolate grid items-center',
               'px-4 py-2 text-xs',
               'text-neutral-600 dark:text-neutral-300',
               'uppercase tracking-wide select-none',

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -680,7 +680,7 @@ onBeforeUnmount(() => {
           <div
             v-if="settings.view === 'list'"
             ref="listHeaderRef"
-            class="sticky top-0 z-50 isolate -mx-2 min-w-max bg-white dark:bg-default"
+            class="sticky top-0 z-30 isolate -mx-2 min-w-max bg-white dark:bg-default"
           >
             <div
             :class="[

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -249,7 +249,30 @@ const scrollSelectionIntoView = async (item, index) => {
   const element = Array.from(document.querySelectorAll('[data-keyboard-item-key]')).find(
     (candidate) => candidate.getAttribute('data-keyboard-item-key') === key
   );
-  element?.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+  if (!element) return;
+
+  element.scrollIntoView?.({ block: 'nearest', inline: 'nearest' });
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+
+  const target = getScrollTarget();
+  if (!target) return;
+
+  const itemRect = element.getBoundingClientRect();
+  const targetRect =
+    target === document.scrollingElement || target === document.documentElement
+      ? { top: 0, bottom: window.innerHeight }
+      : target.getBoundingClientRect();
+  const padding = 8;
+  const topAdjustment = itemRect.top - (targetRect.top + padding);
+  const bottomAdjustment = itemRect.bottom - (targetRect.bottom - padding);
+  const adjustment = topAdjustment < 0 ? topAdjustment : bottomAdjustment > 0 ? bottomAdjustment : 0;
+
+  if (adjustment === 0) return;
+  if (typeof target.scrollBy === 'function') {
+    target.scrollBy({ top: adjustment, behavior: 'auto' });
+  } else {
+    target.scrollTop += adjustment;
+  }
 };
 
 const selectRelativeItem = async (direction, extendSelection = false) => {

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -215,12 +215,12 @@ const getKeyboardActiveIndex = () => {
 
 const getKeyboardSelectionAnchorIndex = () => {
   const anchorIndex = getItemIndexByKey(keyboardSelectionAnchorKey.value);
-  if (anchorIndex >= 0 && fileStore.selectedItemKeys.has(keyboardSelectionAnchorKey.value)) {
-    return anchorIndex;
-  }
+  if (anchorIndex >= 0) return anchorIndex;
 
   const selected = fileStore.selectedItems[0];
-  return selected ? getItemIndexByKey(getItemKey(selected)) : -1;
+  if (selected) return getItemIndexByKey(getItemKey(selected));
+
+  return getKeyboardActiveIndex();
 };
 
 const selectItemRange = async (anchorIndex, activeIndex) => {
@@ -268,13 +268,13 @@ const selectRelativeItem = async (direction, extendSelection = false) => {
 
   if (extendSelection) {
     const anchorIndex = getKeyboardSelectionAnchorIndex();
-    const resolvedAnchorIndex = anchorIndex >= 0 ? anchorIndex : nextIndex;
+    const resolvedAnchorIndex =
+      anchorIndex >= 0 ? anchorIndex : currentIndex >= 0 ? currentIndex : nextIndex;
     keyboardSelectionAnchorKey.value = getItemKey(items[resolvedAnchorIndex]);
     await selectItemRange(resolvedAnchorIndex, nextIndex);
     return;
   }
 
-  fileStore.selectedItems = [nextItem];
   keyboardSelectionAnchorKey.value = getItemKey(nextItem);
   keyboardActiveItemKey.value = getItemKey(nextItem);
   await scrollSelectionIntoView(nextItem, nextIndex);
@@ -295,6 +295,12 @@ const toggleKeyboardSelection = async () => {
   await scrollSelectionIntoView(item, itemIndex);
 };
 
+const handleKeyboardItemClick = (item) => {
+  const key = getItemKey(item);
+  keyboardSelectionAnchorKey.value = key;
+  keyboardActiveItemKey.value = key;
+};
+
 const normalizeTypeaheadText = (value) =>
   String(value || '')
     .normalize('NFD')
@@ -311,7 +317,7 @@ const selectTypeaheadMatch = async (key) => {
   keyboardTypeaheadTimer = window.setTimeout(() => {
     keyboardTypeahead.value = '';
     keyboardTypeaheadTimer = null;
-  }, 800);
+  }, 600);
 
   const activeIndex = getKeyboardActiveIndex();
   const orderedItems = [...items.slice(activeIndex + 1), ...items.slice(0, activeIndex + 1)];
@@ -375,7 +381,9 @@ const handleFolderKeydown = (event) => {
     return;
   }
 
-  const selected = fileStore.selectedItems.length === 1 ? fileStore.selectedItems[0] : null;
+  const activeIndex = getKeyboardActiveIndex();
+  const activeItem = activeIndex >= 0 ? sortedItems.value[activeIndex] : null;
+  const selected = activeItem || (fileStore.selectedItems.length === 1 ? fileStore.selectedItems[0] : null);
   if (event.key === 'Enter' || (event.key === 'ArrowRight' && selected?.kind === 'directory')) {
     if (!selected) return;
     event.preventDefault();
@@ -689,6 +697,9 @@ onBeforeUnmount(() => {
             :data-keyboard-item-key="getItemKey(item)"
             :class="[
               'relative',
+              getItemKey(item) === keyboardActiveItemKey
+                ? 'z-10 ring-2 ring-blue-500 dark:ring-blue-400 ring-offset-1 dark:ring-offset-zinc-800 rounded-lg'
+                : '',
               item.kind === 'directory' && isDragTarget(item)
                 ? 'ring-2 ring-blue-500 dark:ring-blue-400 ring-offset-2 dark:ring-offset-zinc-800 rounded-lg'
                 : '',
@@ -696,6 +707,7 @@ onBeforeUnmount(() => {
             @dragover="(e) => item.kind === 'directory' && handleDragOver(e, item)"
             @dragleave="(e) => item.kind === 'directory' && handleDragLeave(e, item)"
             @drop="(e) => item.kind === 'directory' && handleDrop(e, item)"
+            @click="handleKeyboardItemClick(item)"
           />
 
           <div

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -263,14 +263,19 @@ const scrollSelectionIntoView = async (item, index) => {
     target === document.scrollingElement || target === document.documentElement;
   const scrollContainerRect = dropTargetRef.value?.getBoundingClientRect?.();
   const headerRect = listHeaderRef.value?.getBoundingClientRect?.();
-  const targetRect = isDocumentScroller
+  const baseTargetRect = isDocumentScroller
     ? {
         // The document can scroll behind the fixed toolbar. Use the folder viewport
-        // and sticky list header as the actual visible bounds for keyboard focus.
-        top: Math.max(scrollContainerRect?.top ?? 0, headerRect?.bottom ?? 0),
+        // as the actual visible bounds for keyboard focus.
+        top: scrollContainerRect?.top ?? 0,
         bottom: Math.min(scrollContainerRect?.bottom ?? window.innerHeight, window.innerHeight),
       }
     : target.getBoundingClientRect();
+  // The sticky header obscures rows at the top of both document and local scrollers.
+  const targetRect = {
+    ...baseTargetRect,
+    top: Math.max(baseTargetRect.top, headerRect?.bottom ?? baseTargetRect.top),
+  };
   const padding = 8;
   const topAdjustment = itemRect.top - (targetRect.top + padding);
   const bottomAdjustment = itemRect.bottom - (targetRect.bottom - padding);

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -675,12 +675,14 @@ onBeforeUnmount(() => {
           <div
             v-if="settings.view === 'list'"
             ref="listHeaderRef"
+            class="sticky top-0 z-50 isolate -mx-2 min-w-max bg-white dark:bg-default"
+          >
+            <div
             :class="[
-              'sticky top-0 z-50 isolate grid items-center',
+              'grid items-center',
               'px-4 py-2 text-xs',
               'text-neutral-600 dark:text-neutral-300',
               'uppercase tracking-wide select-none',
-              'bg-white dark:bg-default',
               'backdrop-blur-sm',
               'min-w-max',
             ]"
@@ -719,6 +721,7 @@ onBeforeUnmount(() => {
                   class="mx-auto h-full w-px bg-transparent hover:bg-neutral-300 dark:hover:bg-neutral-600"
                 ></div>
               </div>
+            </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- navigate folder contents with arrow keys, Enter, Backspace and keyboard shortcuts
- support selection with Space and Shift+Arrow, plus 600 ms typeahead matching
- preserve mouse selection and restore the focused row fully below sticky toolbars and column headers
- keep column headers visible while scrolling long folders

Closes #197

## Validation
- `npm --prefix frontend run build`
- tested with long and virtualized folder lists

This PR is independent of the archive extraction work.