### PR TITLE
feat(auth): OIDC mobile bridge for native app passkey sign-in

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -58,6 +58,8 @@ module.exports = {
   OIDC_CLIENT_ID: process.env.OIDC_CLIENT_ID || null,
   OIDC_CLIENT_SECRET: process.env.OIDC_CLIENT_SECRET || null,
   OIDC_CALLBACK_URL: process.env.OIDC_CALLBACK_URL || process.env.OIDC_REDIRECT_URI || null,
+  // Allowlisted native app redirect URIs for the mobile OIDC bridge (iOS/Android).
+  OIDC_MOBILE_REDIRECT_URIS: process.env.OIDC_MOBILE_REDIRECT_URIS || null,
   OIDC_SCOPES: process.env.OIDC_SCOPES || process.env.OIDC_SCOPE || null,
   OIDC_ADMIN_GROUPS: process.env.OIDC_ADMIN_GROUPS || process.env.OIDC_ADMIN_GROUP || null,
   OIDC_REQUIRE_EMAIL_VERIFIED: normalizeBoolean(process.env.OIDC_REQUIRE_EMAIL_VERIFIED) || false,

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -94,6 +94,19 @@ const parseScopes = (raw) => {
   return list.length ? list : null;
 };
 
+// Native app redirect URIs for the mobile OIDC bridge. Case preserving (schemes
+// are case sensitive) and restricted to custom scheme URIs so the bridge can
+// never be pointed at an http(s) open redirect. Falls back to a shared default.
+const DEFAULT_MOBILE_REDIRECT_URIS = ['nextexplorer://oidc-callback'];
+const parseMobileRedirectUris = (raw) => {
+  const list = String(raw || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .filter((uri) => /^[a-z][a-z0-9+.-]*:\/\//i.test(uri) && !/^https?:\/\//i.test(uri));
+  return list.length ? list : DEFAULT_MOBILE_REDIRECT_URIS;
+};
+
 // --- Personal folder naming ---
 const DEFAULT_USER_FOLDER_NAME_ORDER = ['id', 'username', 'email_local'];
 const VALID_USER_FOLDER_NAME_TOKENS = new Set([
@@ -245,6 +258,7 @@ const auth = {
     adminGroups: parseScopes(env.OIDC_ADMIN_GROUPS) || null,
     requireEmailVerified: env.OIDC_REQUIRE_EMAIL_VERIFIED,
     autoCreateUsers: env.OIDC_AUTO_CREATE_USERS,
+    mobileRedirectUris: parseMobileRedirectUris(env.OIDC_MOBILE_REDIRECT_URIS),
   },
 };
 

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -10,6 +10,7 @@ const {
   getUserAuthMethods,
   getRequestUser,
 } = require('../services/users');
+const { issueCode, redeemCode, isValidChallenge } = require('../services/oidcMobileBridge');
 const rateLimit = require('express-rate-limit');
 const asyncHandler = require('../utils/asyncHandler');
 const {
@@ -255,6 +256,112 @@ router.get(
       // ignore
     }
     throw new NotFoundError('OIDC is not configured.');
+  })
+);
+
+// Allowlisted custom scheme URIs the native apps (iOS/Android) register. The code
+// is only ever delivered to one of these, never an arbitrary or http(s) URL.
+const mobileRedirectUris = (auth && auth.oidc && auth.oidc.mobileRedirectUris) || [
+  'nextexplorer://oidc-callback',
+];
+
+const resolveMobileRedirect = (requested) => {
+  if (requested === undefined) return mobileRedirectUris[0];
+  return mobileRedirectUris.includes(requested) ? requested : null;
+};
+
+const buildMobileRedirect = (redirectUri, params) => {
+  const url = new URL(redirectUri);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+};
+
+// Step 1 of native OIDC: the app opens this in ASWebAuthenticationSession (iOS) or
+// Custom Tabs (Android) with a PKCE code_challenge. It stashes the challenge and the
+// chosen redirect in the (throwaway) browser session and kicks off standard OIDC login.
+router.get(
+  '/oidc/mobile/login',
+  asyncHandler(async (req, res) => {
+    if (!(res.oidc && typeof res.oidc.login === 'function')) {
+      throw new NotFoundError('OIDC is not configured.');
+    }
+    const codeChallenge = req.query?.code_challenge;
+    const method = req.query?.code_challenge_method || 'S256';
+    if (!isValidChallenge(codeChallenge) || method !== 'S256') {
+      throw new ValidationError('A valid PKCE code_challenge (S256) is required.');
+    }
+    const redirectUri = resolveMobileRedirect(req.query?.redirect_uri);
+    if (!redirectUri) {
+      throw new ValidationError('Unrecognized redirect_uri.');
+    }
+    if (req.session) {
+      req.session.oidcMobile = { codeChallenge, method, redirectUri };
+    }
+    await res.oidc.login({ returnTo: '/api/auth/oidc/mobile/complete' });
+  })
+);
+
+// Step 2: OIDC login has completed inside the web session. Mint a single use code
+// bound to the authenticated user and the PKCE challenge, then hand it back to the
+// app via the custom scheme. Errors are reported the same way so the app can react.
+router.get(
+  '/oidc/mobile/complete',
+  asyncHandler(async (req, res) => {
+    const pending = req.session?.oidcMobile;
+    if (req.session) delete req.session.oidcMobile;
+
+    const redirectUri = resolveMobileRedirect(pending?.redirectUri);
+    if (!redirectUri) {
+      throw new ValidationError('Unrecognized redirect_uri.');
+    }
+
+    const isAuthed = Boolean(
+      req.oidc && typeof req.oidc.isAuthenticated === 'function' && req.oidc.isAuthenticated()
+    );
+    if (!isAuthed || !pending || !isValidChallenge(pending.codeChallenge)) {
+      return res.redirect(buildMobileRedirect(redirectUri, { error: 'auth_failed' }));
+    }
+
+    const user = await getRequestUser(req);
+    if (!user || !user.id || String(user.id).startsWith('oidc:')) {
+      return res.redirect(buildMobileRedirect(redirectUri, { error: 'no_profile' }));
+    }
+
+    const code = issueCode({
+      userId: user.id,
+      codeChallenge: pending.codeChallenge,
+      method: pending.method,
+    });
+    return res.redirect(buildMobileRedirect(redirectUri, { code }));
+  })
+);
+
+// Step 3: the app exchanges the one time code plus its PKCE verifier for a normal
+// local session cookie, reusing the same session plumbing as password login.
+router.post(
+  '/oidc/exchange',
+  loginLimiter,
+  asyncHandler(async (req, res) => {
+    const { code, code_verifier: codeVerifier } = req.body || {};
+    const result = redeemCode({ code, codeVerifier });
+    if (!result) {
+      throw new UnauthorizedError(
+        'Invalid or expired authorization code.',
+        ErrorCodes.AUTH_INVALID_CREDENTIALS
+      );
+    }
+
+    if (req.session) req.session.localUserId = result.userId;
+    const user = await getRequestUser(req);
+    if (!user) {
+      if (req.session) delete req.session.localUserId;
+      throw new UnauthorizedError('User no longer exists.', ErrorCodes.AUTH_INVALID_CREDENTIALS);
+    }
+
+    res.clearCookie('guestSession', { path: '/api' });
+    res.json({ user });
   })
 );
 

--- a/backend/src/services/oidcMobileBridge.js
+++ b/backend/src/services/oidcMobileBridge.js
@@ -1,0 +1,77 @@
+const crypto = require('crypto');
+
+// Short lived, single use authorization codes that bridge a completed OIDC
+// browser login (inside ASWebAuthenticationSession) to a native app session.
+// The code is handed to the app via a custom scheme redirect and exchanged,
+// with PKCE, for a normal local session cookie. Kept in memory: codes live for
+// seconds and never need to survive a restart.
+const CODE_TTL_MS = 60 * 1000;
+const codes = new Map();
+
+// PKCE verifier/challenge per RFC 7636: unreserved chars, 43..128 length.
+const PKCE_PATTERN = /^[A-Za-z0-9\-._~]{43,128}$/;
+
+const base64url = (buffer) =>
+  buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+const sweep = (now = Date.now()) => {
+  for (const [code, entry] of codes) {
+    if (entry.expiresAt <= now) codes.delete(code);
+  }
+};
+
+const isValidChallenge = (challenge) =>
+  typeof challenge === 'string' && PKCE_PATTERN.test(challenge);
+
+const issueCode = ({ userId, codeChallenge, method = 'S256' }) => {
+  if (userId === undefined || userId === null || userId === '') {
+    throw new Error('userId is required');
+  }
+  if (!isValidChallenge(codeChallenge)) {
+    throw new Error('A valid PKCE code_challenge is required');
+  }
+  if (method !== 'S256') {
+    throw new Error('Only the S256 code_challenge_method is supported');
+  }
+  sweep();
+  const code = base64url(crypto.randomBytes(32));
+  codes.set(code, {
+    userId,
+    codeChallenge,
+    method,
+    expiresAt: Date.now() + CODE_TTL_MS,
+  });
+  return code;
+};
+
+const verifyChallenge = (codeVerifier, codeChallenge) => {
+  if (typeof codeVerifier !== 'string' || !PKCE_PATTERN.test(codeVerifier)) return false;
+  const computed = base64url(crypto.createHash('sha256').update(codeVerifier).digest());
+  const a = Buffer.from(computed);
+  const b = Buffer.from(String(codeChallenge));
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+};
+
+// Consumes the code before checking the verifier, so a wrong guess burns it and
+// there is no online brute force against a live code.
+const redeemCode = ({ code, codeVerifier }) => {
+  sweep();
+  if (typeof code !== 'string' || !code) return null;
+  const entry = codes.get(code);
+  if (!entry) return null;
+  codes.delete(code);
+  if (entry.expiresAt <= Date.now()) return null;
+  if (!verifyChallenge(codeVerifier, entry.codeChallenge)) return null;
+  return { userId: entry.userId };
+};
+
+const _reset = () => codes.clear();
+
+module.exports = {
+  CODE_TTL_MS,
+  isValidChallenge,
+  issueCode,
+  verifyChallenge,
+  redeemCode,
+  _reset,
+};

--- a/backend/tests/routes/oidcMobileBridge.test.js
+++ b/backend/tests/routes/oidcMobileBridge.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import express from 'express';
+import session from 'express-session';
+import bodyParser from 'body-parser';
+import request from 'supertest';
+import { setupTestEnv, clearModuleCache, modulePath } from '../helpers/env-test-utils.js';
+
+const require = createRequire(import.meta.url);
+const crypto = require('node:crypto');
+
+let envContext;
+let bridge;
+let app; // exchange app: real session, no res.oidc.login
+let loginApp; // login app: stubbed res.oidc.login so /oidc/mobile/login is exercisable
+let admin;
+
+const b64url = (buf) =>
+  buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+const makePkce = () => {
+  const verifier = b64url(crypto.randomBytes(32));
+  const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+  return { verifier, challenge };
+};
+
+// oidcLogin: when true, stub res.oidc.login so /oidc/mobile/login is exercisable.
+const buildApp = (authRoutes, errorHandlers, { oidcLogin = false } = {}) => {
+  const instance = express();
+  instance.use(bodyParser.json());
+  instance.use(
+    session({
+      secret: process.env.SESSION_SECRET,
+      resave: false,
+      saveUninitialized: false,
+    })
+  );
+  instance.use((req, res, next) => {
+    req.oidc = { isAuthenticated: () => false };
+    if (oidcLogin) {
+      res.oidc = { login: async ({ returnTo }) => res.redirect(returnTo || '/') };
+    }
+    next();
+  });
+  instance.use('/api/auth', authRoutes);
+  instance.use(errorHandlers.notFoundHandler);
+  instance.use(errorHandlers.errorHandler);
+  return instance;
+};
+
+// One shared server per file. Submodules of the users service cache the DB
+// instance, so tearing down and rebuilding per test does not reset the DB
+// reliably. A single long lived app (as in production) keeps the tests honest.
+beforeAll(async () => {
+  envContext = await setupTestEnv({
+    tag: 'oidc-mobile-routes-test-',
+    modules: ['src/services/db', 'src/services/users', 'src/routes/auth'],
+    env: { AUTH_ENABLED: 'true' },
+  });
+  bridge = require(modulePath('src/services/oidcMobileBridge'));
+
+  try {
+    fs.rmSync(path.join(envContext.configDir, 'app.db'), { force: true });
+  } catch (_) {
+    // ignore
+  }
+  process.env.AUTH_ENABLED = 'true';
+  clearModuleCache('src/config/env');
+  clearModuleCache('src/config/index');
+  clearModuleCache('src/services/db');
+  clearModuleCache('src/services/users');
+
+  const authRoutes = envContext.requireFresh('src/routes/auth');
+  const errorHandlers = envContext.requireFresh('src/middleware/errorHandler');
+  app = buildApp(authRoutes, errorHandlers);
+  loginApp = buildApp(authRoutes, errorHandlers, { oidcLogin: true });
+
+  const setup = await request(app).post('/api/auth/setup').send({
+    email: 'admin@example.com',
+    username: 'admin',
+    password: 'secret123',
+  });
+  expect(setup.status).toBe(201);
+  admin = setup.body.user;
+});
+
+afterAll(async () => {
+  await envContext.cleanup();
+});
+
+beforeEach(() => bridge._reset());
+
+describe('OIDC mobile bridge routes', () => {
+  describe('POST /api/auth/oidc/exchange', () => {
+    it('exchanges a valid code + verifier for a working local session', async () => {
+      const { verifier, challenge } = makePkce();
+      const code = bridge.issueCode({ userId: admin.id, codeChallenge: challenge });
+
+      const agent = request.agent(app);
+      const exchange = await agent
+        .post('/api/auth/oidc/exchange')
+        .send({ code, code_verifier: verifier });
+      expect(exchange.status).toBe(200);
+      expect(exchange.body.user.username).toBe('admin');
+
+      const me = await agent.get('/api/auth/me');
+      expect(me.status).toBe(200);
+      expect(me.body.user.username).toBe('admin');
+    });
+
+    it('rejects a wrong verifier with 401', async () => {
+      const { challenge } = makePkce();
+      const code = bridge.issueCode({ userId: admin.id, codeChallenge: challenge });
+
+      const res = await request(app)
+        .post('/api/auth/oidc/exchange')
+        .send({ code, code_verifier: makePkce().verifier });
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects a reused code with 401', async () => {
+      const { verifier, challenge } = makePkce();
+      const code = bridge.issueCode({ userId: admin.id, codeChallenge: challenge });
+
+      const first = await request(app)
+        .post('/api/auth/oidc/exchange')
+        .send({ code, code_verifier: verifier });
+      expect(first.status).toBe(200);
+
+      const second = await request(app)
+        .post('/api/auth/oidc/exchange')
+        .send({ code, code_verifier: verifier });
+      expect(second.status).toBe(401);
+    });
+
+    it('rejects an unknown code with 401', async () => {
+      const res = await request(app)
+        .post('/api/auth/oidc/exchange')
+        .send({ code: 'does-not-exist', code_verifier: makePkce().verifier });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET /api/auth/oidc/mobile/login', () => {
+    it('returns 400 for a missing or invalid PKCE challenge', async () => {
+      const res = await request(loginApp).get('/api/auth/oidc/mobile/login');
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for an unrecognized redirect_uri', async () => {
+      const { challenge } = makePkce();
+      const res = await request(loginApp)
+        .get('/api/auth/oidc/mobile/login')
+        .query({ code_challenge: challenge, redirect_uri: 'evil://steal' });
+      expect(res.status).toBe(400);
+    });
+
+    it('kicks off OIDC login with a valid challenge', async () => {
+      const { challenge } = makePkce();
+      const res = await request(loginApp)
+        .get('/api/auth/oidc/mobile/login')
+        .query({ code_challenge: challenge });
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe('/api/auth/oidc/mobile/complete');
+    });
+
+    it('returns 404 when OIDC is not configured', async () => {
+      const { challenge } = makePkce();
+      const res = await request(app) // app has no res.oidc.login
+        .get('/api/auth/oidc/mobile/login')
+        .query({ code_challenge: challenge });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/backend/tests/services/oidcMobileBridge.test.js
+++ b/backend/tests/services/oidcMobileBridge.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const crypto = require('node:crypto');
+const bridge = require('../../src/services/oidcMobileBridge');
+
+const b64url = (buf) =>
+  buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+const makePkce = () => {
+  const verifier = b64url(crypto.randomBytes(32));
+  const challenge = b64url(crypto.createHash('sha256').update(verifier).digest());
+  return { verifier, challenge };
+};
+
+describe('oidcMobileBridge', () => {
+  beforeEach(() => bridge._reset());
+
+  describe('isValidChallenge', () => {
+    it('accepts a well formed S256 challenge', () => {
+      const { challenge } = makePkce();
+      expect(bridge.isValidChallenge(challenge)).toBe(true);
+    });
+
+    it('rejects non-strings, empties, and out of range lengths', () => {
+      expect(bridge.isValidChallenge(undefined)).toBe(false);
+      expect(bridge.isValidChallenge('')).toBe(false);
+      expect(bridge.isValidChallenge('a'.repeat(42))).toBe(false);
+      expect(bridge.isValidChallenge('a'.repeat(129))).toBe(false);
+      expect(bridge.isValidChallenge(`bad chars ${'a'.repeat(40)}`)).toBe(false);
+    });
+  });
+
+  describe('issueCode', () => {
+    it('mints a code for a valid user and challenge', () => {
+      const { challenge } = makePkce();
+      const code = bridge.issueCode({ userId: 'u1', codeChallenge: challenge });
+      expect(typeof code).toBe('string');
+      expect(code.length).toBeGreaterThan(20);
+    });
+
+    it('rejects a missing user id', () => {
+      const { challenge } = makePkce();
+      expect(() => bridge.issueCode({ userId: '', codeChallenge: challenge })).toThrow();
+    });
+
+    it('rejects an invalid challenge', () => {
+      expect(() => bridge.issueCode({ userId: 'u1', codeChallenge: 'short' })).toThrow();
+    });
+
+    it('rejects an unsupported method', () => {
+      const { challenge } = makePkce();
+      expect(() =>
+        bridge.issueCode({ userId: 'u1', codeChallenge: challenge, method: 'plain' })
+      ).toThrow();
+    });
+  });
+
+  describe('redeemCode', () => {
+    it('redeems a valid code once and returns the bound user', () => {
+      const { verifier, challenge } = makePkce();
+      const code = bridge.issueCode({ userId: 'user-42', codeChallenge: challenge });
+      expect(bridge.redeemCode({ code, codeVerifier: verifier })).toEqual({ userId: 'user-42' });
+    });
+
+    it('is single use: a second redemption fails', () => {
+      const { verifier, challenge } = makePkce();
+      const code = bridge.issueCode({ userId: 'u1', codeChallenge: challenge });
+      expect(bridge.redeemCode({ code, codeVerifier: verifier })).not.toBeNull();
+      expect(bridge.redeemCode({ code, codeVerifier: verifier })).toBeNull();
+    });
+
+    it('rejects a wrong verifier and burns the code', () => {
+      const { challenge } = makePkce();
+      const wrong = makePkce().verifier;
+      const code = bridge.issueCode({ userId: 'u1', codeChallenge: challenge });
+      expect(bridge.redeemCode({ code, codeVerifier: wrong })).toBeNull();
+      // even the correct verifier now fails, the code is gone
+      expect(bridge.redeemCode({ code, codeVerifier: challenge })).toBeNull();
+    });
+
+    it('rejects an unknown code', () => {
+      const { verifier } = makePkce();
+      expect(bridge.redeemCode({ code: 'nope', codeVerifier: verifier })).toBeNull();
+      expect(bridge.redeemCode({ code: '', codeVerifier: verifier })).toBeNull();
+    });
+
+    it('rejects an expired code', () => {
+      const { verifier, challenge } = makePkce();
+      const code = bridge.issueCode({ userId: 'u1', codeChallenge: challenge });
+      const now = Date.now() + bridge.CODE_TTL_MS + 1000;
+      const original = Date.now;
+      Date.now = () => now;
+      try {
+        expect(bridge.redeemCode({ code, codeVerifier: verifier })).toBeNull();
+      } finally {
+        Date.now = original;
+      }
+    });
+  });
+
+  describe('verifyChallenge', () => {
+    it('matches a verifier to its S256 challenge', () => {
+      const { verifier, challenge } = makePkce();
+      expect(bridge.verifyChallenge(verifier, challenge)).toBe(true);
+    });
+
+    it('rejects a mismatched or malformed verifier', () => {
+      const { challenge } = makePkce();
+      expect(bridge.verifyChallenge(makePkce().verifier, challenge)).toBe(false);
+      expect(bridge.verifyChallenge('short', challenge)).toBe(false);
+      expect(bridge.verifyChallenge(undefined, challenge)).toBe(false);
+    });
+  });
+});

--- a/docker/docker-compose.oidc.yml
+++ b/docker/docker-compose.oidc.yml
@@ -86,6 +86,13 @@ services:
       # When false, OIDC login is only allowed for users that already exist in the DB
       # - OIDC_AUTO_CREATE_USERS=true
 
+      # Native app (iOS/Android) OIDC redirect URIs for the mobile bridge, as a
+      # comma separated allowlist of custom scheme URIs. Passkey based IdPs work in
+      # the app via ASWebAuthenticationSession / Custom Tabs, which exchange a PKCE
+      # backed one time code (GET /api/auth/oidc/mobile/login -> POST
+      # /api/auth/oidc/exchange) for a normal session. Defaults to the value below.
+      # - OIDC_MOBILE_REDIRECT_URIS=nextexplorer://oidc-callback
+
       # ============================================
       # AUTHENTICATION MODE
       # ============================================


### PR DESCRIPTION
## Problem
Native apps must run OIDC sign-in in a **system web session** — on iOS `ASWebAuthenticationSession` is the only web context that supports passkeys/WebAuthn. That session never exposes the HttpOnly `appSession` cookie to the app, and a `WKWebView` (which can read cookies) can't do passkeys reliably. So a passkey-only IdP like pocket-id currently can't complete sign-in in the app.

## Solution
A PKCE-bound bridge that lets a native client complete the **existing** OIDC web flow and then exchange a one-time code for a normal local session — so the app reuses its existing cookie handling, on the same path as password login. No new token/refresh model.

- `GET /api/auth/oidc/mobile/login` — validates a PKCE `code_challenge` (S256) and an allowlisted custom-scheme `redirect_uri`, stashes them in the session, and runs the standard `res.oidc.login` with `returnTo` the completion route.
- `GET /api/auth/oidc/mobile/complete` — after the IdP + server callback authenticate the user, mints a single-use, 60s-TTL code bound to the user id and the PKCE challenge, then redirects to `<redirect_uri>?code=` (or `?error=`).
- `POST /api/auth/oidc/exchange` — verifies the PKCE `code_verifier`, redeems the code (consume-before-verify, timing-safe compare), establishes a normal local session (`connect.sid`) and returns `{ user }`.
- `oidcMobileBridge` service — in-memory single-use codes, TTL, S256 verification.
- `OIDC_MOBILE_REDIRECT_URIS` env (comma-separated, custom-scheme only; default `nextexplorer://oidc-callback`).

## Platform-neutral
The `redirect_uri` allowlist serves any native client (iOS and Android).

## Security
PKCE binds the one-time code to the initiating app (defense against custom-scheme interception); codes are single-use, short-TTL, consumed before verification, compared timing-safe; `redirect_uri` is restricted to a configured custom-scheme allowlist.

## Tests
21 tests (service + routes) via vitest + supertest, all passing. Prettier clean.