### PR TITLE
[2/14] Archives: extract and compress with 7-Zip, and a test harness that isolates properly

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -69,6 +69,10 @@ module.exports = {
   // Search
   SEARCH_DEEP: normalizeBoolean(process.env.SEARCH_DEEP),
   SEARCH_RIPGREP: normalizeBoolean(process.env.SEARCH_RIPGREP),
+  // --- Archive extraction ---
+  MAX_EXTRACTED_ARCHIVE_SIZE: process.env.MAX_EXTRACTED_ARCHIVE_SIZE?.trim() || null,
+  MAX_ARCHIVE_ENTRIES: Number(process.env.MAX_ARCHIVE_ENTRIES) || 100000,
+  ARCHIVE_EXTENSIONS: process.env.ARCHIVE_EXTENSIONS || '',
   SEARCH_MAX_FILESIZE: process.env.SEARCH_MAX_FILESIZE?.trim() || null,
 
   // OnlyOffice

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -337,7 +337,58 @@ const shares = {
 };
 
 // --- Main Export ---
+
+// --- Archive extraction ---
+// Extensions the app is willing to offer for extraction, provided the local
+// 7-Zip build actually supports them (checked at runtime by archiveService).
+// A whitelist keeps container-ish formats 7-Zip can technically read (docx,
+// apk, exe…) from being presented as archives in the UI.
+const DEFAULT_ARCHIVE_EXTENSIONS = [
+  '7z',
+  'zip',
+  'iso',
+  'rar',
+  'tar',
+  'gz',
+  'tgz',
+  'bz2',
+  'tbz2',
+  'xz',
+  'txz',
+  'cab',
+  'wim',
+  'cpio',
+  'rpm',
+  'deb',
+  'z',
+  'lzh',
+  'arj',
+  'zst',
+];
+
+const archives = (() => {
+  const raw = String(env.ARCHIVE_EXTENSIONS || '').trim();
+  // Extraction guards, generous enough for real archives but low enough that a
+  // crafted one cannot fill the volume before anyone notices.
+  const limits = {
+    maxExtractedBytes: (() => {
+      const parsed = parseByteSize(env.MAX_EXTRACTED_ARCHIVE_SIZE);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : 32 * 1024 * 1024 * 1024;
+    })(),
+    maxEntries: env.MAX_ARCHIVE_ENTRIES,
+  };
+  if (!raw) return { extensions: DEFAULT_ARCHIVE_EXTENSIONS, ...limits };
+  // 'zip,iso' replaces the default list; '+udf,squashfs' extends it.
+  const extend = raw.startsWith('+');
+  const list = parseExtensionList(extend ? raw.slice(1) : raw);
+  return {
+    extensions: extend ? [...new Set([...DEFAULT_ARCHIVE_EXTENSIONS, ...list])] : list,
+    ...limits,
+  };
+})();
+
 module.exports = {
+  archives,
   port: env.PORT,
   address: env.ADDRESS,
   http: {

--- a/backend/src/routes/zip.js
+++ b/backend/src/routes/zip.js
@@ -4,6 +4,8 @@ const fs = require('fs/promises');
 const AdmZip = require('adm-zip');
 
 const asyncHandler = require('../utils/asyncHandler');
+const { mapWithConcurrency } = require('../utils/mapWithConcurrency');
+const { startNdjsonStream, throttlePercent } = require('../utils/ndjsonStream');
 const logger = require('../utils/logger');
 const { pathExists } = require('../utils/fsUtils');
 const {
@@ -15,8 +17,45 @@ const {
 } = require('../utils/pathUtils');
 const { ValidationError, ForbiddenError, NotFoundError } = require('../errors/AppError');
 const { ACTIONS, authorizeAndResolve } = require('../services/authorizationService');
+const {
+  getSupportedArchiveExtensions,
+  isSevenZipAvailable,
+  readArchiveFootprint,
+  extractArchive,
+  createZipArchive,
+  archiveBaseName,
+  normalizeArchivePassword,
+} = require('../services/archiveService');
+const { archives } = require('../config/index');
 
 const router = express.Router();
+
+/**
+ * Refuse archives that would expand far beyond their own size.
+ *
+ * Extraction is otherwise unbounded: a few kilobytes of nested, highly
+ * compressible entries can fill the volume ("zip bomb"). The declared sizes
+ * come from the archive itself, so this is a cheap pre-flight check, not a
+ * guarantee — it stops the accidental and the trivially malicious case.
+ */
+const ensureArchiveWithinLimits = ({ entryCount = 0, totalBytes = 0 }) => {
+  if (entryCount > archives.maxEntries) {
+    throw new ValidationError(
+      `This archive holds more than ${archives.maxEntries} entries and was not extracted.`
+    );
+  }
+  if (totalBytes > archives.maxExtractedBytes) {
+    throw new ValidationError(
+      'This archive expands beyond the allowed size and was not extracted.'
+    );
+  }
+};
+
+/** Declared footprint of a zip read by the bundled JS extractor. */
+const admZipFootprint = (entries = []) => ({
+  entryCount: entries.length,
+  totalBytes: entries.reduce((total, entry) => total + (entry?.header?.size || 0), 0),
+});
 
 const buildItemMetadata = async (absolutePath, relativeParent, name) => {
   const stats = await fs.stat(absolutePath);
@@ -39,12 +78,48 @@ const defaultZipNameForItems = (items = []) => {
   return `${ext ? name.slice(0, -ext.length) : name}.zip`;
 };
 
+const extractIntoCurrentFolder = async ({
+  stagingDirectory,
+  destinationDirectory,
+  relativeParentPath,
+  movedPaths,
+}) => {
+  const stagedEntries = await fs.readdir(stagingDirectory, { withFileTypes: true });
+  const items = [];
+
+  for (const entry of stagedEntries) {
+    const entryName = ensureValidName(entry.name);
+    const destinationName = await findAvailableName(destinationDirectory, entryName);
+    const sourcePath = path.join(stagingDirectory, entryName);
+    const destinationPath = path.join(destinationDirectory, destinationName);
+
+    await fs.rename(sourcePath, destinationPath);
+    movedPaths.push(destinationPath);
+
+    items.push(await buildItemMetadata(destinationPath, relativeParentPath, destinationName));
+  }
+
+  return items;
+};
+
 router.post(
   '/files/zip/extract',
   asyncHandler(async (req, res) => {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    const onClose = () => {
+      if (!res.writableEnded) abort();
+    };
+    req.once('aborted', abort);
+    res.once('close', onClose);
     const inputPath = req.body?.path ?? '';
+    const destination = req.body?.destination ?? 'folder';
+    const archivePassword = normalizeArchivePassword(req.body?.password);
     if (typeof inputPath !== 'string' || !inputPath.trim()) {
-      throw new ValidationError('A zip file path is required.');
+      throw new ValidationError('An archive file path is required.');
+    }
+    if (destination !== 'folder' && destination !== 'current') {
+      throw new ValidationError('Invalid archive extraction destination.');
     }
 
     const relativePath = normalizeRelativePath(inputPath);
@@ -65,10 +140,16 @@ router.post(
     if (!(await pathExists(zipAbsolutePath))) throw new NotFoundError('File not found.');
 
     const stats = await fs.stat(zipAbsolutePath);
-    if (!stats.isFile()) throw new ValidationError('Only zip files can be extracted.');
+    if (!stats.isFile()) throw new ValidationError('Only archive files can be extracted.');
 
-    if (path.extname(zipAbsolutePath).toLowerCase() !== '.zip') {
-      throw new ValidationError('Only .zip archives are supported.');
+    const archiveExtension = path.extname(zipAbsolutePath).slice(1).toLowerCase();
+    const supportedExtensions = await getSupportedArchiveExtensions();
+    if (!supportedExtensions.includes(archiveExtension)) {
+      throw new ValidationError(
+        `Unsupported archive format ".${archiveExtension}". Supported: ${supportedExtensions
+          .map((ext) => `.${ext}`)
+          .join(', ')}.`
+      );
     }
 
     const parentRelativePath = normalizeRelativePath(
@@ -83,47 +164,145 @@ router.post(
       throw new ForbiddenError(parentAccessInfo?.denialReason || 'Destination is read-only.');
     }
 
+    const { allowed: filesAllowed, accessInfo: filesAccessInfo } = await authorizeAndResolve(
+      context,
+      parentRelativePath,
+      ACTIONS.write
+    );
+    if (!filesAllowed) {
+      throw new ForbiddenError(filesAccessInfo?.denialReason || 'Destination is read-only.');
+    }
+
     const parentAbsolutePath = parentResolved?.absolutePath;
     if (!parentAbsolutePath) throw new ForbiddenError('Cannot resolve destination folder.');
 
     const parentStats = await fs.stat(parentAbsolutePath);
     if (!parentStats.isDirectory()) throw new ValidationError('Destination must be a directory.');
 
-    const ext = path.extname(zipAbsolutePath);
-    const zipBaseName = path.basename(zipAbsolutePath, ext);
     const baseFolderName = (() => {
       try {
-        return ensureValidName(zipBaseName || 'Archive');
+        return ensureValidName(archiveBaseName(path.basename(zipAbsolutePath)));
       } catch (_) {
         return 'Archive';
       }
     })();
 
-    const folderName = await findAvailableFolderName(parentAbsolutePath, baseFolderName);
-    const destinationFolderAbsolutePath = path.join(parentAbsolutePath, folderName);
+    const folderName =
+      destination === 'folder'
+        ? await findAvailableFolderName(parentAbsolutePath, baseFolderName)
+        : baseFolderName;
+    const destinationFolderAbsolutePath =
+      destination === 'folder'
+        ? path.join(parentAbsolutePath, folderName)
+        : await fs.mkdtemp(path.join(parentAbsolutePath, '.nextexplorer-extract-'));
+    const movedPaths = [];
 
-    await fs.mkdir(destinationFolderAbsolutePath);
-
-    try {
-      new AdmZip(zipAbsolutePath).extractAllTo(destinationFolderAbsolutePath, true);
-    } catch (error) {
-      logger.warn({ zipAbsolutePath, err: error }, 'Zip extract failed; cleaning up folder');
-      await fs.rm(destinationFolderAbsolutePath, { recursive: true, force: true });
-      throw error;
+    if (destination === 'folder') {
+      await fs.mkdir(destinationFolderAbsolutePath);
     }
 
-    const item = await buildItemMetadata(
-      destinationFolderAbsolutePath,
-      parentRelativePath,
-      folderName
-    );
-    res.status(201).json({ success: true, item });
+    // Everything above throws BEFORE any byte is written, so validation errors
+    // still surface as normal HTTP errors. From here on the response streams
+    // NDJSON progress events, mirroring the copy/move endpoints:
+    //   {type:'start',    name}
+    //   {type:'progress', percent}    (throttled)
+    //   {type:'done',     success, item}
+    //   {type:'error',    message, code}
+    const writeEvent = startNdjsonStream(res);
+
+    writeEvent({ type: 'start', name: folderName });
+
+    const onPercent = throttlePercent(writeEvent);
+
+    try {
+      if (await isSevenZipAvailable()) {
+        // Listing first means an archive that would expand beyond the limits
+        // is refused before anything is written to disk.
+        // Cheap pre-flight when the archive declares a usable listing...
+        const footprint = await readArchiveFootprint(zipAbsolutePath);
+        if (footprint) ensureArchiveWithinLimits(footprint);
+        // 7-Zip streams to disk, so large archives don't get buffered in RAM.
+        // ...and a running guard for everything else: encrypted archives,
+        // listings too large to parse, and the second pass of tarballs.
+        await extractArchive(zipAbsolutePath, destinationFolderAbsolutePath, onPercent, {
+          signal: controller.signal,
+          password: archivePassword,
+          maxBytes: archives.maxExtractedBytes,
+        });
+      } else {
+        const fallbackZip = new AdmZip(zipAbsolutePath);
+        ensureArchiveWithinLimits(admZipFootprint(fallbackZip.getEntries()));
+        fallbackZip.extractAllTo(destinationFolderAbsolutePath, true);
+        if (controller.signal.aborted) {
+          const error = new Error('Operation cancelled.');
+          error.code = 'OPERATION_CANCELLED';
+          throw error;
+        }
+      }
+
+      if (destination === 'folder') {
+        const item = await buildItemMetadata(
+          destinationFolderAbsolutePath,
+          parentRelativePath,
+          folderName
+        );
+        writeEvent({ type: 'done', success: true, item, items: [item] });
+      } else {
+        // Extract to a private sibling first, then move each root entry into the
+        // current folder. This avoids partial writes and lets us apply the same
+        // collision rule used everywhere else: name, name (1), name (2), ...
+        const items = await extractIntoCurrentFolder({
+          stagingDirectory: destinationFolderAbsolutePath,
+          destinationDirectory: parentAbsolutePath,
+          relativeParentPath: parentRelativePath,
+          movedPaths,
+        });
+        await fs.rm(destinationFolderAbsolutePath, { recursive: true, force: true });
+        writeEvent({
+          type: 'done',
+          success: true,
+          item: items.length === 1 ? items[0] : null,
+          items,
+        });
+      }
+    } catch (error) {
+      const isPasswordError =
+        error?.code === 'ARCHIVE_PASSWORD_REQUIRED' || error?.code === 'ARCHIVE_INVALID_PASSWORD';
+      if (isPasswordError) {
+        logger.info({ zipAbsolutePath, code: error.code }, 'Archive password required or rejected');
+      } else {
+        logger.warn(
+          { zipAbsolutePath, err: error },
+          'Archive extract failed; cleaning up destination'
+        );
+      }
+      await fs.rm(destinationFolderAbsolutePath, { recursive: true, force: true });
+      await mapWithConcurrency(movedPaths, (movedPath) =>
+        fs.rm(movedPath, { recursive: true, force: true })
+      );
+      writeEvent({
+        type: 'error',
+        message: error.message || 'Archive extraction failed.',
+        code: error.code || 'EXTRACT_FAILED',
+      });
+    } finally {
+      req.off('aborted', abort);
+      res.off('close', onClose);
+      res.end();
+    }
   })
 );
 
 router.post(
   '/files/zip/compress',
   asyncHandler(async (req, res) => {
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    const onClose = () => {
+      if (!res.writableEnded) abort();
+    };
+    req.once('aborted', abort);
+    res.once('close', onClose);
     const { items = [], destination = '', name } = req.body || {};
 
     if (!Array.isArray(items) || items.length === 0) {
@@ -152,26 +331,25 @@ router.post(
     const destStats = await fs.stat(destinationAbsolutePath);
     if (!destStats.isDirectory()) throw new ValidationError('Destination must be a directory.');
 
-    const sourceTargets = await Promise.all(
-      items.map(async (item) => {
-        if (!item || typeof item.name !== 'string') {
-          throw new ValidationError('Each item must include a name.');
-        }
-        const itemParent = normalizeRelativePath(item.path || '');
-        const itemRelative = combineRelativePath(itemParent, item.name);
-        const { allowed, accessInfo, resolved } = await authorizeAndResolve(
-          context,
-          itemRelative,
-          ACTIONS.read
-        );
-        if (!allowed || !resolved) {
-          throw new ForbiddenError(accessInfo?.denialReason || 'Source item is not accessible.');
-        }
+    // The list came in the request; the number of checks in flight is ours.
+    const sourceTargets = await mapWithConcurrency(items, async (item) => {
+      if (!item || typeof item.name !== 'string') {
+        throw new ValidationError('Each item must include a name.');
+      }
+      const itemParent = normalizeRelativePath(item.path || '');
+      const itemRelative = combineRelativePath(itemParent, item.name);
+      const { allowed, accessInfo, resolved } = await authorizeAndResolve(
+        context,
+        itemRelative,
+        ACTIONS.read
+      );
+      if (!allowed || !resolved) {
+        throw new ForbiddenError(accessInfo?.denialReason || 'Source item is not accessible.');
+      }
 
-        const stats = await fs.stat(resolved.absolutePath);
-        return { name: item.name, absolutePath: resolved.absolutePath, stats };
-      })
-    );
+      const stats = await fs.stat(resolved.absolutePath);
+      return { name: item.name, absolutePath: resolved.absolutePath, stats };
+    });
 
     const requestedName = (() => {
       if (typeof name === 'string' && name.trim()) {
@@ -184,16 +362,64 @@ router.post(
     const zipFileName = await findAvailableName(destinationAbsolutePath, requestedName);
     const zipAbsolutePath = path.join(destinationAbsolutePath, zipFileName);
 
-    const zip = new AdmZip();
-    sourceTargets.forEach(({ name: entryName, absolutePath, stats }) => {
-      stats.isDirectory()
-        ? zip.addLocalFolder(absolutePath, entryName)
-        : zip.addLocalFile(absolutePath, '', entryName);
-    });
-    zip.writeZip(zipAbsolutePath);
+    // Everything above throws BEFORE any byte is written, so validation errors
+    // still surface as normal HTTP errors. From here on the response streams
+    // NDJSON progress events, mirroring the extract endpoint:
+    //   {type:'start',    name}
+    //   {type:'progress', percent}    (throttled)
+    //   {type:'done',     success, item}
+    //   {type:'error',    message, code}
+    const writeEvent = startNdjsonStream(res);
 
-    const item = await buildItemMetadata(zipAbsolutePath, normalizedDestination, zipFileName);
-    res.status(201).json({ success: true, item });
+    writeEvent({ type: 'start', name: zipFileName });
+
+    const onPercent = throttlePercent(writeEvent);
+
+    try {
+      if (await isSevenZipAvailable()) {
+        // 7-Zip streams the archive to disk instead of assembling it in RAM.
+        const sourceParent = path.dirname(sourceTargets[0].absolutePath);
+        const hasCommonParent = sourceTargets.every(
+          ({ absolutePath }) => path.dirname(absolutePath) === sourceParent
+        );
+        await createZipArchive(
+          hasCommonParent
+            ? sourceTargets.map(({ name }) => name)
+            : sourceTargets.map(({ absolutePath }) => absolutePath),
+          zipAbsolutePath,
+          onPercent,
+          { signal: controller.signal, cwd: hasCommonParent ? sourceParent : undefined }
+        );
+      } else {
+        const zip = new AdmZip();
+        sourceTargets.forEach(({ name: entryName, absolutePath, stats }) => {
+          stats.isDirectory()
+            ? zip.addLocalFolder(absolutePath, entryName)
+            : zip.addLocalFile(absolutePath, '', entryName);
+        });
+        zip.writeZip(zipAbsolutePath);
+        if (controller.signal.aborted) {
+          const error = new Error('Operation cancelled.');
+          error.code = 'OPERATION_CANCELLED';
+          throw error;
+        }
+      }
+
+      const item = await buildItemMetadata(zipAbsolutePath, normalizedDestination, zipFileName);
+      writeEvent({ type: 'done', success: true, item });
+    } catch (error) {
+      logger.warn({ zipAbsolutePath, err: error }, 'Archive creation failed; cleaning up file');
+      await fs.rm(zipAbsolutePath, { force: true });
+      writeEvent({
+        type: 'error',
+        message: error.message || 'Archive creation failed.',
+        code: error.code || 'COMPRESS_FAILED',
+      });
+    } finally {
+      req.off('aborted', abort);
+      res.off('close', onClose);
+      res.end();
+    }
   })
 );
 

--- a/backend/src/services/archiveService.js
+++ b/backend/src/services/archiveService.js
@@ -1,0 +1,518 @@
+const path = require('path');
+const fs = require('fs/promises');
+const { execFile, spawn } = require('child_process');
+const { promisify } = require('util');
+
+const logger = require('../utils/logger');
+const { archives } = require('../config/index');
+
+const execFileAsync = promisify(execFile);
+
+// Whitelist of extensions the app may offer for extraction, provided the
+// local 7-Zip build actually supports them (checked against `7z i` at
+// startup). Configurable through ARCHIVE_EXTENSIONS (see config/index.js).
+const CANDIDATE_EXTENSIONS = Array.isArray(archives?.extensions) ? archives.extensions : ['zip'];
+
+// Compound extensions that decompress to an inner tar archive. 7-Zip only
+// peels one layer per run, so these need a second pass on the produced .tar.
+const TAR_WRAPPER_EXTENSIONS = new Set(['gz', 'tgz', 'bz2', 'tbz2', 'xz', 'txz', 'zst', 'z']);
+
+const SEVEN_ZIP_BIN = process.env.SEVEN_ZIP_PATH || '7z';
+
+let supportedExtensionsPromise = null;
+
+/**
+ * Probe the local 7-Zip once and derive the extraction formats it supports.
+ * `7z i` lists every compiled-in format with its extensions, so this stays
+ * accurate across builds (e.g. Alpine builds that ship without the RAR codec).
+ * Falls back to plain .zip (handled by the bundled JS extractor) when 7-Zip
+ * is not installed at all.
+ */
+const probeSupportedExtensions = async () => {
+  try {
+    const { stdout } = await execFileAsync(SEVEN_ZIP_BIN, ['i'], {
+      timeout: 10_000,
+      maxBuffer: 1024 * 1024,
+    });
+    const listed = new Set(
+      stdout
+        .toLowerCase()
+        .split('\n')
+        .flatMap((line) => line.split(/\s+/))
+        .filter((token) => /^[a-z0-9]{1,5}$/.test(token))
+    );
+    const supported = CANDIDATE_EXTENSIONS.filter((ext) => listed.has(ext));
+    // Compound tarball extensions piggy-back on the base codec being present.
+    if (listed.has('gzip') || listed.has('gz')) supported.push('tgz');
+    if (listed.has('bzip2')) supported.push('tbz2');
+    if (listed.has('xz')) supported.push('txz');
+    const unique = [...new Set(supported)];
+    logger.info({ bin: SEVEN_ZIP_BIN, extensions: unique }, 'Archive extraction formats detected');
+    return unique;
+  } catch (error) {
+    logger.warn(
+      { bin: SEVEN_ZIP_BIN, err: error?.message },
+      '7-Zip unavailable; archive extraction limited to .zip'
+    );
+    return ['zip'];
+  }
+};
+
+const getSupportedArchiveExtensions = () => {
+  if (!supportedExtensionsPromise) {
+    supportedExtensionsPromise = probeSupportedExtensions();
+  }
+  return supportedExtensionsPromise;
+};
+
+const isSevenZipAvailable = async () => {
+  const extensions = await getSupportedArchiveExtensions();
+  // The zip-only fallback list means the probe failed.
+  return !(extensions.length === 1 && extensions[0] === 'zip');
+};
+
+/**
+ * Base name an extracted folder should take for a given archive filename:
+ * strips the archive extension, plus the inner `.tar` of compound tarballs
+ * (backup.tar.gz -> backup).
+ */
+const archiveBaseName = (filename) => {
+  const ext = path.extname(filename).slice(1).toLowerCase();
+  let base = path.basename(filename, path.extname(filename));
+  if (TAR_WRAPPER_EXTENSIONS.has(ext) && base.toLowerCase().endsWith('.tar')) {
+    base = base.slice(0, -4);
+  }
+  return base || 'Archive';
+};
+
+const EXTRACT_TIMEOUT_MS = 30 * 60 * 1000;
+const EXTRACT_SIZE_POLL_MS = 2000;
+
+const createSizeLimitError = () => {
+  const error = new Error('This archive expands beyond the allowed size and was not extracted.');
+  error.code = 'ARCHIVE_TOO_LARGE';
+  return error;
+};
+
+const createCancellationError = () => {
+  const error = new Error('Operation cancelled.');
+  error.code = 'OPERATION_CANCELLED';
+  return error;
+};
+
+const ARCHIVE_PASSWORD_ERROR_PATTERN =
+  /wrong password|(?:enter|password).*(?:password|required|incorrect)|can not open encrypted archive|data error in encrypted file|headers error/i;
+
+const normalizeArchivePassword = (value) => {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') {
+    const error = new Error('Invalid archive password.');
+    error.code = 'INVALID_ARCHIVE_PASSWORD';
+    throw error;
+  }
+  // Control characters are exactly what must not reach the extractor prompt.
+  // eslint-disable-next-line no-control-regex
+  if (value.length > 4096 || /[\x00-\x1F\x7F]/.test(value)) {
+    const error = new Error('Invalid archive password.');
+    error.code = 'INVALID_ARCHIVE_PASSWORD';
+    throw error;
+  }
+  return value;
+};
+
+const isArchivePasswordError = (error) =>
+  ARCHIVE_PASSWORD_ERROR_PATTERN.test(String(error?.message || ''));
+
+const createArchivePasswordError = (passwordProvided) => {
+  const error = new Error(
+    passwordProvided ? 'Incorrect archive password or corrupted archive.' : 'Archive password required.'
+  );
+  error.code = passwordProvided ? 'ARCHIVE_INVALID_PASSWORD' : 'ARCHIVE_PASSWORD_REQUIRED';
+  return error;
+};
+
+const throwIfCancelled = (signal) => {
+  if (signal?.aborted) throw createCancellationError();
+};
+
+const appendOutput = (current, chunk) => `${current}${chunk}`.slice(-4000);
+
+const reportProgress = (chunk, onPercent) => {
+  if (typeof onPercent !== 'function') return;
+  const matches = String(chunk).match(/(\d{1,3})%/g);
+  if (!matches?.length) return;
+  const percent = Number.parseInt(matches[matches.length - 1], 10);
+  if (Number.isFinite(percent)) onPercent(Math.min(100, Math.max(0, percent)));
+};
+
+const commandErrorFromOutput = (code, output, passwordProvided) => {
+  const error = new Error(`7z exited with code ${code}: ${output.trim().slice(-500)}`);
+  return isArchivePasswordError(error) ? createArchivePasswordError(passwordProvided) : error;
+};
+
+// When no -p switch is supplied, 7-Zip asks its controlling terminal for the
+// password. A PTY lets us answer that prompt while keeping the secret out of
+// argv, process listings and logs.
+const runSevenZipWithPassword = (args, onPercent, options = {}) =>
+  new Promise((resolve, reject) => {
+    const { signal, cwd, password } = options;
+    if (signal?.aborted) {
+      reject(createCancellationError());
+      return;
+    }
+
+    let pty;
+    try {
+      // Loaded lazily so archive extraction still works when the terminal
+      // feature is disabled at the UI level.
+      pty = require('@homebridge/node-pty-prebuilt-multiarch');
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const child = pty.spawn(SEVEN_ZIP_BIN, args, {
+      name: 'xterm-256color',
+      cols: 120,
+      rows: 40,
+      cwd,
+      env: { ...process.env, TERM: 'xterm-256color' },
+    });
+
+    let outputTail = '';
+    let passwordWritten = false;
+    let settled = false;
+    let killTimer = null;
+    const cleanup = () => {
+      signal?.removeEventListener('abort', abort);
+      if (killTimer) clearTimeout(killTimer);
+    };
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+    const abort = () => {
+      child.kill('SIGTERM');
+      killTimer = setTimeout(() => child.kill('SIGKILL'), 3000);
+      finish(reject, createCancellationError());
+    };
+
+    child.onData((chunk) => {
+      outputTail = appendOutput(outputTail, chunk);
+      reportProgress(chunk, onPercent);
+      if (!passwordWritten && /enter password/i.test(outputTail)) {
+        passwordWritten = true;
+        child.write(`${password}\r`);
+      }
+    });
+    child.onExit(({ exitCode }) => {
+      if (signal?.aborted) {
+        finish(reject, createCancellationError());
+      } else if (exitCode === 0) {
+        onPercent?.(100);
+        finish(resolve);
+      } else {
+        finish(reject, commandErrorFromOutput(exitCode, outputTail, true));
+      }
+    });
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+
+/**
+ * Run one 7-Zip command. `-bsp1` sends the percentage indicator to stdout, so
+ * progress can be parsed from the output stream and forwarded to the caller
+ * (0-100 per run).
+ */
+const runSevenZip = (args, onPercent, options = {}) =>
+  new Promise((resolve, reject) => {
+    const { signal, cwd, password } = options;
+    if (password !== null && password !== undefined) {
+      runSevenZipWithPassword(args, onPercent, options).then(resolve, reject);
+      return;
+    }
+    if (signal?.aborted) {
+      reject(createCancellationError());
+      return;
+    }
+
+    const child = spawn(SEVEN_ZIP_BIN, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: EXTRACT_TIMEOUT_MS,
+    });
+
+    let outputTail = '';
+    let settled = false;
+    let killTimer = null;
+    const cleanup = () => {
+      signal?.removeEventListener('abort', abort);
+      if (killTimer) clearTimeout(killTimer);
+    };
+    const finish = (callback, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback(value);
+    };
+    const abort = () => {
+      child.kill('SIGTERM');
+      killTimer = setTimeout(() => child.kill('SIGKILL'), 3000);
+      finish(reject, createCancellationError());
+    };
+
+    child.stdout.on('data', (chunk) => {
+      outputTail = appendOutput(outputTail, chunk);
+      reportProgress(chunk, onPercent);
+    });
+
+    child.stderr.on('data', (chunk) => {
+      outputTail = appendOutput(outputTail, chunk);
+    });
+
+    child.on('error', (error) => finish(reject, error));
+    child.on('close', (code) => {
+      if (signal?.aborted) {
+        finish(reject, createCancellationError());
+        return;
+      }
+      if (code === 0) {
+        onPercent?.(100);
+        finish(resolve);
+      } else {
+        finish(reject, commandErrorFromOutput(code, outputTail, false));
+      }
+    });
+    signal?.addEventListener('abort', abort, { once: true });
+  });
+
+const runSevenZipExtract = (
+  archiveAbsolutePath,
+  destinationAbsolutePath,
+  onPercent,
+  options = {}
+) =>
+  runSevenZip(
+    // -snl- keeps 7-Zip from restoring symbolic links. Path confinement is a
+    // string comparison, so a link like `evil -> /` inside a tar would make
+    // every later access step outside the volume while still looking valid.
+    ['x', '-y', '-bsp1', '-snl-', `-o${destinationAbsolutePath}`, '--', archiveAbsolutePath],
+    onPercent,
+    options
+  );
+
+/**
+ * Create a .zip archive from the given absolute paths, reporting progress
+ * through `onPercent(0-100)`. 7-Zip stores each entry under its base name,
+ * matching the behaviour of the previous in-memory implementation — but the
+ * archive is streamed to disk instead of being assembled in the Node heap.
+ */
+const createZipArchive = (sourcePaths, zipAbsolutePath, onPercent, options = {}) =>
+  runSevenZip(
+    // `--` keeps the source names operands: callers pass file names straight
+    // from the volume, and 7-Zip would read a leading dash as a switch
+    // (`-sdel` deletes the sources, `@list` reads paths from a file).
+    ['a', '-tzip', '-y', '-bsp1', zipAbsolutePath, '--', ...sourcePaths],
+    onPercent,
+    options
+  );
+
+/**
+ * Extract an archive into the given (existing, empty) destination folder,
+ * reporting overall progress through `onPercent(0-100)`. Compound tarballs
+ * are peeled in two passes (each mapped to half of the progress range); the
+ * intermediate .tar is removed so the folder holds the real content.
+ */
+/**
+ * Total uncompressed size and entry count declared by an archive.
+ *
+ * `7z l -slt` lists without extracting, so an archive that would expand far
+ * beyond its own size can be refused before a single byte is written. The
+ * password is deliberately NOT passed here: it would land in argv (and in
+ * process listings), and an encrypted archive simply reports no footprint —
+ * which the caller handles by watching the extraction instead.
+ *
+ * Returns null whenever the listing is unusable (encrypted headers, timeout,
+ * output larger than the buffer, unknown layout).
+ */
+const readArchiveFootprint = async (archiveAbsolutePath) => {
+  try {
+    const { stdout } = await execFileAsync(
+      SEVEN_ZIP_BIN,
+      ['l', '-slt', '-y', '--', archiveAbsolutePath],
+      { timeout: 30_000, maxBuffer: 16 * 1024 * 1024 }
+    );
+    let totalBytes = 0;
+    let entryCount = 0;
+    for (const line of stdout.split('\n')) {
+      const match = /^Size\s*=\s*(\d+)\s*$/.exec(line.trim());
+      if (match) {
+        totalBytes += Number.parseInt(match[1], 10) || 0;
+        entryCount += 1;
+      }
+    }
+    return entryCount ? { totalBytes, entryCount } : null;
+  } catch (error) {
+    return null;
+  }
+};
+
+/** Bytes currently held under a directory, following no symlink. */
+const directorySize = async (absolutePath) => {
+  let total = 0;
+  const stack = [absolutePath];
+  while (stack.length) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const child = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(child);
+      } else if (entry.isFile()) {
+        try {
+          total += (await fs.lstat(child)).size;
+        } catch {
+          // The file may already be gone; it simply does not count.
+        }
+      }
+    }
+  }
+  return total;
+};
+
+/**
+ * Abort an extraction that outgrows `maxBytes` while it runs.
+ *
+ * The declared footprint is the cheap check, but it is unavailable for
+ * encrypted or oversized listings — exactly the archives worth guarding
+ * against. Watching what actually lands on disk covers those, plus the second
+ * pass of compound tarballs and any archive that under-reports its own size.
+ */
+const watchExtractionSize = (destinationAbsolutePath, maxBytes, onExceeded) => {
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0) return () => {};
+  let stopped = false;
+  const timer = setInterval(async () => {
+    if (stopped) return;
+    const written = await directorySize(destinationAbsolutePath);
+    if (!stopped && written > maxBytes) {
+      stopped = true;
+      onExceeded(written);
+    }
+  }, EXTRACT_SIZE_POLL_MS);
+  // Never hold the process open for the sake of this watcher.
+  timer.unref?.();
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
+};
+
+
+/**
+ * Reject an extraction that produced a symbolic link.
+ *
+ * `-snl-` already tells 7-Zip not to restore links, but this is the check
+ * that actually protects the volume boundary, so it does not rely on a
+ * single switch of an external tool.
+ */
+const assertNoSymlinks = async (rootAbsolutePath) => {
+  const stack = [rootAbsolutePath];
+  while (stack.length) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) {
+        const error = new Error('This archive contains symbolic links and was not extracted.');
+        error.code = 'ARCHIVE_CONTAINS_SYMLINK';
+        throw error;
+      }
+      if (entry.isDirectory()) stack.push(path.join(current, entry.name));
+    }
+  }
+};
+
+const extractArchive = async (
+  archiveAbsolutePath,
+  destinationAbsolutePath,
+  onPercent,
+  options = {}
+) => {
+  const { signal, password = null, maxBytes = 0 } = options;
+  throwIfCancelled(signal);
+  const ext = path.extname(archiveAbsolutePath).slice(1).toLowerCase();
+  const isCompound = TAR_WRAPPER_EXTENSIONS.has(ext);
+
+  // The watcher cancels through the same signal path as a user cancellation,
+  // so a partial extraction is cleaned up exactly like an aborted one.
+  const controller = new AbortController();
+  const forwardAbort = () => controller.abort();
+  signal?.addEventListener('abort', forwardAbort, { once: true });
+  let sizeExceeded = false;
+  const stopWatching = watchExtractionSize(destinationAbsolutePath, maxBytes, () => {
+    sizeExceeded = true;
+    controller.abort();
+  });
+
+  try {
+    await runSevenZipExtract(
+      archiveAbsolutePath,
+      destinationAbsolutePath,
+      isCompound ? (p) => onPercent?.(Math.round(p / 2)) : onPercent,
+      { signal: controller.signal, password }
+    );
+
+    if (isCompound) {
+      throwIfCancelled(controller.signal);
+      const entries = await fs.readdir(destinationAbsolutePath);
+      if (entries.length === 1 && entries[0].toLowerCase().endsWith('.tar')) {
+        const innerTar = path.join(destinationAbsolutePath, entries[0]);
+        await runSevenZipExtract(
+          innerTar,
+          destinationAbsolutePath,
+          (p) => onPercent?.(50 + Math.round(p / 2)),
+          { signal: controller.signal, password }
+        );
+        await fs.rm(innerTar, { force: true });
+      } else {
+        onPercent?.(100);
+      }
+    }
+    // The periodic watcher misses anything that finishes between two polls,
+    // so the decisive check is this one, once everything is on disk.
+    if (Number.isFinite(maxBytes) && maxBytes > 0) {
+      const written = await directorySize(destinationAbsolutePath);
+      if (written > maxBytes) throw createSizeLimitError();
+    }
+
+    await assertNoSymlinks(destinationAbsolutePath);
+  } catch (error) {
+    // A cancellation raised by the watcher is really a size refusal.
+    if (sizeExceeded) throw createSizeLimitError();
+    throw error;
+  } finally {
+    stopWatching();
+    signal?.removeEventListener('abort', forwardAbort);
+  }
+};
+
+module.exports = {
+  getSupportedArchiveExtensions,
+  isSevenZipAvailable,
+  readArchiveFootprint,
+  extractArchive,
+  createZipArchive,
+  archiveBaseName,
+  normalizeArchivePassword,
+  isArchivePasswordError,
+};

--- a/backend/src/utils/mapWithConcurrency.js
+++ b/backend/src/utils/mapWithConcurrency.js
@@ -1,0 +1,40 @@
+const os = require('os');
+
+/**
+ * Map over items with a bounded number of them in flight.
+ *
+ * `Promise.all(items.map(...))` starts everything at once, which is fine for a
+ * list the code chose and quite different for one the request brought with it:
+ * a client that asks about ten thousand paths gets ten thousand simultaneous
+ * authorization checks and stats, and the machine has no say in it. The list is
+ * the client's, so the concurrency has to be ours.
+ *
+ * The same shape as the pool the transfer service has always used, written once
+ * so a new route does not have to remember to write it again.
+ */
+const DEFAULT_CONCURRENCY = Math.max(
+  1,
+  typeof os.availableParallelism === 'function' ? os.availableParallelism() : os.cpus().length
+);
+
+const mapWithConcurrency = async (items, mapper, concurrency = DEFAULT_CONCURRENCY) => {
+  const list = Array.isArray(items) ? items : [];
+  const results = new Array(list.length);
+  let next = 0;
+
+  const workerCount = Math.min(Math.max(1, concurrency), list.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    for (;;) {
+      const index = next;
+      next += 1;
+      if (index >= list.length) return;
+      // eslint-disable-next-line no-await-in-loop
+      results[index] = await mapper(list[index], index);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+};
+
+module.exports = { mapWithConcurrency, DEFAULT_CONCURRENCY };

--- a/backend/src/utils/ndjsonStream.js
+++ b/backend/src/utils/ndjsonStream.js
@@ -1,0 +1,81 @@
+/**
+ * NDJSON progress streams, in one place.
+ *
+ * Delete, transfer and archive all stream the same way: a 200 committed before
+ * the work starts, then one JSON object per line. They had three copies of the
+ * same header block and the same "don't write to a closed socket" guard, and
+ * the copies had already drifted — only delete flushed its headers, so the
+ * other two left the client waiting on an empty response until the first event
+ * happened to arrive.
+ *
+ * The status is committed here on purpose: once headers are out, a failure can
+ * only be reported as an error *event*, never as an HTTP status. Callers must
+ * therefore do their authorization and validation before calling this.
+ */
+const startNdjsonStream = (res, { onClose } = {}) => {
+  res.status(200);
+  res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  // Without this, nginx holds progress lines until the response ends.
+  res.setHeader('X-Accel-Buffering', 'no');
+  if (typeof onClose === 'function') res.once('close', onClose);
+  res.flushHeaders?.();
+
+  return (event) => {
+    if (res.writableEnded || res.destroyed) return;
+    res.write(`${JSON.stringify(event)}\n`);
+  };
+};
+
+/**
+ * Percent events, throttled so a fast operation does not spend its time
+ * writing progress lines nobody can read that quickly.
+ */
+const throttlePercent = (writeEvent, intervalMs = 150) => {
+  let lastAt = 0;
+  let lastPercent = -1;
+
+  return (percent) => {
+    const now = Date.now();
+    if (percent === lastPercent) return;
+    if (percent < 100 && now - lastAt < intervalMs) return;
+    lastAt = now;
+    lastPercent = percent;
+    writeEvent({ type: 'progress', percent });
+  };
+};
+
+/**
+ * Let progress events through at a steady rate, keeping the last one.
+ *
+ * A bulk operation reports once per item: three thousand files means three
+ * thousand socket writes, three thousand lines to parse and as many reactive
+ * updates in the browser — for a bar that can only show a hundred distinct
+ * positions. The final event is never dropped, so the bar always lands on
+ * completion rather than stopping just short of it.
+ */
+const throttleProgress = (writeEvent, intervalMs = 100) => {
+  let lastAt = 0;
+  let pending = null;
+
+  const send = (event) => {
+    pending = null;
+    lastAt = Date.now();
+    writeEvent(event);
+  };
+
+  const throttled = (event) => {
+    const now = Date.now();
+    if (now - lastAt >= intervalMs) send(event);
+    else pending = event;
+  };
+
+  // Called once the work is done, so the last position is not lost.
+  throttled.flush = () => {
+    if (pending) send(pending);
+  };
+
+  return throttled;
+};
+
+module.exports = { startNdjsonStream, throttlePercent, throttleProgress };

--- a/backend/tests/helpers/env-test-utils.js
+++ b/backend/tests/helpers/env-test-utils.js
@@ -12,7 +12,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
-const DEFAULT_MODULES = ['src/config/env', 'src/config/index', 'src/services/db'];
+const SRC_ROOT = path.join(REPO_ROOT, 'src') + path.sep;
 
 /**
  * Override environment variables and return a restore function.
@@ -72,6 +72,26 @@ const clearModulesCache = (modules) => {
 };
 
 /**
+ * Drop every module of the application from the require cache.
+ *
+ * Most of them read the configured directories once, at load time, and keep
+ * what they computed. A test that only cleared the modules it names therefore
+ * ran against the *first* test's temporary volume as soon as a helper it never
+ * mentioned sat in between — pathUtils, fsUtils, authorizationService have all
+ * played that role. The failures were the worst kind: green in isolation, red
+ * in a suite, and pointing at the assertion rather than the cause.
+ *
+ * Clearing the whole tree removes the guessing. It costs a reload of whatever
+ * the test actually requires afterwards, which is a few milliseconds, and it
+ * cannot be forgotten.
+ */
+const clearApplicationModules = () => {
+  for (const resolved of Object.keys(require.cache)) {
+    if (resolved.startsWith(SRC_ROOT)) delete require.cache[resolved];
+  }
+};
+
+/**
  * Create temporary directories for test isolation.
  * @param {string} tag - Prefix for the temp directory name
  * @returns {Promise<{tmpRoot: string, configDir: string, cacheDir: string, volumeDir: string}>}
@@ -92,24 +112,71 @@ const createTempDirs = async (tag = 'backend-tests-') => {
 /**
  * Set up a complete test environment with temp dirs and env overrides.
  *
+ * Every application module is dropped from the require cache, so nothing
+ * carries the previous test's directories over. `modules` is therefore no
+ * longer needed and is kept only for callers that still pass it.
+ *
  * @param {Object} options - Setup options
  * @param {string} options.tag - Prefix for temp directory
- * @param {string[]} options.modules - Additional modules to clear from cache
+ * @param {string[]} [options.modules] - Unused; all application modules are cleared
  * @param {Record<string, string>} options.env - Additional env vars to set
  * @returns {Promise<TestEnvContext>} Context object with cleanup and helper methods
  *
  * @example
- * const env = await setupTestEnv({
- *   tag: 'my-test-',
- *   modules: ['src/services/myService'],
- *   env: { MY_VAR: 'value' }
- * });
+ * const env = await setupTestEnv({ tag: 'my-test-', env: { MY_VAR: 'value' } });
  *
  * const myService = env.requireFresh('src/services/myService');
  * // ... run tests ...
  *
  * await env.cleanup();
  */
+/**
+ * Stop the background work a test may have started, without starting any.
+ *
+ * `require.cache` is consulted rather than `require` so that a module the test
+ * never loaded stays unloaded — asking a service to stop is otherwise a way of
+ * starting it.
+ */
+const loadedModule = (relativePath) => {
+  const resolved = modulePath(relativePath);
+  try {
+    return require.cache[require.resolve(resolved)]?.exports || null;
+  } catch {
+    return null;
+  }
+};
+
+const quiesceLoadedServices = async () => {
+  const searchIndex = loadedModule('src/services/searchIndexManager');
+  try {
+    searchIndex?.stop?.();
+  } catch {
+    /* a manager that never started has nothing to stop */
+  }
+
+  // Thumbnails are the other thing that outlives the request that asked for
+  // it: three queues and three timers, which go on writing into a cache
+  // directory that is about to be deleted — and a write landing during the
+  // removal fails it outright with ENOTEMPTY.
+  const thumbnails = loadedModule('src/services/thumbnailService');
+  try {
+    await thumbnails?.stopThumbnailWork?.();
+  } catch {
+    /* nothing queued is nothing to drain */
+  }
+
+  const db = loadedModule('src/services/db');
+  try {
+    db?.closeDb?.();
+  } catch {
+    /* an unopened database has no handle to close */
+  }
+
+  // One turn for anything that was mid-flight to settle before the directory
+  // it is writing into disappears.
+  await new Promise((resolve) => setImmediate(resolve));
+};
+
 const setupTestEnv = async ({ tag, modules = [], env = {} } = {}) => {
   const dirs = await createTempDirs(tag);
   const envOverrides = {
@@ -121,9 +188,9 @@ const setupTestEnv = async ({ tag, modules = [], env = {} } = {}) => {
   };
   const restoreEnv = overrideEnv(envOverrides);
 
-  const modulesToClear = Array.from(new Set([...DEFAULT_MODULES, ...modules]));
-  const clearAll = () => modulesToClear.forEach(clearModuleCache);
-  clearAll();
+  // `modules` is accepted for compatibility; clearing everything covers it.
+  void modules;
+  clearApplicationModules();
 
   return {
     ...dirs,
@@ -133,9 +200,31 @@ const setupTestEnv = async ({ tag, modules = [], env = {} } = {}) => {
      * Call this in afterAll/afterEach to restore state.
      */
     cleanup: async () => {
+      // Close what the test started before the ground is removed from under
+      // it. Dropping the module registry does not stop a timer or a queued
+      // pass that a loaded module already scheduled: it keeps running against
+      // a directory that is about to be deleted and an environment that is
+      // about to be restored, and it lands on whichever test comes next. That
+      // is the whole of the intermittent failure this suite had — five
+      // different tests in five different files over two days, each passing on
+      // its own.
+      //
+      // Only modules already in the registry are touched: requiring one here
+      // to shut it down would start it.
+      await quiesceLoadedServices();
       restoreEnv();
-      clearAll();
-      await fs.rm(dirs.tmpRoot, { recursive: true, force: true });
+      clearApplicationModules();
+      // Retries because quiescing cannot be perfect: a thumbnail write can be
+      // between its temp file and its rename at the instant the queues report
+      // idle, and the directory then refuses to go with ENOTEMPTY. That is a
+      // race the cleanup can absorb — a test failing on the tidying up after it
+      // has already passed teaches nobody anything.
+      await fs.rm(dirs.tmpRoot, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 50,
+      });
     },
     /**
      * Require a module with a fresh cache.
@@ -200,6 +289,7 @@ module.exports = {
   overrideEnv,
   clearModuleCache,
   clearModulesCache,
+  clearApplicationModules,
   createTempDirs,
   setupTestEnv,
   createTestApp,

--- a/backend/tests/routes/archive-extract.test.js
+++ b/backend/tests/routes/archive-extract.test.js
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import express from 'express';
+import request from 'supertest';
+import AdmZip from 'adm-zip';
+import { setupTestEnv, clearModuleCache } from '../helpers/env-test-utils.js';
+
+let envContext;
+
+beforeAll(async () => {
+  envContext = await setupTestEnv({
+    tag: 'archive-extract-test-',
+    modules: [
+      'src/services/db',
+      'src/services/users',
+      'src/services/archiveService',
+      'src/utils/pathUtils',
+      'src/middleware/errorHandler',
+      'src/routes/zip',
+    ],
+  });
+});
+
+afterAll(async () => {
+  await envContext.cleanup();
+});
+
+const buildApp = ({ user } = {}) => {
+  if (!envContext) throw new Error('Test environment not initialized');
+
+  clearModuleCache('src/config/env');
+  clearModuleCache('src/config/index');
+
+  const zipRoutes = envContext.requireFresh('src/routes/zip');
+  const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (user) req.user = user;
+    next();
+  });
+  app.use('/api', zipRoutes);
+  app.use(errorHandler);
+  return app;
+};
+
+const adminUser = { id: 'admin', roles: ['admin'] };
+
+// The extract endpoint streams NDJSON events (start/progress/done/error).
+const parseNdjson = (text) =>
+  String(text || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+
+describe('Archive extraction', () => {
+  it('extracts a zip archive into a sibling folder, streaming its status', async () => {
+    const workDir = path.join(envContext.volumeDir, 'archives');
+    await fs.mkdir(workDir, { recursive: true });
+
+    const zip = new AdmZip();
+    zip.addFile('hello.txt', Buffer.from('hello archive'));
+    zip.addFile('nested/deep.txt', Buffer.from('nested content'));
+    zip.writeZip(path.join(workDir, 'sample.zip'));
+
+    const app = buildApp({ user: adminUser });
+    const response = await request(app)
+      .post('/api/files/zip/extract')
+      .send({ path: 'archives/sample.zip' });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('application/x-ndjson');
+
+    const events = parseNdjson(response.text);
+    expect(events[0]).toMatchObject({ type: 'start', name: 'sample' });
+    const done = events.at(-1);
+    expect(done.type).toBe('done');
+    expect(done.item?.name).toBe('sample');
+    expect(done.item?.kind).toBe('directory');
+
+    const extractedRoot = path.join(workDir, 'sample');
+    expect(await fs.readFile(path.join(extractedRoot, 'hello.txt'), 'utf8')).toBe('hello archive');
+    expect(await fs.readFile(path.join(extractedRoot, 'nested', 'deep.txt'), 'utf8')).toBe(
+      'nested content'
+    );
+  });
+
+  it('extracts root entries directly into the current folder on request', async () => {
+    const workDir = path.join(envContext.volumeDir, 'archives-current');
+    await fs.mkdir(workDir, { recursive: true });
+
+    const zip = new AdmZip();
+    zip.addFile('hello.txt', Buffer.from('hello archive'));
+    zip.addFile('nested/deep.txt', Buffer.from('nested content'));
+    zip.writeZip(path.join(workDir, 'sample.zip'));
+
+    const app = buildApp({ user: adminUser });
+    const response = await request(app)
+      .post('/api/files/zip/extract')
+      .send({ path: 'archives-current/sample.zip', destination: 'current' });
+
+    expect(response.status).toBe(200);
+    const done = parseNdjson(response.text).at(-1);
+    expect(done).toMatchObject({ type: 'done', success: true });
+    expect(done.item).toBeNull();
+    expect(done.items.map((item) => item.name).sort()).toEqual(['hello.txt', 'nested']);
+    expect(await fs.readFile(path.join(workDir, 'hello.txt'), 'utf8')).toBe('hello archive');
+    expect(await fs.readFile(path.join(workDir, 'nested', 'deep.txt'), 'utf8')).toBe(
+      'nested content'
+    );
+    expect(await fs.readdir(workDir)).not.toContain('sample');
+  });
+
+  it('renames conflicting root entries when extracting into the current folder', async () => {
+    const workDir = path.join(envContext.volumeDir, 'archives-collision');
+    await fs.mkdir(workDir, { recursive: true });
+    await fs.writeFile(path.join(workDir, 'report.txt'), 'existing file');
+
+    const zip = new AdmZip();
+    zip.addFile('report.txt', Buffer.from('archive file'));
+    zip.writeZip(path.join(workDir, 'sample.zip'));
+
+    const app = buildApp({ user: adminUser });
+    const response = await request(app)
+      .post('/api/files/zip/extract')
+      .send({ path: 'archives-collision/sample.zip', destination: 'current' });
+
+    expect(response.status).toBe(200);
+    const done = parseNdjson(response.text).at(-1);
+    expect(done.item?.name).toBe('report (1).txt');
+    expect(await fs.readFile(path.join(workDir, 'report.txt'), 'utf8')).toBe('existing file');
+    expect(await fs.readFile(path.join(workDir, 'report (1).txt'), 'utf8')).toBe('archive file');
+  });
+
+  it('rejects formats the local build does not support', async () => {
+    const workDir = path.join(envContext.volumeDir, 'archives-bad');
+    await fs.mkdir(workDir, { recursive: true });
+    await fs.writeFile(path.join(workDir, 'document.docx'), 'not really an archive');
+
+    const app = buildApp({ user: adminUser });
+    const response = await request(app)
+      .post('/api/files/zip/extract')
+      .send({ path: 'archives-bad/document.docx' });
+
+    expect(response.status).toBe(400);
+    expect(response.body?.error?.message || response.text).toMatch(/unsupported archive format/i);
+  });
+
+  it('compresses a selection into a zip, streaming its status', async () => {
+    const workDir = path.join(envContext.volumeDir, 'to-compress');
+    await fs.mkdir(path.join(workDir, 'sub'), { recursive: true });
+    await fs.writeFile(path.join(workDir, 'a.txt'), 'alpha');
+    await fs.writeFile(path.join(workDir, 'sub', 'b.txt'), 'beta');
+
+    const app = buildApp({ user: adminUser });
+    const response = await request(app)
+      .post('/api/files/zip/compress')
+      .send({
+        items: [
+          { name: 'a.txt', path: 'to-compress' },
+          { name: 'sub', path: 'to-compress', kind: 'directory' },
+        ],
+        destination: 'to-compress',
+        name: 'bundle',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('application/x-ndjson');
+
+    const events = parseNdjson(response.text);
+    expect(events[0]).toMatchObject({ type: 'start', name: 'bundle.zip' });
+    const done = events.at(-1);
+    expect(done.type).toBe('done');
+    expect(done.item?.name).toBe('bundle.zip');
+
+    const entries = new AdmZip(path.join(workDir, 'bundle.zip'))
+      .getEntries()
+      .map((entry) => entry.entryName.replace(/\\/g, '/'));
+    expect(entries).toContain('a.txt');
+    expect(entries).toContain('sub/b.txt');
+  });
+
+  it('reports the supported formats from the 7-Zip probe', async () => {
+    const archiveService = envContext.requireFresh('src/services/archiveService');
+    const extensions = await archiveService.getSupportedArchiveExtensions();
+
+    expect(Array.isArray(extensions)).toBe(true);
+    // zip is always available: either through 7-Zip or the bundled fallback.
+    expect(extensions).toContain('zip');
+  });
+
+  describe('ARCHIVE_EXTENSIONS configuration', () => {
+    const loadConfigWithEnv = (value) => {
+      const previous = process.env.ARCHIVE_EXTENSIONS;
+      if (value === undefined) delete process.env.ARCHIVE_EXTENSIONS;
+      else process.env.ARCHIVE_EXTENSIONS = value;
+      clearModuleCache('src/config/env');
+      clearModuleCache('src/config/index');
+      const config = envContext.requireFresh('src/config/index');
+      if (previous === undefined) delete process.env.ARCHIVE_EXTENSIONS;
+      else process.env.ARCHIVE_EXTENSIONS = previous;
+      return config;
+    };
+
+    it('uses the default whitelist when unset', () => {
+      const { archives } = loadConfigWithEnv(undefined);
+      expect(archives.extensions).toContain('iso');
+      expect(archives.extensions).toContain('rar');
+      expect(archives.extensions).toContain('zip');
+    });
+
+    it('replaces the whitelist with a plain list', () => {
+      const { archives } = loadConfigWithEnv('zip, .ISO');
+      expect(archives.extensions).toEqual(['zip', 'iso']);
+    });
+
+    it('extends the defaults with a leading +', () => {
+      const { archives } = loadConfigWithEnv('+udf,squashfs');
+      expect(archives.extensions).toContain('udf');
+      expect(archives.extensions).toContain('squashfs');
+      expect(archives.extensions).toContain('rar');
+      expect(archives.extensions).toContain('zip');
+    });
+  });
+});

--- a/backend/tests/routes/zip-refusals.test.js
+++ b/backend/tests/routes/zip-refusals.test.js
@@ -1,0 +1,157 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import express from 'express';
+import request from 'supertest';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * What the archive endpoints refuse. The extraction and compression suites
+ * cover the paths that work; every branch that says no was untested, and they
+ * are the ones that decide where an archive may be written and what may be read
+ * into it.
+ *
+ * As in the upload suite, the `!allowed || !resolved` pairs cannot be told
+ * apart by any test: the authorization service returns no resolved path when it
+ * refuses, so the second half never fires alone.
+ */
+
+let currentEnv;
+
+afterEach(async () => {
+  if (currentEnv) {
+    await currentEnv.cleanup();
+    currentEnv = null;
+  }
+});
+
+const seed = async (env = {}) => {
+  currentEnv = await setupTestEnv({
+    tag: 'zip-refusals-',
+    env,
+    modules: ['src/config/env', 'src/config/index', 'src/routes/zip'],
+  });
+  const dbService = currentEnv.requireFresh('src/services/db');
+  const db = await dbService.getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+     VALUES ('user-1','r@example.com',1,'r','R','["user"]', ?, ?)`
+  ).run(now, now);
+  await fs.mkdir(path.join(currentEnv.volumeDir, 'Work'), { recursive: true });
+  await fs.writeFile(path.join(currentEnv.volumeDir, 'Work', 'one.txt'), 'one\n');
+  return db;
+};
+
+const buildApp = (user) => {
+  const routes = currentEnv.requireFresh('src/routes/zip');
+  const { errorHandler } = currentEnv.requireFresh('src/middleware/errorHandler');
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    if (user) req.user = user;
+    next();
+  });
+  app.use('/api', routes);
+  app.use(errorHandler);
+  return app;
+};
+
+const ADMIN = { id: 'admin-1', roles: ['admin'] };
+const RESTRICTED = { id: 'user-1', roles: [] };
+
+const compress = (app, body) => request(app).post('/api/files/zip/compress').send(body);
+const reason = (response) => response.body?.error?.message || response.text;
+
+describe('what may go into an archive', () => {
+  it('refuses a request with no items', async () => {
+    await seed();
+
+    const response = await compress(buildApp(ADMIN), { items: [], destination: 'Work' });
+
+    expect(response.status).toBe(400);
+    expect(reason(response)).toMatch(/at least one item/i);
+  });
+
+  it('refuses an item with no name', async () => {
+    await seed();
+
+    const response = await compress(buildApp(ADMIN), {
+      items: [{ path: 'Work' }],
+      destination: 'Work',
+    });
+
+    expect(response.status).toBe(400);
+    expect(reason(response)).toMatch(/must include a name/i);
+  });
+
+  it('refuses a source the caller cannot reach', async () => {
+    await seed({ USER_VOLUMES: 'true' });
+
+    const response = await compress(buildApp(RESTRICTED), {
+      items: [{ name: 'one.txt', path: 'Work' }],
+      destination: 'Work',
+    });
+
+    expect(response.status).toBe(403);
+  });
+});
+
+describe('where an archive may be written', () => {
+  it('refuses an empty destination', async () => {
+    await seed();
+
+    const response = await compress(buildApp(ADMIN), {
+      items: [{ name: 'one.txt', path: 'Work' }],
+      destination: '   ',
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('refuses a destination that is a file', async () => {
+    await seed();
+
+    const response = await compress(buildApp(ADMIN), {
+      items: [{ name: 'one.txt', path: 'Work' }],
+      destination: 'Work/one.txt',
+    });
+
+    expect(response.status).toBe(400);
+    expect(reason(response)).toMatch(/must be a directory/i);
+  });
+
+  it('refuses a destination the caller may not write to', async () => {
+    await seed({ USER_VOLUMES: 'true' });
+
+    const response = await compress(buildApp(RESTRICTED), {
+      items: [{ name: 'one.txt', path: 'Work' }],
+      destination: 'Work',
+    });
+
+    expect(response.status).toBe(403);
+  });
+});
+
+describe('what may be extracted', () => {
+  it('refuses a path that is not there', async () => {
+    await seed();
+
+    const response = await request(buildApp(ADMIN))
+      .post('/api/files/zip/extract')
+      .send({ path: 'Work/absent.zip' });
+
+    expect([400, 404]).toContain(response.status);
+  });
+
+  it('refuses an archive the caller cannot read', async () => {
+    await seed({ USER_VOLUMES: 'true' });
+    await fs.writeFile(path.join(currentEnv.volumeDir, 'Work', 'a.zip'), 'PK');
+
+    const response = await request(buildApp(RESTRICTED))
+      .post('/api/files/zip/extract')
+      .send({ path: 'Work/a.zip' });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/backend/tests/services/archive-primitives.test.js
+++ b/backend/tests/services/archive-primitives.test.js
@@ -1,0 +1,244 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * The parts of archive handling that do not need 7-Zip to be installed.
+ *
+ * `archiveService` sat at 22.6%, and the untested majority needs a real
+ * extractor. What does not is the part standing between a user-supplied string
+ * and a process: `normalizeArchivePassword` is what stops control characters
+ * reaching the extractor's prompt, and it is the only thing that does.
+ *
+ * The rest is naming and degradation. A `.tar.gz` must extract into `project`
+ * and not `project.tar`, because 7-Zip peels one layer per run and the
+ * intermediate name would otherwise stick. And with no 7-Zip at all the service
+ * falls back to zip rather than claiming formats it cannot open — which is the
+ * state of the machine these run on, so that path is exercised for real rather
+ * than simulated.
+ */
+
+let ctx;
+
+const setup = async (env = {}) => {
+  const context = await setupTestEnv({
+    tag: 'archive-primitives-',
+    env,
+    modules: ['src/config/env', 'src/config/index', 'src/services/archiveService'],
+  });
+  ctx = context;
+  return context.requireFresh('src/services/archiveService');
+};
+
+afterEach(async () => {
+  if (ctx) {
+    await ctx.cleanup();
+    ctx = null;
+  }
+});
+
+const refusal = (service, value) => {
+  try {
+    service.normalizeArchivePassword(value);
+    return null;
+  } catch (error) {
+    return error;
+  }
+};
+
+/** Control characters are built rather than typed, so this file stays readable. */
+const ctrl = (code) => String.fromCharCode(code);
+
+describe('the password on its way to the extractor', () => {
+  it('lets an ordinary one through unchanged', async () => {
+    const service = await setup();
+
+    expect(service.normalizeArchivePassword('correct horse battery staple')).toBe(
+      'correct horse battery staple'
+    );
+  });
+
+  it('keeps accents, symbols and spaces', async () => {
+    const service = await setup();
+
+    expect(service.normalizeArchivePassword('Ete 2026 - unicode ok')).toBe('Ete 2026 - unicode ok');
+  });
+
+  it('treats absence as no password rather than an empty one', async () => {
+    const service = await setup();
+
+    expect(service.normalizeArchivePassword(undefined)).toBeNull();
+    expect(service.normalizeArchivePassword(null)).toBeNull();
+  });
+
+  /** An empty string is a password somebody typed; it is not "no password". */
+  it('keeps an empty string as an empty string', async () => {
+    const service = await setup();
+
+    expect(service.normalizeArchivePassword('')).toBe('');
+  });
+
+  /**
+   * The reason this function exists. A newline or a NUL in a value handed to a
+   * process is where a password stops being data.
+   */
+  it.each([
+    ['a NUL', 0],
+    ['a tab', 9],
+    ['a newline', 10],
+    ['a carriage return', 13],
+    ['an escape', 27],
+    ['a unit separator', 31],
+    ['a delete', 127],
+  ])('refuses %s in the middle', async (_label, code) => {
+    const service = await setup();
+
+    expect(refusal(service, `pass${ctrl(code)}word`)?.code).toBe('INVALID_ARCHIVE_PASSWORD');
+  });
+
+  it('refuses one at the very start, where a trimming bug would hide it', async () => {
+    const service = await setup();
+
+    expect(refusal(service, `${ctrl(10)}password`)?.code).toBe('INVALID_ARCHIVE_PASSWORD');
+  });
+
+  it('refuses one at the very end', async () => {
+    const service = await setup();
+
+    expect(refusal(service, `password${ctrl(0)}`)?.code).toBe('INVALID_ARCHIVE_PASSWORD');
+  });
+
+  it('refuses anything that is not a string', async () => {
+    const service = await setup();
+
+    for (const value of [42, true, {}, [], () => {}]) {
+      expect(refusal(service, value)?.code).toBe('INVALID_ARCHIVE_PASSWORD');
+    }
+  });
+
+  it('refuses one longer than four thousand characters', async () => {
+    const service = await setup();
+
+    expect(service.normalizeArchivePassword('a'.repeat(4096))).toHaveLength(4096);
+    expect(refusal(service, 'a'.repeat(4097))?.code).toBe('INVALID_ARCHIVE_PASSWORD');
+  });
+});
+
+describe('recognising a wrong password in what the extractor said', () => {
+  it.each([
+    'Wrong password?',
+    'ERROR: Wrong password : archive.7z',
+    'Data Error in encrypted file. Wrong password?',
+    'Can not open encrypted archive. Wrong password?',
+    'Headers Error',
+  ])('recognises %s', async (message) => {
+    const service = await setup();
+
+    expect(service.isArchivePasswordError(new Error(message))).toBe(true);
+  });
+
+  it('does not mistake an unrelated failure for one', async () => {
+    const service = await setup();
+
+    expect(service.isArchivePasswordError(new Error('No space left on device'))).toBe(false);
+    expect(service.isArchivePasswordError(new Error('Cannot open the file as archive'))).toBe(false);
+  });
+
+  it('says no rather than throwing on something that is not an error', async () => {
+    const service = await setup();
+
+    expect(service.isArchivePasswordError(null)).toBe(false);
+    expect(service.isArchivePasswordError(undefined)).toBe(false);
+    expect(service.isArchivePasswordError({})).toBe(false);
+  });
+});
+
+describe('what an extracted folder is called', () => {
+  it('drops the extension', async () => {
+    const service = await setup();
+
+    expect(service.archiveBaseName('project.zip')).toBe('project');
+    expect(service.archiveBaseName('backup.7z')).toBe('backup');
+  });
+
+  /**
+   * 7-Zip peels one layer per run, so a `.tar.gz` goes to `.tar` first. Naming
+   * the folder after the intermediate leaves `project.tar` sitting on disk.
+   */
+  it.each([
+    ['project.tar.gz', 'project'],
+    ['project.tar.bz2', 'project'],
+    ['project.tar.xz', 'project'],
+    ['project.tar.zst', 'project'],
+    ['project.TAR.GZ', 'project'],
+  ])('strips the inner .tar from %s', async (filename, expected) => {
+    const service = await setup();
+
+    expect(service.archiveBaseName(filename)).toBe(expected);
+  });
+
+  it('leaves a .tar alone, which is already the archive', async () => {
+    const service = await setup();
+
+    expect(service.archiveBaseName('project.tar')).toBe('project');
+  });
+
+  it('does not strip .tar from a name that merely ends in it', async () => {
+    const service = await setup();
+
+    expect(service.archiveBaseName('avatar.zip')).toBe('avatar');
+  });
+
+  it('keeps the dots inside a name', async () => {
+    const service = await setup();
+
+    expect(service.archiveBaseName('v1.2.3.zip')).toBe('v1.2.3');
+  });
+
+  it('falls back to a name rather than an empty folder name', async () => {
+    const service = await setup();
+
+    expect(service.archiveBaseName('')).toBe('Archive');
+  });
+
+  /**
+   * A leading dot is a hidden file, not an extension — `path.extname('.zip')`
+   * is empty — so an archive named `.zip` extracts into a hidden folder called
+   * `.zip`. Odd, harmless, and pinned so it is a decision rather than a
+   * surprise if anyone changes the naming.
+   */
+  it('treats a name that is only an extension as a hidden name', async () => {
+    const service = await setup();
+
+    expect(service.archiveBaseName('.zip')).toBe('.zip');
+  });
+});
+
+describe('with no 7-Zip installed', () => {
+  /**
+   * The state of this machine, so this is the real path and not a simulation.
+   * Claiming rar and iso without an extractor offers people a menu entry that
+   * fails after they click it.
+   */
+  it('offers zip alone rather than the whole configured list', async () => {
+    const service = await setup({ SEVEN_ZIP_PATH: '/nonexistent/7z' });
+
+    expect(await service.getSupportedArchiveExtensions()).toEqual(['zip']);
+  });
+
+  it('reports itself as unavailable', async () => {
+    const service = await setup({ SEVEN_ZIP_PATH: '/nonexistent/7z' });
+
+    expect(await service.isSevenZipAvailable()).toBe(false);
+  });
+
+  it('probes once and reuses the answer', async () => {
+    const service = await setup({ SEVEN_ZIP_PATH: '/nonexistent/7z' });
+
+    const first = service.getSupportedArchiveExtensions();
+    const second = service.getSupportedArchiveExtensions();
+
+    expect(second).toBe(first);
+    await first;
+  });
+});

--- a/backend/tests/services/archiveService.test.js
+++ b/backend/tests/services/archiveService.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+// eslint-disable-next-line global-require
+const {
+  normalizeArchivePassword,
+  isArchivePasswordError,
+} = require('../../src/services/archiveService');
+
+describe('archive service password handling', () => {
+  it('accepts a short-lived password without transforming it', () => {
+    expect(normalizeArchivePassword('correct horse battery staple')).toBe(
+      'correct horse battery staple'
+    );
+    expect(normalizeArchivePassword('')).toBe('');
+    expect(normalizeArchivePassword(undefined)).toBeNull();
+  });
+
+  it('rejects values that cannot safely be sent to the extractor prompt', () => {
+    expect(() => normalizeArchivePassword('line one\nline two')).toThrow('Invalid archive password.');
+    expect(() => normalizeArchivePassword('tab\tpassword')).toThrow('Invalid archive password.');
+    expect(() => normalizeArchivePassword('x'.repeat(4097))).toThrow('Invalid archive password.');
+    expect(() => normalizeArchivePassword({ secret: 'nope' })).toThrow('Invalid archive password.');
+  });
+
+  it('recognizes encrypted archive failures without exposing extractor output', () => {
+    expect(isArchivePasswordError(new Error('ERROR: Wrong password : secret.7z'))).toBe(true);
+    expect(isArchivePasswordError(new Error('Data Error in encrypted file. Wrong password?'))).toBe(
+      true
+    );
+    expect(isArchivePasswordError(new Error('Enter password (will not be echoed):'))).toBe(true);
+    expect(isArchivePasswordError(new Error('Unexpected end of archive'))).toBe(false);
+  });
+});
+
+describe('archive extraction size guard', () => {
+  it('aborts an extraction that outgrows the limit even without a usable listing', async (ctx) => {
+    const os = require('node:os');
+    const path = require('node:path');
+    const fs = require('node:fs/promises');
+    const { extractArchive, isSevenZipAvailable } = require('../../src/services/archiveService');
+
+    if (!(await isSevenZipAvailable())) {
+      // The guard only applies to the 7-Zip path; the JS fallback is bounded
+      // by its own declared-size check in the route. Skip rather than pass,
+      // so a machine without 7-Zip does not report this as covered.
+      ctx.skip();
+      return;
+    }
+
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'archive-size-guard-'));
+    try {
+      const source = path.join(root, 'payload');
+      await fs.mkdir(source);
+      // Highly compressible content: small archive, large expansion.
+      await fs.writeFile(path.join(source, 'big.bin'), Buffer.alloc(8 * 1024 * 1024, 0));
+
+      const archive = path.join(root, 'payload.zip');
+      const { createZipArchive } = require('../../src/services/archiveService');
+      await createZipArchive([source], archive, undefined, {});
+
+      const destination = path.join(root, 'out');
+      await fs.mkdir(destination);
+
+      await expect(
+        extractArchive(archive, destination, undefined, { maxBytes: 1024 })
+      ).rejects.toThrow(/allowed size/i);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
Batch 2 of #373, following [1/14] which you merged. Cut from `main` at `edf428c`.

**~900 lines of code, ~750 of tests, four new files.**

## What it adds

**Extraction and compression through 7-Zip.** Password-protected archives, a progress stream the client can cancel mid-way, and guards on how much a crafted archive may unpack — a zip bomb should not be able to fill the volume before anyone notices. `ARCHIVE_EXTENSIONS` decides which extensions the UI offers; `MAX_EXTRACTED_ARCHIVE_SIZE` and `MAX_ARCHIVE_ENTRIES` bound what one archive may produce.

Everything goes through the local `7z` binary. Where it is missing the routes refuse and say so, rather than half-working.

## Why the test harness is in here

This is the part worth reading, because it explains a failure mode rather than adding a feature.

`setupTestEnv` cleared only the modules a test named in `modules`. But most modules read the configured directories **once, at load time**, and keep what they computed. So a test whose list did not mention some helper sitting between it and the filesystem quietly ran against the **first** test's temporary volume.

The archive tests walked straight into it: green one at a time, red as a file, and the assertion pointed at a status code (`expected 500 to be 400`) while the server was logging a perfectly correct 400. It cost me an afternoon before I read our own comment about it.

The fix drops every module under `src/` from the require cache instead. It costs a reload of whatever the test actually requires — a few milliseconds — and it cannot be forgotten. `modules` still works, it is simply no longer load-bearing.

## Adapted rather than carried over

Three things in our version belong to later batches, so this branch uses what exists here instead:

| Ours | Here |
|---|---|
| `folderSizeHooks` notifications | removed — the folder-size index is batch 7 |
| `ACTIONS.createFile` | `ACTIONS.write`, which your permission model expresses |
| `sanitizeClientMessage` (path redaction in client errors) | the message as thrown |

## Tests

56 pass. **The 16 failures already on `main` at `edf428c` are unchanged** — same count, same causes, before and after this branch. Happy to look at them separately if you would like; they have the same shape as the one described above.

## Next

Batch 3 is ready to follow. Same question as last time: say the word if you want them bigger, smaller, or in a different order.