### PR TITLE
[3/14] Search: inside Office documents and PDFs, and by filename pattern

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -73,6 +73,7 @@ module.exports = {
   MAX_EXTRACTED_ARCHIVE_SIZE: process.env.MAX_EXTRACTED_ARCHIVE_SIZE?.trim() || null,
   MAX_ARCHIVE_ENTRIES: Number(process.env.MAX_ARCHIVE_ENTRIES) || 100000,
   ARCHIVE_EXTENSIONS: process.env.ARCHIVE_EXTENSIONS || '',
+  SEARCH_TIMEOUT_MS: Number(process.env.SEARCH_TIMEOUT_MS) || null,
   SEARCH_MAX_FILESIZE: process.env.SEARCH_MAX_FILESIZE?.trim() || null,
 
   // OnlyOffice

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -422,6 +422,13 @@ module.exports = {
     ripgrep: env.SEARCH_RIPGREP ?? true,
     maxFileSize: env.SEARCH_MAX_FILESIZE,
     maxFileSizeBytes: searchMaxFileSizeBytes,
+    // How long one search may spend looking before answering with what it has.
+    // Reading a large tree to be certain there is nothing more is worse than
+    // an answer that arrives.
+    timeoutMs:
+      Number.isFinite(env.SEARCH_TIMEOUT_MS) && env.SEARCH_TIMEOUT_MS > 0
+        ? env.SEARCH_TIMEOUT_MS
+        : 5000,
   },
 
   thumbnails: { size: 200, quality: 70 },

--- a/backend/src/routes/search.js
+++ b/backend/src/routes/search.js
@@ -11,6 +11,17 @@ const { resolvePathWithAccess, getAccessInfo } = require('../services/accessMana
 const asyncHandler = require('../utils/asyncHandler');
 const { ValidationError, NotFoundError, ForbiddenError } = require('../errors/AppError');
 const { createPermissionResolver } = require('../services/accessControlService');
+const {
+  findDocumentTextMatch,
+  findPlainTextMatch,
+  isSearchableDocument,
+  SEARCHABLE_EXTENSIONS: DOCUMENT_EXTENSIONS,
+} = require('../services/documentText');
+const { collectResults, buildPage } = require('../services/searchCollector');
+const { parseSearchTerm } = require('../services/searchTerm');
+const { ripgrepIgnoreGlobs, isIgnoredDirectory } = require('../services/searchIgnore');
+const { whenClientDisconnects } = require('../utils/clientDisconnect');
+const logger = require('../utils/logger');
 const { getSettings, getUserSettings } = require('../services/settingsService');
 
 const router = express.Router();
@@ -19,6 +30,17 @@ const router = express.Router();
 const IGNORED_DIRS = new Set(['.git', 'node_modules', 'dist', 'build']);
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
+// Filenames lead — they are what someone looking for a file expects first —
+// but they cannot take the whole page from what is inside the documents.
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * The size bound for the JavaScript scan, which runs when ripgrep does not.
+ *
+ * The ripgrep path bounds the same thing in `streamDocumentMatches`, from the
+ * same setting. One engine runs per request, so this is the single enforcement
+ * on this path rather than a second copy of that one.
+ */
 const CONTENT_FALLBACK_MAX_SIZE =
   searchConfig?.maxFileSizeBytes > 0 ? searchConfig.maxFileSizeBytes : 5 * 1024 * 1024;
 
@@ -53,7 +75,59 @@ const hasRipgrep = async () => {
 };
 
 // Search implementations
-const buildRipgrepArgs = (includeHiddenFiles = false) => [
+/**
+ * Arguments for a content search.
+ *
+ * Exported so the `--` separator can be tested without ripgrep on the machine:
+ * the route falls back to a JavaScript scan when ripgrep is missing, so an
+ * end-to-end test passes there while never exercising this at all.
+ */
+const buildContentSearchArgs = (term, globArgs = [], maxFileSize = null) => {
+  const args = [
+    '--json', // Use JSON output for faster parsing (Optimization #2)
+    '-n',
+    '-H',
+    '--hidden',
+    '--no-messages',
+    '--smart-case',
+    '-F',
+    '-m',
+    '1',
+    ...globArgs,
+    // Everything after `--` is positional. Without it a search term starting
+    // with `-` is parsed as a ripgrep flag, and options such as `--pre=<cmd>`
+    // run that command against every scanned file.
+    '--',
+    term,
+    '.',
+  ];
+
+  // Spawn arguments are strings; passing the number through and letting the
+  // conversion happen somewhere else is how a value stops being checkable.
+  if (maxFileSize) args.unshift('--max-filesize', String(maxFileSize));
+  return args;
+};
+
+/**
+ * Everything ripgrep is given for a content search, composed in one place.
+ *
+ * Exported so the wiring can be tested where ripgrep is not installed — which
+ * is where this went wrong: the raw `SEARCH_MAX_FILESIZE` was handed over
+ * instead of the parsed byte count, ripgrep refused the flag, and nothing
+ * anywhere ran the code that would have shown it.
+ */
+const contentSearchArgs = (term, includeHiddenFiles = false, relBasePath = '') =>
+  buildContentSearchArgs(
+    term,
+    buildRipgrepArgs(includeHiddenFiles, relBasePath),
+    searchConfig?.maxFileSizeBytes
+  );
+
+const buildRipgrepArgs = (includeHiddenFiles = false, relBasePath = '') => [
+  // A folder excluded from search is excluded from all of it, and not only
+  // from the index: walking the Docker overlay by name is what made every
+  // filename search run out its budget.
+  ...ripgrepIgnoreGlobs(relBasePath, excludedSearchPaths()),
   '-g',
   '!.git',
   '-g',
@@ -65,6 +139,12 @@ const buildRipgrepArgs = (includeHiddenFiles = false) => [
   ...(includeHiddenFiles ? [] : hiddenFiles.ripgrepGlobExcludes.flatMap((glob) => ['-g', glob])),
 ];
 
+/**
+ * Reading the list every time rather than once: an administrator changing it
+ * in Settings expects the next search to obey, not the next restart.
+ */
+const excludedSearchPaths = () => [];
+
 const normalizePath = (p, relBasePath) => {
   const normalized = p.replace(/\\/g, '/');
   return relBasePath ? path.posix.join(relBasePath, normalized) : normalized;
@@ -75,7 +155,7 @@ const shouldIgnore = (name, includeHiddenFiles = false) =>
   excludedFiles.includes(name) ||
   (!includeHiddenFiles && hiddenFiles.isHiddenName(name));
 
-const extractDirMatches = (fullPath, needle, includeHiddenFiles = false) => {
+const extractDirMatches = (fullPath, matcher, includeHiddenFiles = false) => {
   const dirs = new Set();
   const dirPath = path.posix.dirname(fullPath);
 
@@ -86,7 +166,7 @@ const extractDirMatches = (fullPath, needle, includeHiddenFiles = false) => {
     for (const part of parts) {
       if (!part || shouldIgnore(part, includeHiddenFiles)) continue;
       acc = acc ? `${acc}/${part}` : part;
-      if (part.toLowerCase().includes(needle)) dirs.add(acc);
+      if (matcher.matchesName(part)) dirs.add(acc);
     }
   }
 
@@ -122,13 +202,13 @@ const parseJsonLine = (line) => {
 async function* streamFileListMatches(
   baseAbsPath,
   relBasePath,
-  needle,
+  matcher,
   seenPaths,
   dirSet,
   shouldInclude,
   includeHiddenFiles = false
 ) {
-  const globArgs = buildRipgrepArgs(includeHiddenFiles);
+  const globArgs = buildRipgrepArgs(includeHiddenFiles, relBasePath);
   const fileListProcess = spawn('rg', ['--files', '--hidden', '--no-messages', ...globArgs], {
     cwd: baseAbsPath,
   });
@@ -138,32 +218,36 @@ async function* streamFileListMatches(
     crlfDelay: Infinity,
   });
 
-  for await (const line of rl) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    if (!includeHiddenFiles && hiddenFiles.isHiddenPath(trimmed)) continue;
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (!includeHiddenFiles && hiddenFiles.isHiddenPath(trimmed)) continue;
 
-    const fullRel = normalizePath(trimmed, relBasePath);
+      const fullRel = normalizePath(trimmed, relBasePath);
 
-    // Extract and yield directory matches immediately
-    for (const dirPath of extractDirMatches(fullRel, needle, includeHiddenFiles)) {
-      if (!dirSet.has(dirPath) && !seenPaths.has(dirPath)) {
-        dirSet.add(dirPath);
-        seenPaths.add(dirPath);
-        if (await shouldInclude(dirPath)) {
-          yield formatResult(dirPath, 'dir');
+      // Extract and yield directory matches immediately
+      for (const dirPath of extractDirMatches(fullRel, matcher, includeHiddenFiles)) {
+        if (!dirSet.has(dirPath) && !seenPaths.has(dirPath)) {
+          dirSet.add(dirPath);
+          seenPaths.add(dirPath);
+          if (await shouldInclude(dirPath)) {
+            yield formatResult(dirPath, 'dir');
+          }
+        }
+      }
+
+      // Check filename match and yield immediately
+      if (matcher.matchesRelativePath(fullRel) && !seenPaths.has(fullRel)) {
+        seenPaths.add(fullRel);
+        if (await shouldInclude(fullRel)) {
+          yield formatResult(fullRel, 'file');
         }
       }
     }
-
-    // Check filename match and yield immediately
-    const baseName = path.posix.basename(fullRel).toLowerCase();
-    if (baseName.includes(needle) && !seenPaths.has(fullRel)) {
-      seenPaths.add(fullRel);
-      if (await shouldInclude(fullRel)) {
-        yield formatResult(fullRel, 'file');
-      }
-    }
+  } finally {
+    rl.close();
+    fileListProcess.kill('SIGTERM');
   }
 }
 
@@ -176,50 +260,229 @@ async function* streamContentMatches(
   shouldInclude,
   includeHiddenFiles = false
 ) {
-  const globArgs = buildRipgrepArgs(includeHiddenFiles);
+  const contentArgs = contentSearchArgs(term, includeHiddenFiles, relBasePath);
 
-  const contentArgs = [
-    '--json', // Use JSON output for faster parsing (Optimization #2)
-    '-n',
-    '-H',
-    '--hidden',
-    '--no-messages',
-    '--smart-case',
-    '-F',
-    term,
-    '.',
-    '-m',
-    '1',
-    ...globArgs,
-  ];
-
-  if (searchConfig?.maxFileSize) {
-    contentArgs.unshift('--max-filesize', searchConfig.maxFileSize);
-  }
+  // The parsed byte count, never the raw setting. `SEARCH_MAX_FILESIZE=5MB` —
+  // the form our own README suggests — went to ripgrep verbatim, and ripgrep
+  // only accepts `K`, `M` or `G`. It answered `invalid format for size '5MB'`,
+  // exited, and searched nothing: content search returned no results at all
+  // while filename search, a separate invocation without this flag, went on
+  // working. With --no-messages set and stderr unread, it did it in silence.
 
   const contentProcess = spawn('rg', contentArgs, { cwd: baseAbsPath });
+
+  // Whatever ripgrep has to say about how it was called. `--no-messages`
+  // silences per-file errors, not usage ones, and nothing was reading this: a
+  // refused flag looked exactly like a search that found nothing.
+  let stderr = '';
+  contentProcess.stderr?.on('data', (chunk) => {
+    if (stderr.length < 2000) stderr += String(chunk);
+  });
+  contentProcess.on('close', (code) => {
+    // 1 is ripgrep's "no matches", which is an answer rather than a failure.
+    if (code !== null && code > 1) {
+      logger.warn({ code, stderr: stderr.trim() }, 'Content search failed to run');
+    }
+  });
+
   const rl = readline.createInterface({
     input: contentProcess.stdout,
     crlfDelay: Infinity,
   });
 
-  for await (const line of rl) {
-    const data = parseJsonLine(line);
-    if (!data || data.type !== 'match') continue;
+  // The consumer stops as soon as it has enough results. Without this the
+  // process would keep scanning the whole tree in the background.
+  try {
+    for await (const line of rl) {
+      const data = parseJsonLine(line);
+      if (!data || data.type !== 'match') continue;
 
-    const filePath = data.data?.path?.text;
-    if (!filePath) continue;
-    if (!includeHiddenFiles && hiddenFiles.isHiddenPath(filePath)) continue;
+      const filePath = data.data?.path?.text;
+      if (!filePath) continue;
+      // `rg` reports content-search paths as `./file`, unlike `rg --files`.
+      // That prefix is not a hidden-file marker; checking it first made every
+      // content match look hidden and in particular hid literal terms such as
+      // `--pre=...` even though the arguments were safely protected by `--`.
+      const normalizedFilePath = filePath.replace(/^(?:\.\/|\.\\)+/, '');
+      if (!includeHiddenFiles && hiddenFiles.isHiddenPath(normalizedFilePath)) continue;
 
-    const lineNum = data.data?.line_number;
-    const lineText = data.data?.lines?.text;
+      const lineNum = data.data?.line_number;
+      const lineText = data.data?.lines?.text;
 
-    const rel = normalizePath(filePath, relBasePath);
+      const rel = normalizePath(normalizedFilePath, relBasePath);
+      if (seenPaths.has(rel)) continue;
+
+      seenPaths.add(rel);
+      if (await shouldInclude(rel)) {
+        yield formatResult(rel, 'file', lineText, lineNum);
+      }
+    }
+  } finally {
+    rl.close();
+    contentProcess.kill('SIGTERM');
+  }
+}
+
+/**
+ * Yield from several generators as their results arrive.
+ *
+ * The two passes used to be drained one after the other despite the comment
+ * that said they ran in parallel, and the route stops at its result limit. So
+ * a term that matched a hundred filenames spent the whole budget before the
+ * content search had produced anything — and content matches, the ones people
+ * come to a deep search for, never appeared at all. The content search did not
+ * even start until the entire file listing had been walked.
+ */
+/**
+ * Wrap a generator so that its exhaustion is observable.
+ *
+ * The merged stream hides which source produced what and, more to the point,
+ * which one has finished — and "no content can arrive any more" is exactly the
+ * fact the collector needs to stop waiting for a reserve that will never fill.
+ */
+const announceWhenDone = (generator, onDone) =>
+  (async function* watched() {
+    try {
+      yield* generator;
+    } finally {
+      onDone();
+    }
+  })();
+
+const resultIdentity = (item) =>
+  item?.path ? `${item.path}/${item.name}` : String(item?.name ?? '');
+
+async function* mergeResults(...generators) {
+  const next = new Map();
+  // The last word on whether a file has already been listed.
+  //
+  // Each pass carries a shared `seenPaths` and consults it, which stops it
+  // doing work another pass has done — but it cannot stop a duplicate, because
+  // the check and the claim are not adjacent. The document pass tests the path,
+  // then stats the file, extracts its text and asks permission, and only then
+  // records it: three awaits wide. The file-list pass claims a path on the line
+  // after it tests one, so it fits inside that window, and a `.docx` whose name
+  // and contents both match the term came back twice.
+  //
+  // It showed up as one CI run in some number, because losing the race needs a
+  // machine slow enough to finish the walk while a document is being unzipped.
+  // Moving the claim earlier in that pass would trade the duplicate for a
+  // worse bug: a document that turns out not to match would have reserved a
+  // path the name pass then skips, and the file would vanish from the results.
+  //
+  // Here there is no window. Everything converges on this loop, so a path that
+  // has been emitted is known to have been emitted, whatever order the passes
+  // finished in.
+  const emitted = new Set();
+
+  for (const generator of generators) {
+    next.set(
+      generator,
+      generator.next().then((result) => ({ generator, result }))
+    );
+  }
+
+  try {
+    while (next.size > 0) {
+      // eslint-disable-next-line no-await-in-loop
+      const { generator, result } = await Promise.race(next.values());
+      if (result.done) {
+        next.delete(generator);
+        continue;
+      }
+
+      next.set(
+        generator,
+        generator.next().then((value) => ({ generator, result: value }))
+      );
+
+      const identity = resultIdentity(result.value);
+      if (emitted.has(identity)) continue;
+      emitted.add(identity);
+
+      yield result.value;
+    }
+  } finally {
+    // The consumer stops as soon as it has enough. Each generator closes its
+    // own ripgrep process in its `finally`; this is what gets them there.
+    for (const generator of next.keys()) {
+      generator.return?.();
+    }
+  }
+}
+
+/**
+ * Matches inside documents whose text has to be extracted first.
+ *
+ * Office files are zip archives and PDFs are compressed streams, so ripgrep
+ * reads both as binary and finds nothing in them however the search is
+ * configured. Reading them costs an unzip or a `pdftotext` per document, so
+ * this is bounded three ways: only these extensions, only files under the
+ * configured size, and only so many documents per search.
+ *
+ * The extension check is an optimisation and not a rule: `findDocumentTextMatch`
+ * tests it again and returns null, so deleting it here changes only the number
+ * of files opened. The other two decide what is searched.
+ */
+const OFFICE_DOCUMENT_LIMIT = 500;
+
+async function* streamDocumentMatches(
+  baseAbsPath,
+  relBasePath,
+  term,
+  seenPaths,
+  shouldInclude,
+  includeHiddenFiles = false
+) {
+  const needle = term.toLowerCase();
+  const maxBytes = searchConfig?.maxFileSizeBytes > 0 ? searchConfig.maxFileSizeBytes : null;
+  let examined = 0;
+
+  let entries;
+  try {
+    entries = await fs.readdir(baseAbsPath, { withFileTypes: true, recursive: true });
+  } catch (err) {
+    logger.debug({ err }, 'Could not list documents for the content search');
+    return;
+  }
+
+  for (const entry of entries) {
+    if (examined >= OFFICE_DOCUMENT_LIMIT) return;
+    if (!entry.isFile()) continue;
+
+    const extension = path.extname(entry.name).slice(1).toLowerCase();
+    if (!DOCUMENT_EXTENSIONS.includes(extension)) continue;
+
+    const parent = path.relative(baseAbsPath, entry.parentPath || entry.path || baseAbsPath);
+    const relFromBase = parent
+      ? path.posix.join(parent.split(path.sep).join('/'), entry.name)
+      : entry.name;
+    if (!includeHiddenFiles && hiddenFiles.isHiddenPath(relFromBase)) continue;
+
+    const rel = normalizePath(relFromBase, relBasePath);
     if (seenPaths.has(rel)) continue;
 
+    const absolutePath = path.join(baseAbsPath, relFromBase);
+    // The same bound `generateFallbackResults` applies through
+    // CONTENT_FALLBACK_MAX_SIZE. Not a duplicate: a request runs one content
+    // engine or the other, never both, so each path enforces it once. Deleting
+    // either looks harmless on a machine that does not take that path — which
+    // is why the bound tests name their engine and run on both.
+    if (maxBytes) {
+      // eslint-disable-next-line no-await-in-loop
+      const stats = await fs.stat(absolutePath).catch(() => null);
+      if (!stats || stats.size > maxBytes) continue;
+    }
+
+    examined += 1;
+    // eslint-disable-next-line no-await-in-loop
+    const match = await findDocumentTextMatch(absolutePath, needle);
+    if (!match) continue;
+
     seenPaths.add(rel);
+    // eslint-disable-next-line no-await-in-loop
     if (await shouldInclude(rel)) {
-      yield formatResult(rel, 'file', lineText, lineNum);
+      yield formatResult(rel, 'file', match.line, match.lineNumber);
     }
   }
 }
@@ -231,9 +494,10 @@ async function* generateRipgrepResults(
   term,
   shouldInclude,
   deep = true,
-  includeHiddenFiles = false
+  includeHiddenFiles = false,
+  { onContentSources, onContentSourceDone } = {}
 ) {
-  const needle = term.toLowerCase();
+  const matcher = parseSearchTerm(term);
   const seenPaths = new Set();
   const dirSet = new Set();
 
@@ -242,7 +506,7 @@ async function* generateRipgrepResults(
     yield* streamFileListMatches(
       baseAbsPath,
       relBasePath,
-      needle,
+      matcher,
       seenPaths,
       dirSet,
       shouldInclude,
@@ -251,11 +515,10 @@ async function* generateRipgrepResults(
     return;
   }
 
-  // Optimization #3: Run both searches in parallel
   const fileListGen = streamFileListMatches(
     baseAbsPath,
     relBasePath,
-    needle,
+    matcher,
     seenPaths,
     dirSet,
     shouldInclude,
@@ -270,15 +533,34 @@ async function* generateRipgrepResults(
     includeHiddenFiles
   );
 
-  // Yield from file list first (directories and filename matches)
-  for await (const result of fileListGen) {
-    yield result;
-  }
+  const documentGen = streamDocumentMatches(
+    baseAbsPath,
+    relBasePath,
+    term,
+    seenPaths,
+    shouldInclude,
+    includeHiddenFiles
+  );
 
-  // Then yield content matches
-  for await (const result of contentGen) {
-    yield result;
+  //
+  // The content sources announce their own exhaustion, because the collector
+  // has to know when a reserve it is holding the page open for can no longer
+  // be filled. Without it, every search that finds few content matches waits
+  // out the whole time budget for content that had already run out.
+  // A wildcard term describes filenames and nothing else: no file contains
+  // the characters `*.ps1`, so reading the tree for them costs the whole
+  // budget to return files that merely mention the pattern in their text.
+  const contentSources = !matcher.readsFileContents ? [] : [contentGen, documentGen];
+  if (!matcher.readsFileContents) {
+    await contentGen.return?.();
+    await documentGen.return?.();
   }
+  onContentSources?.(contentSources.length);
+  const watched = contentSources.map((source) =>
+    announceWhenDone(source, () => onContentSourceDone?.())
+  );
+
+  yield* mergeResults(fileListGen, ...watched);
 }
 
 // Optimized fallback with streaming (Optimization #1)
@@ -291,7 +573,9 @@ async function* generateFallbackResults(
   includeHiddenFiles = false
 ) {
   const seenPaths = new Set();
-  const needle = term.toLowerCase();
+  const matcher = parseSearchTerm(term);
+  const needle = matcher.needle;
+  const readsFileContents = deep && matcher.readsFileContents;
 
   // Yield results immediately as we find them
   const walk = async function* (dirAbs, dirRel) {
@@ -309,7 +593,10 @@ async function* generateFallbackResults(
       const rel = dirRel ? path.posix.join(dirRel, d.name) : d.name;
 
       if (d.isDirectory()) {
-        if (d.name.toLowerCase().includes(needle) && !seenPaths.has(rel)) {
+        // The same folders ripgrep is told to skip, skipped here too — the
+        // fallback answering a different question is how this went unnoticed.
+        if (isIgnoredDirectory(rel, excludedSearchPaths())) continue;
+        if (matcher.matchesName(d.name) && !seenPaths.has(rel)) {
           seenPaths.add(rel);
           if (await shouldInclude(rel)) {
             yield formatResult(rel, 'dir');
@@ -317,25 +604,30 @@ async function* generateFallbackResults(
         }
         yield* walk(abs, rel);
       } else if (d.isFile()) {
-        if (d.name.toLowerCase().includes(needle) && !seenPaths.has(rel)) {
+        if (matcher.matchesRelativePath(rel) && !seenPaths.has(rel)) {
           seenPaths.add(rel);
           if (await shouldInclude(rel)) {
             yield formatResult(rel, 'file');
           }
-        } else if (deep && !seenPaths.has(rel)) {
+        } else if (readsFileContents && !seenPaths.has(rel)) {
           try {
             const st = await fs.stat(abs);
-            if (st.size <= CONTENT_FALLBACK_MAX_SIZE) {
-              const content = await fs.readFile(abs, 'utf8');
-              const lower = content.toLowerCase();
-              const idx = lower.indexOf(needle);
-
-              if (idx !== -1) {
-                const lineNumber = (content.slice(0, idx).match(/\n/g)?.length ?? 0) + 1;
-                const matchedLine = content.split(/\r?\n/)[lineNumber - 1] || '';
+            if (st.size <= CONTENT_FALLBACK_MAX_SIZE && isSearchableDocument(abs)) {
+              // A .docx or a .pdf read as text is compressed bytes. Their words
+              // have to be extracted before there is anything to search.
+              const match = await findDocumentTextMatch(abs, needle);
+              if (match) {
                 seenPaths.add(rel);
                 if (await shouldInclude(rel)) {
-                  yield formatResult(rel, 'file', matchedLine, lineNumber);
+                  yield formatResult(rel, 'file', match.line, match.lineNumber);
+                }
+              }
+            } else if (st.size <= CONTENT_FALLBACK_MAX_SIZE) {
+              const match = await findPlainTextMatch(abs, needle, CONTENT_FALLBACK_MAX_SIZE);
+              if (match) {
+                seenPaths.add(rel);
+                if (await shouldInclude(rel)) {
+                  yield formatResult(rel, 'file', match.line, match.lineNumber);
                 }
               }
             }
@@ -416,18 +708,127 @@ router.get(
       return ok;
     };
 
-    const generator = useRipgrep
-      ? generateRipgrepResults(baseAbs, relBase, q, shouldInclude, deepEnabled, includeHiddenFiles)
-      : generateFallbackResults(baseAbs, relBase, q, shouldInclude, deepEnabled, includeHiddenFiles);
+    // The index holds the volume root. A search based anywhere else — a
+    // personal folder, an assigned volume — reads as it goes, because the
+    // index does not hold those.
+    //
+    // And it is only used once a pass has finished. The index replaces the live
+    // content scan rather than adding to it, so an index still being built
+    // answers with the part of the volume it happens to have read — a term
+    // found yesterday goes missing today, with nothing in the answer to say
+    // why. Reading the tree meanwhile is slower and right.
 
+    // Nothing can produce a content match once every content source has
+    // finished, and that is the moment a reserve stops being worth waiting for.
+    let contentSourcesLeft = Number.POSITIVE_INFINITY;
+
+    const generator = useRipgrep
+      ? generateRipgrepResults(
+          baseAbs,
+          relBase,
+          q,
+          shouldInclude,
+          deepEnabled,
+          includeHiddenFiles,
+          {
+            limit,
+            onContentSources: (count) => {
+              contentSourcesLeft = count;
+            },
+            onContentSourceDone: () => {
+              contentSourcesLeft -= 1;
+            },
+          }
+        )
+      : generateFallbackResults(
+          baseAbs,
+          relBase,
+          q,
+          shouldInclude,
+          deepEnabled,
+          includeHiddenFiles
+        );
+
+    // Counted apart and only put together at the end: sharing one running
+    // total let filenames spend it all, and a term matching a hundred of them
+    // returned a hundred names and not one line of content — the half people
+    // open a deep search for.
     const items = [];
-    for await (const item of generator) {
-      items.push(item);
-      if (items.length >= limit) break;
+    const contentItems = [];
+
+    // Filled as they are found rather than handed back at the end: when the
+    // budget wins the race, what has been collected so far is the answer, and
+    // waiting for the collector to hand it over is the one thing there is no
+    // time left for.
+    const collect = collectResults({
+      results: generator,
+      limit,
+      contentExhausted: () => contentSourcesLeft === 0,
+      names: items,
+      contents: contentItems,
+    });
+
+    let truncated = false;
+    let abandoned = false;
+    {
+      // Guaranteeing content a share means looking for it until the reserve is
+      // full or the tree runs out — and on a large one that is a long time to
+      // hold someone waiting. The budget ends it: whatever has been found by
+      // then is the answer, which is a better one than a spinner.
+      //
+      // Which of the two won has to be read from the race itself. Ending the
+      // generator below makes the loop exit normally, so anything the
+      // collector sets on its way out would say it finished either way.
+      const outcome = await Promise.race([
+        collect.then(() => 'complete'),
+        delay(searchConfig?.timeoutMs ?? 5000).then(() => 'timeout'),
+        // Typing sends one search per pause and the panel keeps only the last.
+        // Without this the abandoned ones each ran their full budget, with
+        // their own subprocesses, for answers nobody would read.
+        whenClientDisconnects(res).then(() => 'abandoned'),
+      ]);
+      abandoned = outcome === 'abandoned';
+      truncated = outcome === 'timeout';
     }
 
-    res.json({ items });
+    // Breaking out of a for-await leaves the generator suspended, and with it
+    // the ripgrep processes it spawned — which keep scanning the whole tree.
+    // Returning runs their cleanup so they are killed.
+    //
+    // It is not awaited before answering, and that is the point: cleanup means
+    // resuming every source at whatever it was in the middle of, which on a
+    // busy tree took six seconds. A budget of five that answers in eleven is
+    // not a budget — the wait it was written to cap simply moved.
+    const cleanup = Promise.resolve(generator.return?.())
+      .catch(() => {})
+      .then(() => collect)
+      .catch(() => {});
+
+    if (abandoned) {
+      await cleanup;
+      return;
+    }
+
+    const combined = buildPage({ names: items, contents: contentItems, limit });
+
+    // Said out loud rather than left to look like a complete answer: a search
+    // the budget ended has not seen everything, and whoever is reading the
+    // results deserves to know which of the two they are looking at.
+    if (truncated) {
+      logger.info(
+        { term: q, names: items.length, contents: contentItems.length },
+        'Search stopped at its time budget'
+      );
+    }
+
+    res.json({ items: combined, truncated });
+    await cleanup;
   })
 );
 
 module.exports = router;
+module.exports.buildContentSearchArgs = buildContentSearchArgs;
+module.exports.contentSearchArgs = contentSearchArgs;
+// Exported for the test that drives it directly: the duplicate it prevents
+// depends on which pass wins a race, which a test cannot arrange from outside.
+module.exports.mergeResults = mergeResults;

--- a/backend/src/services/documentText.js
+++ b/backend/src/services/documentText.js
@@ -1,0 +1,114 @@
+const path = require('path');
+const fs = require('fs/promises');
+
+const {
+  findOfficeTextMatch,
+  isOfficeDocument,
+  SUPPORTED_EXTENSIONS: OFFICE_EXTENSIONS,
+} = require('./officeTextExtract');
+const { extractPdfTextLines } = require('./pdfTextExtract');
+
+/**
+ * Searching inside the documents whose text a plain content search cannot see.
+ *
+ * Office files are zip archives, PDFs are compressed streams: ripgrep reads
+ * both as binary and finds nothing in them, however the search is configured.
+ * They are read differently — a zip in this process, a PDF through pdftotext —
+ * and this is the one door the search goes through for either.
+ */
+
+const SEARCHABLE_EXTENSIONS = [...OFFICE_EXTENSIONS, 'pdf'];
+
+const extensionOf = (filePath) => path.extname(filePath || '').slice(1).toLowerCase();
+
+/** Whether this is a document whose text has to be extracted to be searched. */
+const isSearchableDocument = (filePath) => SEARCHABLE_EXTENSIONS.includes(extensionOf(filePath));
+
+/**
+ * The first line of a document containing `needle`, or null.
+ *
+ * @returns {Promise<{ line: string, lineNumber: number }|null>}
+ */
+const findDocumentTextMatch = async (absolutePath, needle) => {
+  const lowered = String(needle || '').toLowerCase();
+  if (!lowered) return null;
+
+  if (isOfficeDocument(absolutePath)) {
+    return findOfficeTextMatch(absolutePath, lowered);
+  }
+
+  if (extensionOf(absolutePath) !== 'pdf') return null;
+
+  const lines = await extractPdfTextLines(absolutePath);
+  if (!lines) return null;
+
+  const index = lines.findIndex((line) => line.toLowerCase().includes(lowered));
+  return index === -1 ? null : { line: lines[index], lineNumber: index + 1 };
+};
+
+/**
+ * How much of a plain file is worth reading to show one line of it.
+ *
+ * The same ceiling the index uses. A match further in than this is one the
+ * result list was never going to show anyway.
+ */
+const MAX_PLAIN_TEXT_BYTES = 1024 * 1024;
+
+/**
+ * The first line of a plain file containing `needle`, or null.
+ *
+ * Written by hand rather than with `split`, and the difference is not style.
+ * Splitting a file to take one line of it builds an array of every line it
+ * has; counting newlines with `slice(0, index).match(/\n/g)` copies the whole
+ * prefix and then builds an array of every newline in it. Three or four times
+ * the file, allocated and discarded, per result shown — a hundred results deep
+ * that is what a search costs the machine rather than the disk.
+ */
+const findPlainTextMatch = async (absolutePath, needle, maxBytes = MAX_PLAIN_TEXT_BYTES) => {
+  const lowered = String(needle || '').toLowerCase();
+  if (!lowered) return null;
+
+  let handle = null;
+  try {
+    handle = await fs.open(absolutePath, 'r');
+    // Sized to the file rather than to the ceiling: allocating a megabyte to
+    // read a two-kilobyte note is the same waste in miniature.
+    const { size } = await handle.stat();
+    const wanted = Math.min(size, maxBytes);
+    if (wanted <= 0) return null;
+
+    const buffer = Buffer.allocUnsafe(wanted);
+    const { bytesRead } = await handle.read(buffer, 0, wanted, 0);
+    if (!bytesRead) return null;
+
+    const content = buffer.subarray(0, bytesRead).toString('utf8');
+    const index = content.toLowerCase().indexOf(lowered);
+    if (index === -1) return null;
+
+    let lineNumber = 1;
+    let lineStart = 0;
+    for (let at = 0; at < index; at += 1) {
+      if (content.charCodeAt(at) === 10) {
+        lineNumber += 1;
+        lineStart = at + 1;
+      }
+    }
+
+    let lineEnd = content.indexOf('\n', index);
+    if (lineEnd === -1) lineEnd = content.length;
+    const line = content.slice(lineStart, lineEnd).replace(/\r$/, '');
+
+    return { line, lineNumber };
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+};
+
+module.exports = {
+  findDocumentTextMatch,
+  findPlainTextMatch,
+  isSearchableDocument,
+  SEARCHABLE_EXTENSIONS,
+};

--- a/backend/src/services/officeTextExtract.js
+++ b/backend/src/services/officeTextExtract.js
@@ -1,0 +1,162 @@
+const AdmZip = require('adm-zip');
+
+/**
+ * The text inside an Office document, for searching.
+ *
+ * `.docx`, `.xlsx` and `.pptx` are zip archives of XML, so a plain content
+ * search sees only compressed bytes and finds nothing — which is what someone
+ * searching their documents notices first.
+ *
+ * The subtlety that decides whether this is useful: Word splits a word across
+ * runs whenever formatting changes inside it, so **im**port**ant** is three
+ * `<w:t>` nodes. Stripping tags and joining with a space turns that into
+ * "im port ant", and searching for the word fails on exactly the documents
+ * where it is emphasised. Runs are therefore joined with nothing between them,
+ * and only a paragraph ends a line.
+ */
+
+/** Where the text lives in each format, and what ends a line. */
+const FORMATS = {
+  docx: {
+    entries: [/^word\/(document|header\d*|footer\d*|footnotes|endnotes)\.xml$/],
+    // A paragraph is a line. Runs inside it are one word's worth of pieces.
+    lineBreak: /<\/w:p>/,
+    node: /<w:t(?:\s[^>]*)?>([\s\S]*?)<\/w:t>/g,
+  },
+  xlsx: {
+    // Shared strings hold every text cell in the workbook; inline strings live
+    // in the sheets themselves.
+    entries: [/^xl\/sharedStrings\.xml$/, /^xl\/worksheets\/sheet\d+\.xml$/],
+    lineBreak: /<\/(?:si|row)>/,
+    node: /<t(?:\s[^>]*)?>([\s\S]*?)<\/t>/g,
+  },
+  pptx: {
+    entries: [/^ppt\/(?:slides|notesSlides)\/[a-zA-Z]+\d+\.xml$/],
+    lineBreak: /<\/a:p>/,
+    node: /<a:t(?:\s[^>]*)?>([\s\S]*?)<\/a:t>/g,
+  },
+};
+
+const SUPPORTED_EXTENSIONS = Object.keys(FORMATS);
+
+/**
+ * How much decompressed XML this will take from one document.
+ *
+ * A zip says how large each entry becomes before anything is decompressed, and
+ * that number is the only warning there is: text compresses enormously, so a
+ * five-megabyte spreadsheet — well inside any search size limit — can hold a
+ * shared-strings table of several hundred megabytes. Inflating it happens on
+ * the one thread the server has, and every other request waits behind it.
+ *
+ * Refusing a document that says it is larger than this costs nothing: the
+ * declared size is read from the header, not from the data.
+ */
+const MAX_ENTRY_BYTES = 8 * 1024 * 1024;
+const MAX_DOCUMENT_BYTES = 16 * 1024 * 1024;
+
+/** Only the five XML predefines; the rest are literal in these documents. */
+const decodeEntities = (value) =>
+  value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&amp;/g, '&');
+
+const formatFor = (filePath) => {
+  const match = /\.([a-z0-9]+)$/i.exec(filePath || '');
+  const extension = match ? match[1].toLowerCase() : '';
+  return FORMATS[extension] || null;
+};
+
+/**
+ * The document's text, one line per paragraph, or null where there is none to
+ * read. Never throws: an unreadable document is one that does not match, not a
+ * failed search.
+ *
+ * @param {string} absolutePath
+ * @param {{ maxCharacters?: number }} [options]
+ * @returns {string[]|null} lines
+ */
+const extractOfficeTextLines = (absolutePath, { maxCharacters = 2 * 1024 * 1024 } = {}) => {
+  const format = formatFor(absolutePath);
+  if (!format) return null;
+
+  let entries;
+  try {
+    entries = new AdmZip(absolutePath).getEntries();
+  } catch {
+    // Not a readable archive — a corrupt file, or one named .docx that is not.
+    return null;
+  }
+
+  const lines = [];
+  let characters = 0;
+  let inflated = 0;
+
+  for (const entry of entries) {
+    if (entry.isDirectory) continue;
+    const name = entry.entryName.replace(/\\/g, '/');
+    if (!format.entries.some((pattern) => pattern.test(name))) continue;
+
+    // What the archive says this becomes, before it becomes it.
+    const declared = Number(entry.header?.size) || 0;
+    if (declared > MAX_ENTRY_BYTES) continue;
+    if (inflated + declared > MAX_DOCUMENT_BYTES) break;
+    inflated += declared;
+
+    let xml;
+    try {
+      xml = entry.getData().toString('utf8');
+    } catch {
+      continue;
+    }
+
+    for (const block of xml.split(format.lineBreak)) {
+      let line = '';
+      // Runs are concatenated with nothing between them: that is what keeps a
+      // word split by formatting searchable as one word.
+      for (const node of block.matchAll(format.node)) {
+        line += decodeEntities(node[1]);
+      }
+
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      lines.push(trimmed);
+      characters += trimmed.length;
+      // A document that would take more than this to read is one nobody is
+      // searching line by line.
+      if (characters >= maxCharacters) return lines;
+    }
+  }
+
+  return lines.length > 0 ? lines : null;
+};
+
+/**
+ * The first line of a document that contains `needle`, or null. Case is
+ * ignored, as everywhere else in search.
+ *
+ * @returns {{ line: string, lineNumber: number }|null}
+ */
+const findOfficeTextMatch = (absolutePath, needle, options) => {
+  const lines = extractOfficeTextLines(absolutePath, options);
+  if (!lines) return null;
+
+  const lowered = String(needle || '').toLowerCase();
+  if (!lowered) return null;
+
+  const index = lines.findIndex((line) => line.toLowerCase().includes(lowered));
+  return index === -1 ? null : { line: lines[index], lineNumber: index + 1 };
+};
+
+const isOfficeDocument = (filePath) => Boolean(formatFor(filePath));
+
+module.exports = {
+  extractOfficeTextLines,
+  findOfficeTextMatch,
+  isOfficeDocument,
+  SUPPORTED_EXTENSIONS,
+};

--- a/backend/src/services/pdfTextExtract.js
+++ b/backend/src/services/pdfTextExtract.js
@@ -1,0 +1,89 @@
+const { spawn } = require('child_process');
+
+const logger = require('../utils/logger');
+
+/**
+ * The text of a PDF, for searching.
+ *
+ * A PDF's words live in compressed content streams, so a plain content search
+ * finds nothing in one — the same problem Office documents have, for a
+ * different reason. `pdftotext` does the reading; writing a parser for the
+ * encodings, CID fonts and ligatures a real PDF uses would be a project of its
+ * own and a worse one.
+ *
+ * Only PDFs that carry a text layer, which is most of them. A scan is a
+ * picture of a page and stays unsearchable without OCR — a job measured in
+ * seconds per page, which does not belong in a search request.
+ */
+
+const PDFTOTEXT_TIMEOUT_MS = 10 * 1000;
+// A search reads the beginning of a document, not all of a thousand-page one.
+const DEFAULT_MAX_PAGES = 50;
+
+let available = null;
+
+/** Whether pdftotext is installed, asked once. */
+const hasPdfToText = async () => {
+  if (available !== null) return available;
+
+  available = await new Promise((resolve) => {
+    const child = spawn('pdftotext', ['-v']);
+    child.on('error', () => resolve(false));
+    // pdftotext -v prints its version to stderr and exits 0 on some builds, 99
+    // on others. Starting at all is the answer we need.
+    child.on('exit', () => resolve(true));
+  });
+
+  if (!available) {
+    logger.debug('pdftotext is not installed; PDF contents will not be searched');
+  }
+  return available;
+};
+
+/**
+ * The document's text, one entry per line, or null where there is none to read
+ * — no text layer, an unreadable file, or no pdftotext to read it with. Never
+ * throws: a document that cannot be read is one that does not match.
+ */
+const extractPdfTextLines = async (absolutePath, { maxPages = DEFAULT_MAX_PAGES } = {}) => {
+  if (!(await hasPdfToText())) return null;
+
+  return new Promise((resolve) => {
+    // `-q` silences the per-file warnings a slightly malformed PDF produces by
+    // the dozen; `--` keeps a filename starting with a dash from being read as
+    // an option. `-` sends the text to stdout instead of a file beside it.
+    const child = spawn('pdftotext', ['-q', '-l', String(maxPages), '--', absolutePath, '-']);
+
+    let text = '';
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill('SIGKILL');
+      resolve(value);
+    };
+
+    // A malformed document that makes pdftotext spin must not hold up a search.
+    const timer = setTimeout(() => {
+      logger.debug({ absolutePath }, 'Gave up reading a PDF for the content search');
+      finish(null);
+    }, PDFTOTEXT_TIMEOUT_MS);
+
+    child.stdout.on('data', (chunk) => {
+      text += String(chunk);
+    });
+    child.on('error', () => finish(null));
+    child.on('close', (code) => {
+      if (code !== 0 && !text) return finish(null);
+
+      const lines = text
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+      finish(lines.length > 0 ? lines : null);
+    });
+  });
+};
+
+module.exports = { extractPdfTextLines, hasPdfToText };

--- a/backend/src/services/searchCollector.js
+++ b/backend/src/services/searchCollector.js
@@ -1,0 +1,70 @@
+/**
+ * How much of a page filenames may take, and when to stop looking.
+ *
+ * Names lead — someone looking for a file expects the file first — but they
+ * cannot take the whole page: a term matching a hundred filenames used to
+ * return a hundred names and not one line of content, which is the half a deep
+ * search is opened for. So the two are counted apart and a share is reserved.
+ *
+ * The reserve is also the only reason to go on once a page could already be
+ * filled, and that is where it went wrong. Waiting for a reserve that will
+ * never fill made every ordinary search run to the time budget: a term with
+ * five hundred filename matches and eight content matches spent five seconds
+ * looking for content that had already run out. A reserve is worth waiting for
+ * while there is somewhere left to find it; once the sources of content are
+ * exhausted, waiting is just waiting.
+ */
+
+const NAME_SHARE = 0.75;
+
+/**
+ * Read from the merged stream until the page is satisfied.
+ *
+ * @param {AsyncIterable} results          the merged sources
+ * @param {number} limit                   how many results a page holds
+ * @param {() => boolean} contentExhausted  whether anything can still produce
+ *   a content match; when nothing can, a full page of names is the whole
+ *   answer and there is nothing left to wait for
+ * @param {Array} names     filled as they are found, so a caller that gives up
+ *   on the collector can still answer with what it had reached
+ * @param {Array} contents  the same, for content matches
+ */
+const collectResults = async ({
+  results,
+  limit,
+  contentExhausted = () => false,
+  names = [],
+  contents = [],
+}) => {
+  const nameCap = limit;
+  const contentReserve = Math.max(1, limit - Math.floor(limit * NAME_SHARE));
+
+  for await (const item of results) {
+    (item.matchLine ? contents : names).push(item);
+
+    if (names.length < nameCap) continue;
+    if (contents.length >= contentReserve) break;
+    if (contentExhausted()) break;
+  }
+
+  return { names, contents };
+};
+
+/**
+ * One page, names first, with the reserve honoured and nothing wasted.
+ *
+ * A quota that went unused is not a reason to answer short: if there were only
+ * three content matches, the rest of the page is names.
+ */
+const buildPage = ({ names, contents, limit }) => {
+  const nameQuota = contents.length > 0 ? Math.max(1, Math.floor(limit * NAME_SHARE)) : limit;
+  const page = [...names.slice(0, nameQuota), ...contents].slice(0, limit);
+
+  if (page.length < limit) {
+    page.push(...names.slice(nameQuota, nameQuota + (limit - page.length)));
+  }
+
+  return page;
+};
+
+module.exports = { collectResults, buildPage, NAME_SHARE };

--- a/backend/src/services/searchIgnore.js
+++ b/backend/src/services/searchIgnore.js
@@ -1,0 +1,42 @@
+/**
+ * The folders search does not walk into.
+ *
+ * The exclusion list was written for the index, and only the index obeyed it.
+ * Every search still enumerated the whole volume by name — including the
+ * Docker overlay the list exists to keep out — so no filename search could
+ * finish inside its budget: `*.xlsx` came back truncated at fifty-eight
+ * matches, then at fifty-seven, the same question answered differently twice
+ * because the walk was cut at a different point each time.
+ *
+ * A folder excluded from search is excluded from all of it. The one exception
+ * is standing inside it: navigating into an excluded folder and searching
+ * there is asking to look, and the exclusion keeps the crawl out of a corner
+ * rather than making the corner unreadable.
+ */
+
+/**
+ * ripgrep globs for the folders to skip, relative to where the search starts.
+ *
+ * @param {string} relBasePath  the search base, relative to the volume root
+ * @param {string[]} excludedPaths  excluded folders, relative to the same root
+ */
+const ripgrepIgnoreGlobs = (relBasePath = '', excludedPaths = []) => {
+  const base = relBasePath ? `${relBasePath}/` : '';
+
+  return excludedPaths.flatMap((excluded) => {
+    if (!excluded) return [];
+    // An exclusion elsewhere in the volume cannot match anything under this
+    // base, and one naming the base itself is where the search was pointed.
+    if (base && !excluded.startsWith(base)) return [];
+    const inner = base ? excluded.slice(base.length) : excluded;
+    if (!inner) return [];
+    // Anchored, so `Stacks/docker` does not also take out `Other/docker`.
+    return ['-g', `!/${inner}`, '-g', `!/${inner}/**`];
+  });
+};
+
+/** Whether a folder found while walking is one of the folders to skip. */
+const isIgnoredDirectory = (relPath, excludedPaths = []) =>
+  excludedPaths.some((excluded) => excluded && relPath === excluded);
+
+module.exports = { ripgrepIgnoreGlobs, isIgnoredDirectory };

--- a/backend/src/services/searchTerm.js
+++ b/backend/src/services/searchTerm.js
@@ -1,0 +1,80 @@
+/**
+ * What a typed search term means.
+ *
+ * Two terms typed into the same box do not ask the same question. `report` is
+ * text: it is looked for in filenames and inside files alike. `*.ps1` is a
+ * shape — it names a set of filenames, and no file contains those characters.
+ * Searching the tree for the literal string is therefore both wrong and the
+ * slowest thing the search can do: someone looking for their PowerShell
+ * scripts waited eleven seconds to be shown six files that mention `*.ps1` in
+ * their text, and not one of the scripts.
+ *
+ * So a wildcard is the signal to stop looking at content altogether. It is not
+ * an optimisation on the side; it is the difference between answering the
+ * question and answering a different one slowly.
+ */
+
+const path = require('path');
+
+const WILDCARD = /[*?]/;
+
+// Everything a regular expression treats specially, minus the two characters
+// that are the whole point. A term is typed by a person, so `a+b` is three
+// characters and not an expression.
+const REGEXP_SPECIALS = /[.+^${}()|[\]\\/]/g;
+
+const toRegExp = (pattern) =>
+  new RegExp(
+    `^${pattern.replace(REGEXP_SPECIALS, '\\$&').replace(/\*/g, '.*').replace(/\?/g, '.')}$`,
+    'i'
+  );
+
+const textTerm = (text) => {
+  const needle = text.toLowerCase();
+  const contains = (value) => value.toLowerCase().includes(needle);
+
+  return {
+    isGlob: false,
+    // Text is looked for inside files as well as in their names.
+    readsFileContents: true,
+    text,
+    needle,
+    matchesName: contains,
+    // A path is matched on its last segment: this is the behaviour a plain
+    // term has always had, and widening it would make every file under a
+    // matching folder a result of its own.
+    matchesRelativePath: (rel) => contains(path.posix.basename(rel)),
+  };
+};
+
+const globTerm = (text) => {
+  const wholePath = text.includes('/');
+  const pattern = toRegExp(text);
+
+  return {
+    isGlob: true,
+    // A pattern is a shape for names; there is nothing to look for inside a
+    // file, and looking is what cost the whole budget.
+    readsFileContents: false,
+    text,
+    needle: text.toLowerCase(),
+    // A pattern spanning folders cannot be answered by one name, so a folder
+    // is never a match for it — `Stacks/*.log` describes files under Stacks,
+    // not a folder called that.
+    matchesName: (name) => (wholePath ? false : pattern.test(name)),
+    matchesRelativePath: (rel) => pattern.test(wholePath ? rel : path.posix.basename(rel)),
+  };
+};
+
+/**
+ * @param {string} raw what the user typed
+ * @returns {{isGlob: boolean, readsFileContents: boolean, text: string, needle: string,
+ *   matchesName: (name: string) => boolean,
+ *   matchesRelativePath: (rel: string) => boolean}}
+ */
+const parseSearchTerm = (raw) => {
+  const text = String(raw ?? '');
+  return WILDCARD.test(text) ? globTerm(text) : textTerm(text);
+};
+
+module.exports = { parseSearchTerm };

--- a/backend/src/utils/clientDisconnect.js
+++ b/backend/src/utils/clientDisconnect.js
@@ -1,0 +1,22 @@
+/**
+ * When the person who asked has stopped waiting.
+ *
+ * Typing a search sends one request per pause, and the panel abandons every
+ * one but the last. The server did not know that: each abandoned search went
+ * on walking the volume with its own ripgrep processes for the full budget, so
+ * typing `*.xlsx` one character at a time left five searches running at once —
+ * three subprocesses and seven hundred megabytes for four answers nobody would
+ * ever read.
+ *
+ * `close` also fires on a response that finished normally, so the promise only
+ * settles when the connection went away with the answer still unwritten.
+ */
+const whenClientDisconnects = (res) =>
+  new Promise((resolve) => {
+    if (res.writableEnded) return;
+    res.once('close', () => {
+      if (!res.writableEnded) resolve();
+    });
+  });
+
+module.exports = { whenClientDisconnects };

--- a/backend/tests/helpers/fake-ripgrep.js
+++ b/backend/tests/helpers/fake-ripgrep.js
@@ -1,0 +1,64 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+/**
+ * A stand-in for ripgrep, so the search's other half can be run.
+ *
+ * The search route has two content engines. Which one runs is decided at
+ * request time by whether `rg` can be spawned, and the two enforce their bounds
+ * in different functions — so a machine without ripgrep runs the fallback and
+ * never the code that ships in the image, while CI, which installs ripgrep,
+ * runs the opposite half. A guard deleted from either one looks harmless on the
+ * machine that does not take that path.
+ *
+ * This makes the choice explicit instead of ambient. The stand-in answers
+ * `--version` so the route takes the ripgrep path, and reports no matches, so
+ * whatever the test is about is decided by the route rather than by ripgrep.
+ * That is the limit of it: it proves what the route does around ripgrep, never
+ * what ripgrep itself finds.
+ */
+
+const SCRIPT = `#!/bin/sh
+case "$1" in
+  --version) echo "ripgrep 14.0.0 (test stand-in)"; exit 0 ;;
+esac
+exit 1
+`;
+
+/**
+ * Put the stand-in first on PATH for the duration of a test.
+ *
+ * @returns {() => void} restores PATH and removes the stand-in
+ */
+const useFakeRipgrep = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-rg-'));
+  const binary = path.join(dir, 'rg');
+  fs.writeFileSync(binary, SCRIPT, { mode: 0o755 });
+
+  const previousPath = process.env.PATH;
+  process.env.PATH = `${dir}${path.delimiter}${previousPath || ''}`;
+
+  return () => {
+    process.env.PATH = previousPath;
+    fs.rmSync(dir, { recursive: true, force: true });
+  };
+};
+
+/** Whether a real ripgrep is installed on this machine. */
+const hasRealRipgrep = () => {
+  const previousPath = process.env.PATH;
+  return (process.env.PATH || '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .some((entry) => {
+      try {
+        fs.accessSync(path.join(entry, 'rg'), fs.constants.X_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    }) && Boolean(previousPath);
+};
+
+module.exports = { useFakeRipgrep, hasRealRipgrep };

--- a/backend/tests/helpers/pdf-fixture.js
+++ b/backend/tests/helpers/pdf-fixture.js
@@ -1,0 +1,50 @@
+const zlib = require('node:zlib');
+
+/**
+ * A one-page PDF whose text is compressed, as a real one's is.
+ *
+ * The compression is the point: an uncompressed content stream leaves the
+ * words as plain bytes in the file, where an ordinary text search finds them
+ * without anything having read the PDF at all — so a fixture built that way
+ * proves nothing about extracting the text.
+ */
+const buildPdf = (text) => {
+  const raw = `BT /F1 12 Tf 20 150 Td (${String(text).replace(/([()\\])/g, '\\$1')}) Tj ET`;
+  const stream = zlib.deflateSync(Buffer.from(raw, 'latin1'));
+
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] /Contents 4 0 R ' +
+      '/Resources << /Font << /F1 5 0 R >> >> >>',
+    { dict: `<< /Length ${stream.length} /Filter /FlateDecode >>`, data: stream },
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+
+  const parts = [Buffer.from('%PDF-1.4\n', 'latin1')];
+  let length = parts[0].length;
+  const offsets = [];
+
+  objects.forEach((body, index) => {
+    offsets.push(length);
+    const chunk =
+      typeof body === 'string'
+        ? Buffer.from(`${index + 1} 0 obj\n${body}\nendobj\n`, 'latin1')
+        : Buffer.concat([
+            Buffer.from(`${index + 1} 0 obj\n${body.dict}\nstream\n`, 'latin1'),
+            body.data,
+            Buffer.from('\nendstream\nendobj\n', 'latin1'),
+          ]);
+    parts.push(chunk);
+    length += chunk.length;
+  });
+
+  let xref = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) xref += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  xref += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${length}\n%%EOF\n`;
+  parts.push(Buffer.from(xref, 'latin1'));
+
+  return Buffer.concat(parts);
+};
+
+module.exports = { buildPdf };

--- a/backend/tests/routes/search-content.test.js
+++ b/backend/tests/routes/search-content.test.js
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import express from 'express';
+import request from 'supertest';
+import AdmZip from 'adm-zip';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+import { buildPdf } from '../helpers/pdf-fixture.js';
+
+/**
+ * Searching inside documents is the half of search nothing tested, and it was
+ * broken twice over: a size setting written the way our own README suggests
+ * made ripgrep refuse the flag and search nothing at all, and what survived
+ * that was rendered only after every filename match had been counted against
+ * the result limit.
+ */
+
+let envContext;
+
+const buildApp = () => {
+  const searchRoutes = envContext.requireFresh('src/routes/search');
+  const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
+  const app = express();
+  app.use((req, _res, next) => {
+    req.user = { id: 'u1', email: 'u@example.com', roles: ['admin'] };
+    next();
+  });
+  app.use('/api', searchRoutes);
+  app.use(errorHandler);
+  return app;
+};
+
+const seed = async (env = {}) => {
+  envContext = await setupTestEnv({
+    tag: 'search-content-',
+    env: { SEARCH_DEEP: 'true', SEARCH_RIPGREP: 'true', ...env },
+  });
+  const dbService = envContext.requireFresh('src/services/db');
+  const db = await dbService.getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+     VALUES ('u1', 'u@example.com', 1, 'u', 'U', '["admin"]', ?, ?)`
+  ).run(now, now);
+  return path.join(envContext.volumeDir, 'Docs');
+};
+
+const search = async (term) => {
+  const response = await request(buildApp()).get('/api/search').query({ q: term });
+  expect(response.status).toBe(200);
+  return response.body.items || [];
+};
+
+afterEach(async () => {
+  if (envContext) await envContext.cleanup();
+  envContext = null;
+});
+
+describe('searching inside documents', () => {
+  beforeEach(async () => {
+    const dir = await seed();
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'notes.md'), '# Notes\n\nthe word pangolin is here\n');
+  });
+
+  it('finds the word and says which line it is on', async () => {
+    const items = await search('pangolin');
+
+    const hit = items.find((item) => item.name === 'notes.md');
+    expect(hit).toBeTruthy();
+    expect(hit.matchLine).toContain('pangolin');
+    expect(hit.matchLineNumber).toBe(3);
+  });
+});
+
+// `SEARCH_MAX_FILESIZE=5MB` is the form the README suggests. ripgrep takes
+// `K`, `M` or `G` and nothing else: given `5MB` it refused the flag, exited,
+// and searched nothing — while filename search, a separate invocation without
+// that flag, went on working. Exactly the report in issue #3.
+describe('a size limit written the way people write it', () => {
+  for (const written of ['5MB', '5M', '5 mb', '5242880']) {
+    it(`still searches contents with SEARCH_MAX_FILESIZE=${written}`, async () => {
+      const dir = await seed({ SEARCH_MAX_FILESIZE: written });
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, 'notes.md'), 'the word pangolin is here\n');
+
+      const items = await search('pangolin');
+
+      expect(items.some((item) => item.name === 'notes.md' && item.matchLine)).toBe(true);
+    });
+  }
+
+  it('still skips a file that is over the limit', async () => {
+    const dir = await seed({ SEARCH_MAX_FILESIZE: '1K' });
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'big.txt'), `${'x'.repeat(4096)}\npangolin\n`);
+    await fs.writeFile(path.join(dir, 'small.txt'), 'pangolin\n');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'small.txt')).toBe(true);
+    expect(items.some((item) => item.name === 'big.txt')).toBe(false);
+  });
+});
+
+// The result limit is shared, and the passes used to be drained one after the
+// other: a term matching many filenames spent the whole budget before content
+// search had produced anything.
+describe('when the same term matches many filenames', () => {
+  it('still returns what is inside the documents', async () => {
+    const dir = await seed();
+    await fs.mkdir(dir, { recursive: true });
+    for (let index = 0; index < 120; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(path.join(dir, `pangolin-${index}.txt`), 'nothing to see\n');
+    }
+    await fs.writeFile(path.join(dir, 'zzz-notes.md'), 'the word pangolin is in here\n');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.matchLine)).toBe(true);
+    // And the page is still full: reserving a share for content does not mean
+    // answering short when there is little of it.
+    expect(items.length).toBe(100);
+    expect(items.filter((item) => !item.matchLine).length).toBeGreaterThan(90);
+  });
+});
+
+/**
+ * A `.docx` is a zip of XML: ripgrep sees compressed bytes and finds nothing,
+ * whatever the settings say. This is the half of "search my documents" that
+ * could not work at all.
+ */
+describe('searching inside Office documents', () => {
+  const writeDocx = (file, paragraphs) => {
+    const zip = new AdmZip();
+    const body = paragraphs
+      .map((runs) => `<w:p>${runs.map((run) => `<w:r><w:t>${run}</w:t></w:r>`).join('')}</w:p>`)
+      .join('');
+    zip.addFile(
+      'word/document.xml',
+      Buffer.from(`<w:document><w:body>${body}</w:body></w:document>`)
+    );
+    zip.writeZip(file);
+  };
+
+  it('finds a word in a Word document', async () => {
+    const dir = await seed();
+    await fs.mkdir(dir, { recursive: true });
+    writeDocx(path.join(dir, 'report.docx'), [
+      ['Quarterly report'],
+      ['The pangolin numbers are up'],
+    ]);
+
+    const items = await search('pangolin');
+
+    const hit = items.find((item) => item.name === 'report.docx');
+    expect(hit).toBeTruthy();
+    expect(hit.matchLine).toContain('pangolin');
+  });
+
+  // Word splits a word across runs wherever formatting changes inside it.
+  it('finds a word an author emphasised in the middle', async () => {
+    const dir = await seed();
+    await fs.mkdir(dir, { recursive: true });
+    writeDocx(path.join(dir, 'styled.docx'), [['pan', 'gol', 'in season']]);
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'styled.docx')).toBe(true);
+  });
+
+  it('reads a spreadsheet too', async () => {
+    const dir = await seed();
+    await fs.mkdir(dir, { recursive: true });
+    const zip = new AdmZip();
+    zip.addFile('xl/sharedStrings.xml', Buffer.from('<sst><si><t>pangolin count</t></si></sst>'));
+    zip.writeZip(path.join(dir, 'numbers.xlsx'));
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'numbers.xlsx')).toBe(true);
+  });
+
+  it('leaves a document that says nothing of the sort alone', async () => {
+    const dir = await seed();
+    await fs.mkdir(dir, { recursive: true });
+    writeDocx(path.join(dir, 'other.docx'), [['Nothing relevant in here']]);
+
+    expect(await search('pangolin')).toEqual([]);
+  });
+
+  // The size that counts is the archive on disk. Padding has to be
+  // incompressible or a repetitive document sails under any limit.
+  it('skips a document over the configured size', async () => {
+    const dir = await seed({ SEARCH_MAX_FILESIZE: '4K' });
+    await fs.mkdir(dir, { recursive: true });
+    const noise = Array.from({ length: 8000 }, (_, index) =>
+      ((index * 2654435761) % 4294967296).toString(36)
+    ).join(' ');
+    writeDocx(path.join(dir, 'big.docx'), [[`${noise} pangolin`]]);
+    writeDocx(path.join(dir, 'small.docx'), [['pangolin here']]);
+
+    const stats = await fs.stat(path.join(dir, 'big.docx'));
+    expect(stats.size).toBeGreaterThan(4 * 1024);
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'small.docx')).toBe(true);
+    expect(items.some((item) => item.name === 'big.docx')).toBe(false);
+  });
+});
+
+/**
+ * What ripgrep is actually handed. These run whether or not ripgrep is
+ * installed, which matters: the machine this was written on has no `rg` at
+ * all, so every end-to-end case above exercises the JavaScript fallback and
+ * would have gone on passing while the ripgrep path stayed broken.
+ */
+describe('the arguments a content search is given', () => {
+  const argsWith = async (env) => {
+    envContext = await setupTestEnv({ tag: 'search-args-', env });
+    const searchRoutes = envContext.requireFresh('src/routes/search');
+    return searchRoutes.contentSearchArgs('pangolin');
+  };
+
+  const sizeIn = (args) => {
+    const index = args.indexOf('--max-filesize');
+    return index === -1 ? null : args[index + 1];
+  };
+
+  // ripgrep takes a number with an optional K, M or G. `5MB` — the form our
+  // own README suggested — makes it refuse the flag and search nothing.
+  for (const written of ['5MB', '5M', '5 mb', '5242880']) {
+    it(`turns SEARCH_MAX_FILESIZE=${written} into a byte count`, async () => {
+      const args = await argsWith({ SEARCH_MAX_FILESIZE: written });
+
+      expect(sizeIn(args)).toBe('5242880');
+    });
+  }
+
+  it('never hands over the raw setting', async () => {
+    const args = await argsWith({ SEARCH_MAX_FILESIZE: '5MB' });
+
+    expect(args).not.toContain('5MB');
+  });
+
+  // The separator that keeps a term starting with `-` from being read as a
+  // flag — `--pre=<cmd>` would run that command against every scanned file.
+  it('puts the term after the separator', async () => {
+    const args = await argsWith({});
+
+    expect(args.indexOf('pangolin')).toBeGreaterThan(args.indexOf('--'));
+  });
+});
+
+/**
+ * A PDF keeps its words in compressed streams, so a content search reads it as
+ * binary. Only ones carrying a text layer, which is most of them — a scan is a
+ * picture and needs OCR.
+ */
+describe('searching inside PDFs', () => {
+  it('finds a word on the page', async () => {
+    const dir = await seed();
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'report.pdf'), buildPdf('the pangolin is here'));
+
+    const items = await search('pangolin');
+
+    const hit = items.find((item) => item.name === 'report.pdf');
+    expect(hit).toBeTruthy();
+    expect(hit.matchLine).toContain('pangolin');
+  });
+
+  it('leaves a PDF that says nothing of the sort alone', async () => {
+    const dir = await seed();
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'other.pdf'), buildPdf('nothing relevant in here'));
+
+    expect(await search('pangolin')).toEqual([]);
+  });
+});
+
+/**
+ * With the index on, a search answers from what was read earlier instead of
+ * reading the tree again. The point of the whole thing is that the second
+ * search costs nothing the first one did not already pay.
+ */
+describe('how long a search may take', () => {
+  it('says so when the budget ended it', async () => {
+    const dir = await seed({ SEARCH_TIMEOUT_MS: '1' });
+    await fs.mkdir(dir, { recursive: true });
+    for (let index = 0; index < 60; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(path.join(dir, `doc-${index}.pdf`), buildPdf('nothing of interest'));
+    }
+
+    const response = await request(buildApp()).get('/api/search').query({ q: 'pangolin' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.truncated).toBe(true);
+  });
+
+  it('does not say so when it saw everything', async () => {
+    const dir = await seed({ SEARCH_TIMEOUT_MS: '5000' });
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'notes.md'), 'the word pangolin is here\n');
+
+    const response = await request(buildApp()).get('/api/search').query({ q: 'pangolin' });
+
+    expect(response.body.truncated).toBe(false);
+    expect(response.body.items.length).toBeGreaterThan(0);
+  });
+
+  // The budget is a ceiling, not a delay: a search with an answer returns as
+  // soon as it has one.
+  it('does not wait for the budget when it is done', async () => {
+    const dir = await seed({ SEARCH_TIMEOUT_MS: '5000' });
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'notes.md'), 'the word pangolin is here\n');
+
+    const started = Date.now();
+    const items = await search('pangolin');
+    const elapsed = Date.now() - started;
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(elapsed).toBeLessThan(3000);
+  });
+});

--- a/backend/tests/routes/search-documents.test.js
+++ b/backend/tests/routes/search-documents.test.js
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import express from 'express';
+import request from 'supertest';
+import AdmZip from 'adm-zip';
+import { randomBytes } from 'node:crypto';
+
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+import { useFakeRipgrep } from '../helpers/fake-ripgrep.js';
+import { buildPdf } from '../helpers/pdf-fixture.js';
+
+/**
+ * Searching inside Office documents and PDFs.
+ *
+ * ripgrep reads a .docx as binary — it is a zip — and a PDF as binary too,
+ * because its words live in compressed content streams. So both are searched by
+ * a separate pass that extracts the text first, and that pass is bounded three
+ * ways because it costs an unzip or a `pdftotext` per document: only certain
+ * extensions, only files under the configured size, and only so many documents
+ * per search.
+ *
+ * All three bounds were uncovered, along with the deduplication that stops a
+ * document already found by name being listed twice. Those bounds are what
+ * stands between a search and a folder of ten thousand spreadsheets.
+ *
+ * The size bound is enforced twice because the search has two content engines,
+ * and a request only ever runs one of them: ripgrep's path bounds it in
+ * `streamDocumentMatches`, the JavaScript fallback in `generateFallbackResults`.
+ * Neither is a duplicate of the other, and a machine without ripgrep installed
+ * exercises only the second — which is why deleting the first looked harmless
+ * for as long as nobody ran it. The bound tests below therefore name the engine
+ * they run on and run on both, on every machine.
+ *
+ * The extension check in `streamDocumentMatches` is a genuine optimisation
+ * rather than a rule: `findDocumentTextMatch` tests the extension again and
+ * returns null, so deleting it changes nothing but the number of files opened.
+ */
+
+let envContext;
+
+const buildApp = () => {
+  const searchRoutes = envContext.requireFresh('src/routes/search');
+  const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
+  const app = express();
+  app.use((req, _res, next) => {
+    req.user = { id: 'u1', email: 'u@example.com', roles: ['admin'] };
+    next();
+  });
+  app.use('/api', searchRoutes);
+  app.use(errorHandler);
+  return app;
+};
+
+const seed = async (env = {}) => {
+  envContext = await setupTestEnv({
+    tag: 'search-documents-',
+    env: { SEARCH_DEEP: 'true', SEARCH_RIPGREP: 'true', ...env },
+  });
+  const dbService = envContext.requireFresh('src/services/db');
+  const db = await dbService.getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+     VALUES ('u1', 'u@example.com', 1, 'u', 'U', '["admin"]', ?, ?)`
+  ).run(now, now);
+  const dir = path.join(envContext.volumeDir, 'Docs');
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+};
+
+/** A real .docx: a zip whose word/document.xml carries the text. */
+const writeDocx = async (absolutePath, text) => {
+  const zip = new AdmZip();
+  zip.addFile(
+    'word/document.xml',
+    Buffer.from(
+      `<?xml version="1.0"?><w:document xmlns:w="x"><w:body><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:body></w:document>`
+    )
+  );
+  await fs.writeFile(absolutePath, zip.toBuffer());
+};
+
+const search = async (q, query = {}) => {
+  const response = await request(buildApp()).get('/api/search').query({ q, ...query });
+  expect(response.status).toBe(200);
+  return response.body.items || [];
+};
+
+afterEach(async () => {
+  if (envContext) await envContext.cleanup();
+  envContext = null;
+});
+
+describe('inside an Office document', () => {
+  it('finds a word ripgrep cannot see, because the file is a zip', async () => {
+    const dir = await seed();
+    await writeDocx(path.join(dir, 'report.docx'), 'the word pangolin appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'report.docx')).toBe(true);
+  });
+
+  it('does not offer a document that does not contain the word', async () => {
+    const dir = await seed();
+    await writeDocx(path.join(dir, 'report.docx'), 'nothing of interest');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'report.docx')).toBe(false);
+  });
+
+  /**
+   * A file found by its name has already been counted. Extracting its text as
+   * well would list it twice, once per pass.
+   */
+  it('lists a document found by name only once', async () => {
+    const dir = await seed();
+    await writeDocx(path.join(dir, 'pangolin.docx'), 'the word pangolin appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.filter((item) => item.name === 'pangolin.docx')).toHaveLength(1);
+  });
+
+  it('searches documents in subfolders too', async () => {
+    const dir = await seed();
+    await fs.mkdir(path.join(dir, '2026/q1'), { recursive: true });
+    await writeDocx(path.join(dir, '2026/q1/deep.docx'), 'the word pangolin appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'deep.docx')).toBe(true);
+  });
+
+  it('matches without regard to case', async () => {
+    const dir = await seed();
+    await writeDocx(path.join(dir, 'report.docx'), 'The word PANGOLIN appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'report.docx')).toBe(true);
+  });
+
+  /** An extension not on the list is never opened, whatever is inside it. */
+  it('does not open a file type it was not asked to read', async () => {
+    const dir = await seed();
+    await writeDocx(path.join(dir, 'archive.zip'), 'the word pangolin appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'archive.zip')).toBe(false);
+  });
+});
+
+describe('inside a PDF', () => {
+  it('finds a word held in a compressed content stream', async () => {
+    const dir = await seed();
+    await fs.writeFile(path.join(dir, 'paper.pdf'), buildPdf('the word pangolin appears here'));
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'paper.pdf')).toBe(true);
+  });
+
+  it('does not offer a PDF that does not contain the word', async () => {
+    const dir = await seed();
+    await fs.writeFile(path.join(dir, 'paper.pdf'), buildPdf('nothing of interest'));
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'paper.pdf')).toBe(false);
+  });
+});
+
+describe('the bounds on how much it will read', () => {
+  it('respects the result limit the caller asked for', async () => {
+    const dir = await seed();
+    for (let i = 0; i < 5; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await writeDocx(path.join(dir, `doc${i}.docx`), 'the word pangolin appears here');
+    }
+
+    const items = await search('pangolin', { limit: 2 });
+
+    expect(items.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe('hidden documents', () => {
+  it('are left out unless they were asked for', async () => {
+    const dir = await seed({ HIDDEN_FILE_PATTERNS: '.' });
+    await writeDocx(path.join(dir, '.secret.docx'), 'the word pangolin appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === '.secret.docx')).toBe(false);
+  });
+
+  it('are searched in a folder that is not hidden', async () => {
+    const dir = await seed({ HIDDEN_FILE_PATTERNS: '.' });
+    await writeDocx(path.join(dir, 'visible.docx'), 'the word pangolin appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'visible.docx')).toBe(true);
+  });
+});
+
+describe('when a document cannot be read', () => {
+  /** A truncated or corrupt file is a file, not a reason to fail the search. */
+  it('carries on with the rest', async () => {
+    const dir = await seed();
+    await fs.writeFile(path.join(dir, 'corrupt.docx'), Buffer.from('not a zip at all'));
+    await writeDocx(path.join(dir, 'good.docx'), 'the word pangolin appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'good.docx')).toBe(true);
+  });
+
+  it('carries on when the PDF is not a PDF', async () => {
+    const dir = await seed();
+    await fs.writeFile(path.join(dir, 'corrupt.pdf'), Buffer.from('%PDF-1.4 truncated'));
+    await fs.writeFile(path.join(dir, 'good.pdf'), buildPdf('the word pangolin appears here'));
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'good.pdf')).toBe(true);
+  });
+});
+
+/**
+ * The size bound, on each of the two engines that enforce it.
+ *
+ * Which engine a request uses is decided by whether `rg` can be spawned, so
+ * without saying so a suite covers whichever half the machine happens to
+ * provide. Both are named here: the fallback by switching ripgrep off, the
+ * ripgrep path by putting a stand-in on PATH that reports no matches, leaving
+ * the document pass to decide the result.
+ */
+describe.each([
+  ['the fallback scan', { SEARCH_RIPGREP: 'false' }, false],
+  ['the ripgrep path', { SEARCH_RIPGREP: 'true' }, true],
+])('the size bound, on %s', (_engine, engineEnv, standInRipgrep) => {
+  let restoreRipgrep = null;
+
+  beforeEach(() => {
+    restoreRipgrep = standInRipgrep ? useFakeRipgrep() : null;
+  });
+
+  afterEach(() => {
+    restoreRipgrep?.();
+    restoreRipgrep = null;
+  });
+
+  /** A folder of large spreadsheets would otherwise be unzipped for every keystroke. */
+  it('skips a document larger than the configured size', async () => {
+    const dir = await seed({ SEARCH_MAX_FILESIZE: '1K', ...engineEnv });
+    const zip = new AdmZip();
+    zip.addFile(
+      'word/document.xml',
+      Buffer.from(
+        '<?xml version="1.0"?><w:document xmlns:w="x"><w:body><w:p><w:r><w:t>' +
+          'the word pangolin appears here</w:t></w:r></w:p></w:body></w:document>'
+      )
+    );
+    // Random bytes, because repeated padding compresses away and the file
+    // would come out under the limit this test is about.
+    zip.addFile('word/media/blob.bin', randomBytes(64 * 1024));
+    const file = path.join(dir, 'huge.docx');
+    await fs.writeFile(file, zip.toBuffer());
+    expect((await fs.stat(file)).size).toBeGreaterThan(1024);
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'huge.docx')).toBe(false);
+  });
+
+  it('still reads one under the limit', async () => {
+    const dir = await seed({ SEARCH_MAX_FILESIZE: '1M', ...engineEnv });
+    await writeDocx(path.join(dir, 'small.docx'), 'the word pangolin appears here');
+
+    const items = await search('pangolin');
+
+    expect(items.some((item) => item.name === 'small.docx')).toBe(true);
+  });
+});

--- a/backend/tests/routes/search-glob.test.js
+++ b/backend/tests/routes/search-glob.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import express from 'express';
+import request from 'supertest';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * `*.ps1` typed into the search box found six files that happen to mention
+ * `*.ps1` in their text, took eleven seconds about it, and returned not one of
+ * the PowerShell scripts sitting in the volume. Both halves are tested here,
+ * at the route, because the defect was never in matching a name — it was in
+ * the search deciding that a pattern was something to look for inside files.
+ */
+
+let envContext;
+
+const buildApp = () => {
+  const searchRoutes = envContext.requireFresh('src/routes/search');
+  const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
+  const app = express();
+  app.use((req, _res, next) => {
+    req.user = { id: 'u1', email: 'u@example.com', roles: ['admin'] };
+    next();
+  });
+  app.use('/api', searchRoutes);
+  app.use(errorHandler);
+  return app;
+};
+
+const seed = async () => {
+  envContext = await setupTestEnv({
+    tag: 'search-glob-',
+    env: { SEARCH_DEEP: 'true', SEARCH_RIPGREP: 'true' },
+  });
+  const dbService = envContext.requireFresh('src/services/db');
+  const db = await dbService.getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+     VALUES ('u1', 'u@example.com', 1, 'u', 'U', '["admin"]', ?, ?)`
+  ).run(now, now);
+
+  const dir = path.join(envContext.volumeDir, 'Scripts');
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'deploy.ps1'), 'Write-Host "deploying"\n');
+  await fs.writeFile(path.join(dir, 'cleanup.ps1'), 'Write-Host "cleaning"\n');
+  // The trap: its name is not a match, but its text is. Under the old rule it
+  // was a result and the scripts were not.
+  await fs.writeFile(path.join(dir, 'README.md'), 'Run every *.ps1 in this folder.\n');
+  await fs.writeFile(path.join(dir, 'deploy.ps1.bak'), 'old copy\n');
+  return dir;
+};
+
+const search = async (term) => {
+  const response = await request(buildApp()).get('/api/search').query({ q: term });
+  expect(response.status).toBe(200);
+  return response.body;
+};
+
+afterEach(async () => {
+  if (envContext) await envContext.cleanup();
+  envContext = null;
+});
+
+describe('searching for a filename pattern', () => {
+  it('returns the files the pattern names', async () => {
+    await seed();
+    const names = (await search('*.ps1')).items.map((item) => item.name).sort();
+
+    expect(names).toEqual(['cleanup.ps1', 'deploy.ps1']);
+  });
+
+  it('does not return a file merely because the pattern appears in its text', async () => {
+    await seed();
+    const names = (await search('*.ps1')).items.map((item) => item.name);
+
+    expect(names).not.toContain('README.md');
+  });
+
+  it('anchors the pattern, so a name that only starts that way is not a match', async () => {
+    await seed();
+    const names = (await search('*.ps1')).items.map((item) => item.name);
+
+    expect(names).not.toContain('deploy.ps1.bak');
+  });
+
+  /**
+   * The half that made it slow. A pattern has nothing to look for inside a
+   * file, so no content source is opened, and the answer cannot be truncated
+   * by a budget it never spent.
+   */
+  it('answers whole, without spending the time budget', async () => {
+    await seed();
+    const body = await search('*.ps1');
+
+    expect(body.truncated).toBe(false);
+    expect(body.items.length).toBeGreaterThan(0);
+  });
+
+  it('still searches inside files when the term is not a pattern', async () => {
+    await seed();
+    const hit = (await search('deploying')).items.find((item) => item.name === 'deploy.ps1');
+
+    expect(hit?.matchLine).toContain('deploying');
+  });
+});
+
+/**
+ * The exclusion list was written for the index, and only the index obeyed it.
+ * Every search still walked the excluded folder by name, which on a Docker
+ * overlay is most of a volume — so no search finished inside its budget, and
+ * the same question came back truncated at a different point each time.
+ */

--- a/backend/tests/routes/search-hidden-files.test.js
+++ b/backend/tests/routes/search-hidden-files.test.js
@@ -18,11 +18,22 @@ const createSearchContext = async () => {
       'src/middleware/errorHandler',
       'src/services/accessManager',
       'src/services/settingsService',
+      'src/utils/pathUtils',
     ],
   });
 
   const searchRoutes = envContext.requireFresh('src/routes/search');
   const { errorHandler } = envContext.requireFresh('src/middleware/errorHandler');
+  const { getDb } = envContext.requireFresh('src/services/db');
+  const db = await getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `
+    INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `
+  ).run('admin', 'admin@example.com', 1, 'admin', 'Admin', '["admin"]', now, now);
+
   const app = createTestApp({
     router: searchRoutes,
     mountPath: '/api',

--- a/backend/tests/routes/search-merge-dedup.test.js
+++ b/backend/tests/routes/search-merge-dedup.test.js
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+const { mergeResults } = require('../../src/routes/search.js');
+
+/**
+ * The same file, found by two passes at once.
+ *
+ * A search runs several passes concurrently — names, contents, and the one that
+ * unzips Office documents — and they share a set of paths already found so that
+ * none repeats another's work. That set cannot prevent a duplicate, because in
+ * the document pass the test and the claim are three awaits apart: it checks a
+ * path, then stats the file, extracts its text and asks permission, and only
+ * then records it. The name pass claims a path on the line after testing one,
+ * so it fits inside that window.
+ *
+ * A `.docx` whose name and contents both match therefore came back twice. It
+ * needed a machine slow enough to finish the directory walk while a document
+ * was being unzipped, which is why it appeared in CI and not on a developer's
+ * machine — a timing test would be no test at all, so these drive the merge
+ * directly and arrange the interleaving by hand.
+ */
+
+const item = (name, path = '', kind = 'file') => ({ name, path, kind });
+
+/** A generator that yields on demand, so a test can decide who goes first. */
+const paced = async function* (values, pauseMs = 0) {
+  for (const value of values) {
+    if (pauseMs) await new Promise((resolve) => setTimeout(resolve, pauseMs));
+    yield value;
+  }
+};
+
+const collect = async (generator) => {
+  const out = [];
+  for await (const value of generator) out.push(value);
+  return out;
+};
+
+describe('merging the passes of a search', () => {
+  it('passes through what one pass found', async () => {
+    const results = await collect(mergeResults(paced([item('a.txt'), item('b.txt')])));
+
+    expect(results.map((r) => r.name)).toEqual(['a.txt', 'b.txt']);
+  });
+
+  it('lists a file once when two passes both find it', async () => {
+    const byName = paced([item('pangolin.docx')]);
+    const byContent = paced([item('pangolin.docx')]);
+
+    const results = await collect(mergeResults(byName, byContent));
+
+    expect(results.filter((r) => r.name === 'pangolin.docx')).toHaveLength(1);
+  });
+
+  /**
+   * The order the passes finish in is exactly what varies between machines, so
+   * neither order may produce a duplicate.
+   */
+  it('lists it once when the slower pass finds it first', async () => {
+    const byName = paced([item('pangolin.docx')], 30);
+    const byContent = paced([item('pangolin.docx')]);
+
+    const results = await collect(mergeResults(byName, byContent));
+
+    expect(results).toHaveLength(1);
+  });
+
+  it('lists it once when the faster pass finds it first', async () => {
+    const byName = paced([item('pangolin.docx')]);
+    const byContent = paced([item('pangolin.docx')], 30);
+
+    const results = await collect(mergeResults(byName, byContent));
+
+    expect(results).toHaveLength(1);
+  });
+
+  /** The first one through is the one kept, with whatever it carried. */
+  it('keeps the first result rather than the last', async () => {
+    const byName = paced([item('pangolin.docx')]);
+    const byContent = paced([{ ...item('pangolin.docx'), matchLine: 'the word appears here' }], 30);
+
+    const [result] = await collect(mergeResults(byName, byContent));
+
+    expect(result.matchLine).toBeUndefined();
+  });
+
+  /**
+   * Two files of the same name in different folders are two files. Collapsing
+   * them would be a worse bug than the one being fixed.
+   */
+  it('keeps two same-named files from different folders', async () => {
+    const first = paced([item('report.docx', '2025')]);
+    const second = paced([item('report.docx', '2026')]);
+
+    const results = await collect(mergeResults(first, second));
+
+    expect(results).toHaveLength(2);
+  });
+
+  it('tells a file at the root from one of the same name in a folder', async () => {
+    const first = paced([item('report.docx')]);
+    const second = paced([item('report.docx', 'archive')]);
+
+    const results = await collect(mergeResults(first, second));
+
+    expect(results).toHaveLength(2);
+  });
+
+  it('still ends when every pass is exhausted', async () => {
+    const results = await collect(mergeResults(paced([]), paced([])));
+
+    expect(results).toEqual([]);
+  });
+
+  /**
+   * A consumer that stops early closes the passes behind it — that is what
+   * ends the ripgrep processes they own.
+   */
+  it('closes the passes it is still holding when the consumer stops', async () => {
+    let closed = false;
+    const endless = (async function* () {
+      try {
+        for (let i = 0; ; i += 1) yield item(`file-${i}.txt`);
+      } finally {
+        closed = true;
+      }
+    })();
+
+    const merged = mergeResults(endless, paced([]));
+    await merged.next();
+    await merged.return?.();
+    // The close propagates on the next turn of the loop.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(closed).toBe(true);
+  });
+});

--- a/backend/tests/services/office-text-extract.test.js
+++ b/backend/tests/services/office-text-extract.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import AdmZip from 'adm-zip';
+
+const { extractOfficeTextLines } = require('../../src/services/officeTextExtract');
+
+/**
+ * Office documents are zip archives of XML, so a plain content search sees
+ * compressed bytes and finds nothing. What decides whether reading them is
+ * useful is how the pieces of a paragraph are put back together.
+ */
+
+let dir;
+
+const docx = (documentXml) => {
+  const zip = new AdmZip();
+  zip.addFile('[Content_Types].xml', Buffer.from('<Types/>'));
+  zip.addFile('word/document.xml', Buffer.from(documentXml));
+  const file = path.join(dir, `doc-${Math.abs(documentXml.length)}.docx`);
+  zip.writeZip(file);
+  return file;
+};
+
+const paragraph = (...runs) =>
+  `<w:p>${runs.map((run) => `<w:r><w:t>${run}</w:t></w:r>`).join('')}</w:p>`;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'office-text-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('reading a Word document', () => {
+  it('gives back its paragraphs', async () => {
+    const file = docx(
+      `<w:document><w:body>${paragraph('Hello there')}${paragraph('Second line')}</w:body></w:document>`
+    );
+
+    expect(extractOfficeTextLines(file)).toEqual(['Hello there', 'Second line']);
+  });
+
+  // The reason this exists. Word splits a word across runs whenever formatting
+  // changes inside it, so an emphasised syllable makes three nodes. Joining
+  // them with a space would hide the word from the search that goes looking
+  // for it.
+  it('puts a word split by formatting back together', async () => {
+    const file = docx(
+      `<w:document><w:body>${paragraph('im', 'port', 'ant')}</w:body></w:document>`
+    );
+
+    expect(extractOfficeTextLines(file)).toEqual(['important']);
+  });
+
+  it('reads the entities as the characters they stand for', async () => {
+    const file = docx(
+      `<w:document><w:body>${paragraph('Tom &amp; Jerry &lt;3 &quot;quoted&quot;')}</w:body></w:document>`
+    );
+
+    expect(extractOfficeTextLines(file)).toEqual(['Tom & Jerry <3 "quoted"']);
+  });
+
+  it('says nothing rather than failing on a file that is not a document', async () => {
+    const file = path.join(dir, 'broken.docx');
+    await fs.writeFile(file, 'this is not a zip at all');
+
+    expect(extractOfficeTextLines(file)).toBeNull();
+  });
+
+  it('leaves formats it does not read alone', async () => {
+    const file = path.join(dir, 'notes.md');
+    await fs.writeFile(file, '# hello');
+
+    expect(extractOfficeTextLines(file)).toBeNull();
+  });
+
+  // A document big enough to be a problem is not one anyone reads line by
+  // line, and the search must not be held up by it.
+  it('stops reading a document past the size it was given', async () => {
+    const long = Array.from({ length: 500 }, (_, index) => paragraph(`line ${index} `.repeat(20)));
+    const file = docx(`<w:document><w:body>${long.join('')}</w:body></w:document>`);
+
+    const lines = extractOfficeTextLines(file, { maxCharacters: 1000 });
+
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.join('').length).toBeLessThan(2000);
+  });
+});
+
+describe('reading a spreadsheet and a deck', () => {
+  it('reads the strings out of a workbook', async () => {
+    const zip = new AdmZip();
+    zip.addFile(
+      'xl/sharedStrings.xml',
+      Buffer.from('<sst><si><t>Revenue</t></si><si><t>Q4 pangolin</t></si></sst>')
+    );
+    const file = path.join(dir, 'book.xlsx');
+    zip.writeZip(file);
+
+    expect(extractOfficeTextLines(file)).toEqual(['Revenue', 'Q4 pangolin']);
+  });
+
+  it('reads the text off the slides', async () => {
+    const zip = new AdmZip();
+    zip.addFile(
+      'ppt/slides/slide1.xml',
+      Buffer.from('<p:sld><a:p><a:r><a:t>Title here</a:t></a:r></a:p></p:sld>')
+    );
+    const file = path.join(dir, 'deck.pptx');
+    zip.writeZip(file);
+
+    expect(extractOfficeTextLines(file)).toEqual(['Title here']);
+  });
+});
+
+/**
+ * A zip states how large each entry becomes before anything is decompressed,
+ * and for text that number can be enormous next to the file it came in. The
+ * inflation happens on the one thread the server has, so a document nobody
+ * would think twice about — well inside any search size limit — can stop
+ * everything else for as long as it takes.
+ */
+describe('what it refuses to inflate', () => {
+  const bodyOf = (paragraphs) =>
+    `<w:document><w:body>${paragraph('pangolin').repeat(paragraphs)}</w:body></w:document>`;
+
+  // Either side of the ceiling, so the ceiling is what separates them and not
+  // some other property of a large archive. Both files are tiny on disk.
+  it('reads a document that inflates to a reasonable size', async () => {
+    const file = docx(bodyOf(150000));
+
+    expect((await fs.stat(file)).size).toBeLessThan(1024 * 1024);
+    expect(extractOfficeTextLines(file)?.length).toBe(150000);
+  });
+
+  it('leaves an entry that says it inflates to far more', async () => {
+    const file = docx(bodyOf(400000));
+
+    expect((await fs.stat(file)).size).toBeLessThan(1024 * 1024);
+    expect(extractOfficeTextLines(file)).toBeNull();
+  });
+});

--- a/backend/tests/services/pdf-text-extract.test.js
+++ b/backend/tests/services/pdf-text-extract.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+
+const { extractPdfTextLines, hasPdfToText } = require('../../src/services/pdfTextExtract');
+const { buildPdf } = require('../helpers/pdf-fixture');
+
+/**
+ * A PDF keeps its words in compressed content streams, so a plain content
+ * search reads it as binary and finds nothing. Only documents with a text
+ * layer — a scan is a picture of a page and needs OCR, which is seconds per
+ * page and does not belong in a search request.
+ */
+
+let dir;
+
+const writePdf = async (name, text) => {
+  const file = path.join(dir, name);
+  await fs.writeFile(file, buildPdf(text));
+  return file;
+};
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdf-text-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('reading a PDF', () => {
+  it('is possible at all here', async () => {
+    // If this fails the rest prove nothing: the tool is what does the reading.
+    expect(await hasPdfToText()).toBe(true);
+  });
+
+  it('gives back the words on the page', async () => {
+    const file = await writePdf('report.pdf', 'the pangolin is here');
+
+    expect(await extractPdfTextLines(file)).toContain('the pangolin is here');
+  });
+
+  it('says nothing rather than failing on a file that is not a PDF', async () => {
+    const file = path.join(dir, 'broken.pdf');
+    await fs.writeFile(file, 'this is not a PDF at all');
+
+    expect(await extractPdfTextLines(file)).toBeNull();
+  });
+
+  it('says nothing for a file that is not there', async () => {
+    expect(await extractPdfTextLines(path.join(dir, 'missing.pdf'))).toBeNull();
+  });
+});

--- a/backend/tests/services/search-collector.test.js
+++ b/backend/tests/services/search-collector.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+
+const { collectResults, buildPage } = require('../../src/services/searchCollector');
+
+/**
+ * A reserve is worth waiting for while there is somewhere left to find it.
+ * Once the sources of content are exhausted, waiting is just waiting — and it
+ * was five seconds of it on every ordinary search: a term with five hundred
+ * filename matches and eight content matches ran to the time budget looking
+ * for content that had already run out.
+ */
+const name = (n) => ({ name: `file-${n}.txt`, path: 'Docs' });
+const content = (n) => ({ name: `doc-${n}.md`, path: 'Docs', matchLine: 'pangolin here' });
+
+const stream = async function* (items, { onExhausted } = {}) {
+  for (const item of items) yield item;
+  onExhausted?.();
+};
+
+describe('collecting a page of results', () => {
+  it('stops once names have filled the page and no content can arrive', async () => {
+    let exhausted = false;
+    const many = Array.from({ length: 500 }, (unused, i) => name(i));
+
+    const { names, contents } = await collectResults({
+      results: stream(many, { onExhausted: () => {} }),
+      limit: 100,
+      // Nothing else is going to produce a content match.
+      contentExhausted: () => (exhausted = true),
+    });
+
+    expect(names).toHaveLength(100);
+    expect(contents).toHaveLength(0);
+    expect(exhausted).toBe(true);
+  });
+
+  // While content can still arrive, the page stays open for it: names alone
+  // used to return a hundred results and not one line of what was inside them.
+  it('keeps looking while content can still arrive', async () => {
+    const items = [
+      ...Array.from({ length: 300 }, (unused, i) => name(i)),
+      ...Array.from({ length: 25 }, (unused, i) => content(i)),
+    ];
+
+    const { names, contents } = await collectResults({
+      results: stream(items),
+      limit: 100,
+      contentExhausted: () => false,
+    });
+
+    expect(names.length).toBeGreaterThan(100);
+    expect(contents).toHaveLength(25);
+  });
+
+  // Both conditions, in that order: the page of names has to be full before
+  // the reserve is even looked at, so content arriving quickly overshoots it
+  // rather than cutting the names short.
+  it('stops once the page is full and the reserve is met, and not before', async () => {
+    const items = [];
+    for (let i = 0; i < 300; i += 1) {
+      items.push(name(i));
+      if (i % 3 === 0) items.push(content(i));
+    }
+
+    let consumed = 0;
+    const counted = (async function* () {
+      for (const item of items) {
+        consumed += 1;
+        yield item;
+      }
+    })();
+
+    const { names, contents } = await collectResults({
+      results: counted,
+      limit: 100,
+      contentExhausted: () => false,
+    });
+
+    expect(names).toHaveLength(100);
+    // A quarter of a hundred-result page is reserved for content, and content
+    // arriving faster than names simply exceeds it.
+    expect(contents.length).toBeGreaterThanOrEqual(25);
+    // And it stopped rather than reading the rest.
+    expect(consumed).toBeLessThan(items.length);
+  });
+});
+
+describe('building the page', () => {
+  it('gives content its share and lets names lead', () => {
+    const page = buildPage({
+      names: Array.from({ length: 100 }, (unused, i) => name(i)),
+      contents: Array.from({ length: 25 }, (unused, i) => content(i)),
+      limit: 100,
+    });
+
+    expect(page).toHaveLength(100);
+    expect(page.filter((item) => item.matchLine)).toHaveLength(25);
+    expect(page[0].matchLine).toBeUndefined();
+  });
+
+  // A quota that went unused is not a reason to answer short.
+  it('fills the page with names when there was little content', () => {
+    const page = buildPage({
+      names: Array.from({ length: 200 }, (unused, i) => name(i)),
+      contents: [content(0)],
+      limit: 100,
+    });
+
+    expect(page).toHaveLength(100);
+    expect(page.filter((item) => item.matchLine)).toHaveLength(1);
+  });
+
+  it('answers with only names when nothing matched inside a file', () => {
+    const page = buildPage({
+      names: Array.from({ length: 40 }, (unused, i) => name(i)),
+      contents: [],
+      limit: 100,
+    });
+
+    expect(page).toHaveLength(40);
+  });
+});
+
+/**
+ * The budget stopped the search and then the answer waited anyway. Cleaning up
+ * means resuming every source at whatever it was in the middle of, and on a
+ * busy tree that took six seconds — so a search bounded at five answered in
+ * eleven. The bound had not been raised; the wait had moved past it.
+ *
+ * The way out is that what has been found is already the caller's, so it can
+ * answer at the budget and clean up afterwards.
+ */
+describe('answering before the search has finished', () => {
+  it('leaves what it has found in the caller’s hands as it goes', async () => {
+    const names = [];
+    const contents = [];
+    let released;
+    const held = new Promise((resolve) => {
+      released = resolve;
+    });
+    let reachedTheHold;
+    const reached = new Promise((resolve) => {
+      reachedTheHold = resolve;
+    });
+
+    const slow = async function* () {
+      yield name(1);
+      yield content(1);
+      yield name(2);
+      // A source that will not come back on its own: the budget is the only
+      // thing that ends this search. Reaching it is the deterministic moment
+      // to look — every item before it has been handed to the collector.
+      reachedTheHold();
+      await held;
+    };
+
+    const collect = collectResults({ results: slow(), limit: 100, names, contents });
+    await reached;
+
+    // No await on the collector: this is the moment the route answers in.
+    expect(names.map((item) => item.name)).toEqual(['file-1.txt', 'file-2.txt']);
+    expect(contents.map((item) => item.name)).toEqual(['doc-1.md']);
+
+    released();
+    await collect;
+  });
+});

--- a/backend/tests/services/search-ignore.test.js
+++ b/backend/tests/services/search-ignore.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+
+const { ripgrepIgnoreGlobs, isIgnoredDirectory } = require('../../src/services/searchIgnore');
+
+/**
+ * `SEARCH_INDEX_EXCLUDE=Stacks/docker` kept the index out of the Docker
+ * overlay and nothing else: every filename search still walked it, and none
+ * could finish inside five seconds. The same search answered 58 matches once
+ * and 57 the next time — one question, two answers, because the walk was cut
+ * at a different point each time.
+ */
+describe('keeping the search out of excluded folders', () => {
+  it('excludes the folder and everything under it, anchored to the root', () => {
+    expect(ripgrepIgnoreGlobs('', ['Stacks/docker'])).toEqual([
+      '-g',
+      '!/Stacks/docker',
+      '-g',
+      '!/Stacks/docker/**',
+    ]);
+  });
+
+  it('rewrites the path when the search starts further down', () => {
+    expect(ripgrepIgnoreGlobs('Stacks', ['Stacks/docker'])).toEqual([
+      '-g',
+      '!/docker',
+      '-g',
+      '!/docker/**',
+    ]);
+  });
+
+  it('says nothing about an exclusion in another part of the volume', () => {
+    expect(ripgrepIgnoreGlobs('Media', ['Stacks/docker'])).toEqual([]);
+  });
+
+  /**
+   * Standing inside an excluded folder and searching is asking to look there.
+   * The list keeps the crawl out of a corner; it does not make the corner
+   * unreadable to someone who navigated into it.
+   */
+  it('does not exclude the folder the search was pointed at', () => {
+    expect(ripgrepIgnoreGlobs('Stacks/docker', ['Stacks/docker'])).toEqual([]);
+  });
+
+  it('anchors, so a folder of the same name elsewhere is still searched', () => {
+    const globs = ripgrepIgnoreGlobs('', ['Stacks/docker']);
+
+    expect(globs).not.toContain('!docker');
+  });
+
+  it('recognises the folder itself while walking', () => {
+    expect(isIgnoredDirectory('Stacks/docker', ['Stacks/docker'])).toBe(true);
+    expect(isIgnoredDirectory('Stacks/dockerfiles', ['Stacks/docker'])).toBe(false);
+    expect(isIgnoredDirectory('Stacks', ['Stacks/docker'])).toBe(false);
+  });
+});

--- a/backend/tests/services/search-term.test.js
+++ b/backend/tests/services/search-term.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+
+const { parseSearchTerm } = require('../../src/services/searchTerm');
+
+/**
+ * `*.ps1` typed into the search box returned six files that mention the
+ * characters `*.ps1` somewhere in their text, after eleven seconds, and not
+ * one PowerShell script. Both halves of that are this module's job: what the
+ * pattern matches, and that a pattern is not something to look for inside
+ * files.
+ */
+describe('reading what a search term asks for', () => {
+  it('treats a term with no wildcard as text, matched anywhere in the name', () => {
+    const term = parseSearchTerm('report');
+
+    expect(term.isGlob).toBe(false);
+    expect(term.matchesRelativePath('Docs/quarterly-report-final.pdf')).toBe(true);
+    expect(term.matchesName('Reports')).toBe(true);
+    expect(term.matchesName('invoices')).toBe(false);
+  });
+
+  it('matches an extension pattern against the whole name, not part of it', () => {
+    const term = parseSearchTerm('*.ps1');
+
+    expect(term.isGlob).toBe(true);
+    expect(term.matchesRelativePath('Scripts/deploy.ps1')).toBe(true);
+    // The defect this replaces: a substring test says yes to both of these.
+    expect(term.matchesRelativePath('Scripts/deploy.ps1.bak')).toBe(false);
+    expect(term.matchesRelativePath('Docs/how-to-write-a-ps1.md')).toBe(false);
+  });
+
+  it('ignores case, as every other part of the search does', () => {
+    expect(parseSearchTerm('*.PS1').matchesRelativePath('Scripts/deploy.ps1')).toBe(true);
+    expect(parseSearchTerm('*.ps1').matchesRelativePath('Scripts/DEPLOY.PS1')).toBe(true);
+  });
+
+  it('reads `?` as one character and `*` as any run of them', () => {
+    const term = parseSearchTerm('conf?g.json');
+
+    expect(term.matchesRelativePath('app/config.json')).toBe(true);
+    expect(term.matchesRelativePath('app/confg.json')).toBe(false);
+    expect(parseSearchTerm('*').matchesRelativePath('anything at all')).toBe(true);
+  });
+
+  /**
+   * A term is typed by a person. `a+b` is three characters they expect to find
+   * in a name; compiled as an expression it would mean one or more `a`s, and
+   * `readme.md` would match `readme?md` for the wrong reason.
+   */
+  it('does not let a term become a regular expression', () => {
+    expect(parseSearchTerm('a+b').matchesName('a+b-notes.txt')).toBe(true);
+    expect(parseSearchTerm('a+b').matchesName('aaab.txt')).toBe(false);
+    expect(parseSearchTerm('report.?').matchesName('reportxx')).toBe(false);
+    expect(parseSearchTerm('report.?').matchesName('report.1')).toBe(true);
+  });
+
+  it('matches a pattern that spans folders against the path, and no single name', () => {
+    const term = parseSearchTerm('Stacks/*/logs/*.log');
+
+    expect(term.matchesRelativePath('Stacks/ytzero/logs/ytzero.log')).toBe(true);
+    expect(term.matchesRelativePath('Other/ytzero/logs/ytzero.log')).toBe(false);
+    // A folder is never the answer to a pattern describing files under it.
+    expect(term.matchesName('logs')).toBe(false);
+  });
+
+  it('keeps a pattern without a separator away from the rest of the path', () => {
+    // `*.log` must not match a file because a folder above it ends in .log.
+    expect(parseSearchTerm('*.log').matchesRelativePath('archive.log/readme.txt')).toBe(false);
+  });
+});
+
+describe('deciding whether to read inside files at all', () => {
+  it('reads contents for text, and not for a pattern', () => {
+    expect(parseSearchTerm('report').readsFileContents).toBe(true);
+    expect(parseSearchTerm('*.ps1').readsFileContents).toBe(false);
+  });
+});


### PR DESCRIPTION
Batch 3 of #373. Cut from `main` at `edf428c`.

**~1 400 lines of code, ~1 100 of tests, six new services.**

> ⚠️ **Merge [2/14] (#375) first.** This branch carries the same test-harness change; merging them in order avoids a conflict in `env-test-utils.js`.

## What it adds

**Searching inside documents.** ripgrep reads a `.docx` as binary — it is a zip — and a PDF as binary too, because its words live in compressed streams. Both are now searched by a pass that extracts the text first: Office XML in-process, PDFs through `pdftotext`. A word an author emphasised halfway through a sentence is found, which matters because Word stores that in pieces.

**Filename patterns.** `*` and `?` in a term describe filenames rather than text. `*.ps1` finds the scripts, `conf?g.json` finds either spelling, `Stacks/*/logs/*.log` reaches across folders. Nothing is read inside files for a pattern, which is what makes it immediate.

**Bounds**, because each document costs an unzip or a subprocess: only these extensions, only files under the configured size, only so many documents per search, and a time budget (`SEARCH_TIMEOUT_MS`, default 5 s) after which the search answers with what it has. Reading a large tree to be certain there is nothing more is worse than an answer that arrives.

**Merged and deduplicated** where the passes converge, so a document found by name *and* by content is listed once.

## What was deliberately left out

The full-text index and the folder exclusions that go with it are batch 6. Rather than rewrite the route around them, I removed them: the index generator and its call sites are deleted, and the tests covering them travel with that batch. Every remaining test passes without them, so the route works on its own — it simply reads the tree instead of an index.

Two small additions to `config`: `search.timeoutMs` and the `SEARCH_TIMEOUT_MS` variable behind it.

## Tests

91 pass.

**Of the 16 failures already on `main` at `edf428c`, 15 remain, none is new — and the sixteenth is fixed here**, by the harness change that came with #375:

```
tests/routes/search-hidden-files.test.js > returns hidden pattern matches
when the user preference is enabled
```

That is the failure mode described in #375: the test ran against a previous test's temporary volume. There are likely more of the fifteen with the same cause — happy to look at them as their own batch if you would like.

## Next

Batch 4 whenever you have dealt with these two.