### PR TITLE
[4/14] Media: say why a video is silent, and offer the subtitles it carries

### DIFF
--- a/backend/src/middleware/heldRequests.js
+++ b/backend/src/middleware/heldRequests.js
@@ -1,0 +1,112 @@
+const logger = require('../utils/logger');
+
+/**
+ * Requests that were accepted and never answered.
+ *
+ * A container was reported unhealthy while the application served pages
+ * perfectly: `/healthz` connected and nothing came back, with an event loop
+ * whose worst delay over the same minutes was twenty-two milliseconds. Nothing
+ * was blocked — a request was being held, and there was no way to find out
+ * where, so the cause was argued about instead of read.
+ *
+ * This says which path, for how long, and — when it finally answers — with
+ * what. That is the difference between "something in the middleware chain is
+ * holding requests" and "requests to /healthz are held eleven seconds and then
+ * answered 302".
+ *
+ * One timer per request, cleared when the response ends, and a ceiling on how
+ * many are reported: a diagnostic for a stuck server must not become the
+ * loudest thing in its log.
+ *
+ * A request a route means to hold is not a symptom of anything, and reporting
+ * it is worse than useless here: an open editor long-polls every thirty
+ * seconds, which is enough to spend the whole ceiling in five minutes and
+ * leave the instrument silent for the rest of the process's life — the noise
+ * would not merely clutter, it would switch the thing off. A route that holds
+ * a request on purpose says so with `markLongPoll`.
+ */
+
+const LONG_POLL = Symbol('longPollingRequest');
+
+/** Called by a route that means to hold the request open. */
+const markLongPoll = (req) => {
+  if (req) req[LONG_POLL] = true;
+};
+
+const HELD_AFTER_MS = 5000;
+const MAX_REPORTED = 10;
+
+/**
+ * The threshold is a parameter rather than a constant so that a test can hold
+ * a request for twenty milliseconds instead of five seconds. Faking the clock
+ * instead would stop supertest's own sockets from progressing, and the test
+ * would then be measuring the fake.
+ */
+const createHeldRequestLogger = ({
+  heldAfterMs = HELD_AFTER_MS,
+  maxReported = MAX_REPORTED,
+} = {}) => {
+  let reported = 0;
+
+  return (req, res, next) => {
+    const startedAt = Date.now();
+    let warned = false;
+
+    const timer = setTimeout(() => {
+      if (req[LONG_POLL]) return;
+      if (reported >= maxReported) return;
+      reported += 1;
+      warned = true;
+      logger.warn(
+        {
+          method: req.method,
+          path: req.originalUrl || req.url,
+          heldMs: Date.now() - startedAt,
+          // Whether anything downstream has begun answering. Headers already
+          // sent is a slow body; none sent means the route was never reached.
+          headersSent: res.headersSent,
+          authenticated: Boolean(req.user || req.oidc?.isAuthenticated?.()),
+        },
+        'Request accepted and not yet answered'
+      );
+    }, heldAfterMs);
+    timer.unref?.();
+
+    res.on('finish', () => {
+      clearTimeout(timer);
+      if (!warned) return;
+      logger.warn(
+        {
+          method: req.method,
+          path: req.originalUrl || req.url,
+          heldMs: Date.now() - startedAt,
+          statusCode: res.statusCode,
+        },
+        'A held request finally answered'
+      );
+    });
+
+    // A request already reported as held, whose connection then goes away, has
+    // an outcome too: the person stopped waiting. Left unsaid it reads as a
+    // hang that never ended, which is the one thing this instrument exists to
+    // tell apart.
+    res.on('close', () => {
+      clearTimeout(timer);
+      if (!warned || res.writableEnded) return;
+      logger.warn(
+        {
+          method: req.method,
+          path: req.originalUrl || req.url,
+          heldMs: Date.now() - startedAt,
+        },
+        'A held request was abandoned by its client'
+      );
+    });
+
+    next();
+  };
+};
+
+const heldRequestLogger = createHeldRequestLogger();
+
+module.exports = { heldRequestLogger, createHeldRequestLogger, markLongPoll, HELD_AFTER_MS };

--- a/backend/src/routes/files/index.js
+++ b/backend/src/routes/files/index.js
@@ -5,6 +5,7 @@ const transferRoutes = require('./transfer');
 const deleteRoutes = require('./delete');
 const downloadRoutes = require('./download');
 const previewRoutes = require('./preview');
+const mediaRoutes = require('./media');
 
 const router = express.Router();
 
@@ -14,5 +15,6 @@ router.use(transferRoutes);
 router.use(deleteRoutes);
 router.use(downloadRoutes);
 router.use(previewRoutes);
+router.use(mediaRoutes);
 
 module.exports = router;

--- a/backend/src/routes/files/media.js
+++ b/backend/src/routes/files/media.js
@@ -1,0 +1,170 @@
+const path = require('path');
+const fs = require('fs/promises');
+const { normalizeRelativePath } = require('../../utils/pathUtils');
+const { resolvePathWithAccess } = require('../../services/accessManager');
+const { extensions } = require('../../config/index');
+const ffmpegRunner = require('../../services/ffmpegRunner');
+const mediaTracks = require('../../services/mediaTracks');
+const asyncHandler = require('../../utils/asyncHandler');
+const {
+  ValidationError,
+  ForbiddenError,
+  NotFoundError,
+  UnsupportedMediaTypeError,
+} = require('../../errors/AppError');
+const logger = require('../../utils/logger');
+const { markLongPoll } = require('../../middleware/heldRequests');
+
+const router = require('express').Router();
+
+/**
+ * What a video actually contains, and one subtitle track at a time.
+ *
+ * The player hands files straight to a `<video>` element and does not
+ * transcode — that is a media server's job, not a file explorer's. These two
+ * endpoints exist so that limit is stated rather than merely suffered: the
+ * first says which tracks the browser will refuse and why, the second converts
+ * a subtitle track into the one format a browser will display.
+ */
+
+/** Resolve a request's `path` to a readable media file the caller may see. */
+const resolveMediaFile = async (req) => {
+  const { path: relative = '' } = req.query || {};
+  if (typeof relative !== 'string' || !relative) {
+    throw new ValidationError('A file path is required.');
+  }
+
+  const relativePath = normalizeRelativePath(relative);
+  const context = { user: req.user, guestSession: req.guestSession };
+  const { accessInfo, resolved } = await resolvePathWithAccess(context, relativePath);
+
+  if (!accessInfo || !accessInfo.canAccess || !accessInfo.canRead) {
+    throw new ForbiddenError(accessInfo?.denialReason || 'Access not allowed.');
+  }
+
+  const { absolutePath } = resolved;
+  const stats = await fs.stat(absolutePath);
+  if (stats.isDirectory()) {
+    throw new ValidationError('Not a media file.');
+  }
+
+  const extension = path.extname(absolutePath).slice(1).toLowerCase();
+  const isMedia =
+    extensions.videos.includes(extension) || (extensions.audios || []).includes(extension);
+  if (!isMedia) {
+    throw new UnsupportedMediaTypeError('Not a media file.');
+  }
+
+  return absolutePath;
+};
+
+/**
+ * The tracks inside a media file.
+ *
+ * Answers the question a silent video raises. A file whose only soundtrack is
+ * AC-3 plays perfectly with no sound in Chrome and Firefox, and nothing on
+ * screen explains it; with this, the player can say which track it is and that
+ * the browser cannot decode it, instead of leaving a person to conclude the
+ * file is broken.
+ */
+router.get(
+  '/media/tracks',
+  asyncHandler(async (req, res) => {
+    const absolutePath = await resolveMediaFile(req);
+
+    if (!ffmpegRunner.hasFfprobe()) {
+      // Without ffprobe there is nothing to report — say so plainly rather than
+      // returning an empty inventory the player would read as "no subtitles".
+      res.json({ available: false, video: [], audio: [], subtitles: [] });
+      return;
+    }
+
+    const tracks = await mediaTracks.readMediaTracks(absolutePath);
+    if (!tracks) {
+      throw new UnsupportedMediaTypeError('Media could not be read.');
+    }
+
+    res.json({ available: true, ...tracks });
+  })
+);
+
+/**
+ * One subtitle track as WebVTT.
+ *
+ * Which track is named the way the inventory named it: `stream` for an index
+ * ffprobe reported, `file` for a sidecar. A sidecar name is checked against the
+ * enumeration rather than joined onto a path, so the only files reachable here
+ * are the ones this endpoint itself would have offered.
+ */
+router.get(
+  '/media/subtitle',
+  asyncHandler(async (req, res) => {
+    const absolutePath = await resolveMediaFile(req);
+    const { stream, file } = req.query || {};
+
+    // Pulling one subtitle track means demuxing the whole container, because
+    // subtitle packets are interleaved from beginning to end. Measured at
+    // seven to eighteen seconds for a 1080p episode on external storage —
+    // slow, but the request is working, not stuck. Saying so keeps it out of
+    // the held-request instrument, whose ten reports are spent for the life of
+    // the process and are there for finding a server that really is wedged.
+    markLongPoll(req);
+
+    if (!ffmpegRunner.hasFfmpeg()) {
+      throw new UnsupportedMediaTypeError('Subtitle conversion is not available.');
+    }
+
+    let source = absolutePath;
+    let streamIndex = null;
+
+    if (typeof file === 'string' && file) {
+      const sidecars = await mediaTracks.findSidecarSubtitles(absolutePath);
+      const match = sidecars.find((candidate) => candidate.fileName === file);
+      if (!match) {
+        throw new NotFoundError('No such subtitle file.');
+      }
+      source = path.join(path.dirname(absolutePath), match.fileName);
+    } else if (stream !== undefined) {
+      const index = Number(stream);
+      if (!Number.isInteger(index) || index < 0) {
+        throw new ValidationError('A subtitle stream index is required.');
+      }
+
+      const tracks = await mediaTracks.readMediaTracks(absolutePath);
+      const match = (tracks?.subtitles || []).find(
+        (candidate) => candidate.source === 'embedded' && candidate.index === index
+      );
+      if (!match) {
+        throw new NotFoundError('No such subtitle track.');
+      }
+      if (!match.convertible) {
+        // A Blu-ray or DVD subtitle is a picture of words. Turning it into text
+        // needs OCR, which is a different piece of software entirely.
+        throw new UnsupportedMediaTypeError(
+          `Subtitles in ${match.codec} are images and cannot be converted to text.`
+        );
+      }
+      streamIndex = index;
+    } else {
+      throw new ValidationError('A subtitle track must be named.');
+    }
+
+    let vtt;
+    try {
+      vtt = await mediaTracks.extractWebVtt(source, { streamIndex });
+    } catch (error) {
+      logger.warn({ absolutePath, source, streamIndex, err: error }, 'Subtitle conversion failed');
+      throw new UnsupportedMediaTypeError('This subtitle track could not be converted.');
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'text/vtt; charset=utf-8',
+      'Content-Length': Buffer.byteLength(vtt),
+      'X-Content-Type-Options': 'nosniff',
+      'X-Robots-Tag': 'noindex',
+    });
+    res.end(vtt);
+  })
+);
+
+module.exports = router;

--- a/backend/src/services/ffmpegRunner.js
+++ b/backend/src/services/ffmpegRunner.js
@@ -1,0 +1,137 @@
+const fs = require('fs');
+const { spawn, execFile } = require('child_process');
+
+const env = require('../config/env');
+const logger = require('../utils/logger');
+
+/**
+ * Running ffmpeg and ffprobe, directly.
+ *
+ * This replaces `fluent-ffmpeg`, which is deprecated on npm with no successor
+ * and was used for seven calls, every one of them "start a process and read its
+ * output" — something four other places in this codebase already do plainly
+ * (`pdftotext`, `rg`, `7z`, `rsync`). A builder API is a poor trade for a
+ * dependency nobody maintains sitting on the path that produces every
+ * thumbnail.
+ *
+ * Two things it does that the library did and are easy to lose: it resolves the
+ * binaries once at startup rather than trusting `PATH`, and it hands back the
+ * child process so a caller can register it, lower its priority and kill it.
+ */
+
+const CANDIDATES = {
+  ffmpeg: [env.FFMPEG_PATH, '/usr/local/bin/ffmpeg', '/usr/bin/ffmpeg', '/opt/homebrew/bin/ffmpeg'],
+  ffprobe: [
+    env.FFPROBE_PATH,
+    '/usr/local/bin/ffprobe',
+    '/usr/bin/ffprobe',
+    '/opt/homebrew/bin/ffprobe',
+  ],
+};
+
+/**
+ * The first candidate that exists and can be run.
+ *
+ * An absolute path rather than a bare name on purpose: `PATH` is inherited from
+ * whatever started the process, and a file manager running as root should not
+ * be resolving its tools through it.
+ */
+const resolveExecutable = (candidates) => {
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch (_) {
+      // Try the next one.
+    }
+  }
+  return null;
+};
+
+const ffmpegPath = resolveExecutable(CANDIDATES.ffmpeg);
+const ffprobePath = resolveExecutable(CANDIDATES.ffprobe);
+
+if (!ffmpegPath) {
+  logger.warn('FFmpeg binary not found. Video thumbnails will be skipped.');
+}
+
+/** Whether ffmpeg is available at all. */
+const hasFfmpeg = () => Boolean(ffmpegPath);
+
+/** Whether ffprobe is available at all. */
+const hasFfprobe = () => Boolean(ffprobePath);
+
+const PROBE_TIMEOUT_MS = 30_000;
+const PROBE_MAX_BUFFER = 4 * 1024 * 1024;
+
+/**
+ * What ffprobe says about a file, as the object it prints.
+ *
+ * Answers null rather than throwing for every failure — a missing binary, an
+ * unreadable file, a container ffprobe does not know. Every caller here treats
+ * "no information" the same way, and turning that into an exception would only
+ * move the shrug somewhere less obvious.
+ *
+ * @returns {Promise<{format?: object, streams?: object[]}|null>}
+ */
+const probe = (filePath) =>
+  new Promise((resolve) => {
+    if (!ffprobePath) {
+      resolve(null);
+      return;
+    }
+
+    execFile(
+      ffprobePath,
+      [
+        '-hide_banner',
+        '-loglevel',
+        'error',
+        '-show_format',
+        '-show_streams',
+        '-print_format',
+        'json',
+        '--',
+        filePath,
+      ],
+      { timeout: PROBE_TIMEOUT_MS, maxBuffer: PROBE_MAX_BUFFER },
+      (error, stdout) => {
+        if (error) {
+          resolve(null);
+          return;
+        }
+        try {
+          const parsed = JSON.parse(stdout);
+          resolve(parsed && typeof parsed === 'object' ? parsed : null);
+        } catch (_) {
+          resolve(null);
+        }
+      }
+    );
+  });
+
+/**
+ * Start ffmpeg with the given arguments, writing to stdout.
+ *
+ * The child is handed back rather than hidden, because the caller registers it
+ * for cancellation and lowers its scheduling priority — a thumbnail must never
+ * be the reason a listing is slow.
+ *
+ * @returns {import('child_process').ChildProcess}
+ */
+const run = (args) => {
+  if (!ffmpegPath) {
+    throw new Error('FFmpeg binary not found.');
+  }
+  return spawn(ffmpegPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+};
+
+module.exports = {
+  hasFfmpeg,
+  hasFfprobe,
+  probe,
+  run,
+  ffmpegPath,
+  ffprobePath,
+};

--- a/backend/src/services/mediaTracks.js
+++ b/backend/src/services/mediaTracks.js
@@ -1,0 +1,323 @@
+const path = require('path');
+const fs = require('fs/promises');
+
+const ffmpegRunner = require('./ffmpegRunner');
+
+/**
+ * What is inside a video, and which of it a browser can actually use.
+ *
+ * NextExplorer plays media by handing the file to a `<video>` element, which is
+ * a deliberate limit: transcoding belongs to a media server, not to a file
+ * explorer. But that limit is invisible from the outside. A Matroska file with
+ * an AC-3 soundtrack plays perfectly with no sound at all, and nothing on
+ * screen says why — the person is left to conclude the file is broken, or that
+ * we are.
+ *
+ * So this reads what the container holds and says which parts a browser will
+ * refuse, which turns silence into a sentence.
+ */
+
+/**
+ * Audio codecs a browser will decode.
+ *
+ * The absentees are the point: AC-3, E-AC-3, DTS and TrueHD are what a film in
+ * a Matroska container almost always carries, and neither Chrome nor Firefox
+ * will decode any of them — a licensing decision, not a technical one. Safari
+ * on macOS does decode AC-3, which is why this is reported rather than asserted
+ * as a flat failure.
+ */
+const BROWSER_AUDIO_CODECS = new Set([
+  'aac',
+  'mp3',
+  'opus',
+  'vorbis',
+  'flac',
+  'pcm_s16le',
+  'pcm_s24le',
+  'pcm_u8',
+  'pcm_f32le',
+]);
+
+/** Video codecs a browser will decode, give or take the profile. */
+const BROWSER_VIDEO_CODECS = new Set(['h264', 'vp8', 'vp9', 'av1', 'theora']);
+
+/**
+ * Subtitle codecs that are text and can therefore become WebVTT.
+ *
+ * The others — `hdmv_pgs_subtitle` from a Blu-ray, `dvd_subtitle` from a DVD —
+ * are pictures of words. Converting them needs OCR, which is a different
+ * project, so they are listed and marked rather than silently dropped: a person
+ * looking for the subtitles they know are in the file deserves to be told why
+ * they are not on offer.
+ */
+const TEXT_SUBTITLE_CODECS = new Set(['subrip', 'srt', 'ass', 'ssa', 'webvtt', 'mov_text', 'text']);
+
+/** Sidecar subtitle files sitting next to the video. */
+const SIDECAR_EXTENSIONS = ['srt', 'vtt', 'ass', 'ssa'];
+
+const streamsOfType = (data, type) =>
+  (data?.streams || []).filter((stream) => stream?.codec_type === type);
+
+const cleanTag = (value) => {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text && text.toLowerCase() !== 'und' ? text : '';
+};
+
+/**
+ * A language tag a browser will accept.
+ *
+ * Media containers write ISO 639-2 — `fre`, `ger`, `dut` — while `<track
+ * srclang>` wants BCP 47, where those are `fr`, `de`, `nl`. Worse, 639-2 has
+ * two codes for several languages (`fre` and `fra` are both French) depending
+ * on whether the file was tagged from the bibliographic or the terminological
+ * list, so a caption menu would show the same language twice.
+ *
+ * `Intl.getCanonicalLocales` already knows all of this, from ICU's own tables —
+ * a hand-written map would be a worse copy of it. Anything it refuses is
+ * returned as-is, since an unrecognised tag is still better than none.
+ */
+const normaliseLanguage = (value) => {
+  const text = cleanTag(value);
+  if (!text) return null;
+  try {
+    const [canonical] = Intl.getCanonicalLocales(text.replace(/_/g, '-'));
+    return canonical && canonical !== 'und' ? canonical : null;
+  } catch (_) {
+    return text;
+  }
+};
+
+/**
+ * A label for a track, from whatever the file was willing to say.
+ *
+ * Files are inconsistent about this: some name the track, some only tag a
+ * language, plenty do neither. Falling back to the position at least tells two
+ * tracks apart.
+ */
+const describeTrack = (stream, position) => {
+  const title = cleanTag(stream?.tags?.title);
+  const language = normaliseLanguage(stream?.tags?.language);
+  if (title && language) return `${title} (${language})`;
+  return title || language || `Track ${position + 1}`;
+};
+
+const describeAudio = (stream, position) => ({
+  index: stream.index,
+  codec: stream.codec_name || 'unknown',
+  language: normaliseLanguage(stream?.tags?.language),
+  title: cleanTag(stream?.tags?.title) || null,
+  channels: Number(stream.channels) || null,
+  label: describeTrack(stream, position),
+  isDefault: stream?.disposition?.default === 1,
+  // Whether a browser will make a sound out of it.
+  playable: BROWSER_AUDIO_CODECS.has(String(stream.codec_name || '').toLowerCase()),
+});
+
+const describeSubtitle = (stream, position) => {
+  const codec = String(stream.codec_name || '').toLowerCase();
+  return {
+    index: stream.index,
+    codec: codec || 'unknown',
+    language: normaliseLanguage(stream?.tags?.language),
+    title: cleanTag(stream?.tags?.title) || null,
+    label: describeTrack(stream, position),
+    isDefault: stream?.disposition?.default === 1,
+    forced: stream?.disposition?.forced === 1,
+    source: 'embedded',
+    // Image-based subtitles cannot be turned into text without OCR.
+    convertible: TEXT_SUBTITLE_CODECS.has(codec),
+  };
+};
+
+/**
+ * Subtitle files sitting beside the video, as people actually name them:
+ * `film.srt`, `film.fr.srt`, `film.en.forced.srt`.
+ *
+ * Read from the directory listing rather than by guessing filenames, so a
+ * language tag nobody anticipated still shows up.
+ */
+const findSidecarSubtitles = async (absolutePath) => {
+  const directory = path.dirname(absolutePath);
+  const base = path.basename(absolutePath, path.extname(absolutePath)).toLowerCase();
+
+  let entries;
+  try {
+    entries = await fs.readdir(directory, { withFileTypes: true });
+  } catch (_) {
+    return [];
+  }
+
+  const ownName = path.basename(absolutePath);
+  const found = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    // Never offer the file as a subtitle for itself.
+    if (entry.name === ownName) continue;
+    const extension = path.extname(entry.name).slice(1).toLowerCase();
+    if (!SIDECAR_EXTENSIONS.includes(extension)) continue;
+
+    const stem = path.basename(entry.name, path.extname(entry.name)).toLowerCase();
+    if (stem !== base && !stem.startsWith(`${base}.`)) continue;
+
+    // Whatever sits between the video's name and the extension is how people
+    // write the language: `film.fr.srt`, `film.en.forced.srt`.
+    const suffix = stem.slice(base.length).replace(/^\./, '');
+    const parts = suffix.split('.').filter(Boolean);
+    const forced = parts.some((part) => part === 'forced');
+    const language = normaliseLanguage(parts.find((part) => part !== 'forced'));
+
+    found.push({
+      index: null,
+      codec: extension,
+      language,
+      title: null,
+      label: language ? `${language}${forced ? ' (forced)' : ''}` : entry.name,
+      isDefault: false,
+      forced,
+      source: 'sidecar',
+      fileName: entry.name,
+      convertible: true,
+    });
+  }
+
+  return found.sort((a, b) => a.label.localeCompare(b.label));
+};
+
+/**
+ * Everything worth saying about a media file, or null if ffprobe cannot read it.
+ *
+ * @returns {Promise<{video: object[], audio: object[], subtitles: object[],
+ *   hasPlayableAudio: boolean, hasAudio: boolean}|null>}
+ */
+const readMediaTracks = async (absolutePath) => {
+  const data = await ffmpegRunner.probe(absolutePath);
+  if (!data) return null;
+
+  const audio = streamsOfType(data, 'audio').map(describeAudio);
+  const video = streamsOfType(data, 'video').map((stream, position) => ({
+    index: stream.index,
+    codec: stream.codec_name || 'unknown',
+    label: describeTrack(stream, position),
+    playable: BROWSER_VIDEO_CODECS.has(String(stream.codec_name || '').toLowerCase()),
+  }));
+
+  const embedded = streamsOfType(data, 'subtitle').map(describeSubtitle);
+  const sidecar = await findSidecarSubtitles(absolutePath);
+
+  return {
+    video,
+    audio,
+    subtitles: [...sidecar, ...embedded],
+    hasAudio: audio.length > 0,
+    // The distinction the player needs: no soundtrack at all is a silent film,
+    // a soundtrack no browser can decode is a different sentence entirely.
+    hasPlayableAudio: audio.some((track) => track.playable),
+  };
+};
+
+/**
+ * How long a subtitle extraction may take, and how much it may produce.
+ *
+ * A subtitle track is a few hundred kilobytes of text at most; anything past
+ * this is a malformed file or a stream that is not really subtitles, and either
+ * way it should not be allowed to hold a connection open or fill memory.
+ */
+const SUBTITLE_TIMEOUT_MS = 20000;
+const SUBTITLE_MAX_BYTES = 8 * 1024 * 1024;
+
+/**
+ * One subtitle track, rewritten as WebVTT.
+ *
+ * WebVTT is the only subtitle format a `<video>` element accepts, so everything
+ * — SubRip, SubStation Alpha, the MP4 text track — has to become it. ffmpeg
+ * does the conversion in a single pass with no re-encoding of anything else:
+ * `-map` picks the one stream, and the rest of the file is never decoded.
+ *
+ * The result is buffered rather than piped, because it is small and because a
+ * conversion that fails halfway is better reported as an error than as a
+ * truncated subtitle file the player silently accepts.
+ *
+ * @param {string} absolutePath file to read the track from — the video for an
+ *   embedded track, the sidecar itself for a sidecar
+ * @param {{streamIndex?: number|null}} [options] ffprobe stream index to map,
+ *   or nothing at all when the whole input is the subtitle
+ * @returns {Promise<string>} the WebVTT document
+ */
+const extractWebVtt = (absolutePath, { streamIndex = null } = {}) =>
+  new Promise((resolve, reject) => {
+    const args = ['-loglevel', 'error', '-i', absolutePath];
+    if (streamIndex !== null && streamIndex !== undefined) {
+      args.push('-map', `0:${streamIndex}`);
+    }
+    args.push('-f', 'webvtt', 'pipe:1');
+
+    let command;
+    try {
+      command = ffmpegRunner.run(args);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const chunks = [];
+    let size = 0;
+    let settled = false;
+    let timer = null;
+
+    const finish = (error, value) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      if (error) {
+        try {
+          command.kill('SIGKILL');
+        } catch (_) {
+          // Already gone.
+        }
+        reject(error);
+        return;
+      }
+      resolve(value);
+    };
+
+    timer = setTimeout(
+      () => finish(new Error('Subtitle extraction timed out.')),
+      SUBTITLE_TIMEOUT_MS
+    );
+
+    let stderr = '';
+    command.stderr.on('data', (chunk) => {
+      // Kept only to explain a failure; a success says nothing here.
+      if (stderr.length < 4096) stderr += String(chunk);
+    });
+
+    command.stdout.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > SUBTITLE_MAX_BYTES) {
+        finish(new Error('Subtitle track is implausibly large.'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    command.on('error', (error) => finish(error));
+    command.on('close', (code) => {
+      if (code !== 0) {
+        finish(new Error(`FFmpeg exited with ${code}: ${stderr.trim()}`));
+        return;
+      }
+      finish(null, Buffer.concat(chunks).toString('utf8'));
+    });
+  });
+
+module.exports = {
+  readMediaTracks,
+  normaliseLanguage,
+  findSidecarSubtitles,
+  extractWebVtt,
+  SUBTITLE_MAX_BYTES,
+  BROWSER_AUDIO_CODECS,
+  BROWSER_VIDEO_CODECS,
+  TEXT_SUBTITLE_CODECS,
+  SIDECAR_EXTENSIONS,
+};

--- a/backend/tests/routes/media-tracks-route.test.js
+++ b/backend/tests/routes/media-tracks-route.test.js
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import express from 'express';
+import request from 'supertest';
+
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Telling the player what is in a video, and handing it a subtitle.
+ *
+ * Both endpoints read a file the caller named, so the first thing worth
+ * proving is that they read only files the caller is allowed to read, and only
+ * subtitles this endpoint itself would have offered. A filename joined onto a
+ * directory is how a subtitle parameter becomes a way to read anything on the
+ * disk; it is checked against the enumeration instead.
+ */
+
+let ctx;
+
+const hasFfmpeg = async () => {
+  try {
+    await execFileAsync('ffmpeg', ['-version']);
+    return true;
+  } catch (_) {
+    return false;
+  }
+};
+
+const buildFilm = async (dir) => {
+  const srt = path.join(dir, 'subs.srt');
+  await fs.writeFile(srt, '1\n00:00:00,500 --> 00:00:02,000\nBonjour le monde\n');
+  await execFileAsync('ffmpeg', [
+    '-v', 'error', '-y',
+    '-f', 'lavfi', '-i', 'testsrc=size=160x120:rate=25:duration=2',
+    '-f', 'lavfi', '-i', 'sine=frequency=440:duration=2',
+    '-i', srt,
+    '-map', '0:v', '-map', '1:a', '-map', '2:s',
+    '-c:v', 'libx264', '-preset', 'ultrafast', '-c:a', 'ac3', '-c:s', 'srt',
+    '-metadata:s:a:0', 'language=fre',
+    path.join(dir, 'film.mkv'),
+  ]);
+  await fs.rm(srt);
+};
+
+const setup = async () => {
+  ctx = await setupTestEnv({
+    tag: 'media-route-',
+    modules: [
+      'src/config/env',
+      'src/config/index',
+      'src/services/ffmpegRunner',
+      'src/services/mediaTracks',
+      'src/routes/files/media',
+      'src/middleware/errorHandler',
+    ],
+  });
+
+  await buildFilm(ctx.volumeDir);
+  await fs.writeFile(path.join(ctx.volumeDir, 'notes.txt'), 'not a film');
+
+  const routes = ctx.requireFresh('src/routes/files/media');
+  const { errorHandler } = ctx.requireFresh('src/middleware/errorHandler');
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.user = { id: 'owner', roles: ['admin'] };
+    next();
+  });
+  app.use('/api', routes);
+  app.use(errorHandler);
+  return app;
+};
+
+afterEach(async () => {
+  if (ctx) {
+    await ctx.cleanup();
+    ctx = null;
+  }
+});
+
+const tracksOf = (app, file = 'film.mkv') =>
+  request(app).get('/api/media/tracks').query({ path: file });
+
+describe.skipIf(!(await hasFfmpeg()))('asking what is in a video', () => {
+  it('answers', async () => {
+    const response = await tracksOf(await setup());
+
+    expect(response.status).toBe(200);
+  });
+
+  it('names the soundtrack it found', async () => {
+    const response = await tracksOf(await setup());
+
+    expect(response.body.audio).toEqual([expect.objectContaining({ codec: 'ac3', language: 'fr' })]);
+  });
+
+  /** The reported symptom: sound present, browser silent. */
+  it('says the browser will not be able to play it', async () => {
+    const response = await tracksOf(await setup());
+
+    expect(response.body).toMatchObject({ hasAudio: true, hasPlayableAudio: false });
+  });
+
+  it('lists the subtitle track inside the file', async () => {
+    const response = await tracksOf(await setup());
+
+    expect(response.body.subtitles).toHaveLength(1);
+  });
+
+  it('refuses a path that is not a media file', async () => {
+    const response = await tracksOf(await setup(), 'notes.txt');
+
+    expect(response.status).toBe(415);
+  });
+
+  it('refuses a request with no path at all', async () => {
+    const response = await request(await setup()).get('/api/media/tracks');
+
+    expect(response.status).toBe(400);
+  });
+
+  /** The volume root is a boundary, not a starting point. */
+  it('refuses a path that climbs out of the volume', async () => {
+    const response = await tracksOf(await setup(), '../../../etc/passwd');
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+});
+
+describe.skipIf(!(await hasFfmpeg()))('asking for a subtitle', () => {
+  const subtitle = (app, query) => request(app).get('/api/media/subtitle').query(query);
+
+  it('serves the embedded track as WebVTT', async () => {
+    const app = await setup();
+    const { body } = await tracksOf(app);
+    const embedded = body.subtitles.find((track) => track.source === 'embedded');
+
+    const response = await subtitle(app, { path: 'film.mkv', stream: embedded.index });
+
+    expect(response.status).toBe(200);
+    expect(response.text).toContain('WEBVTT');
+  });
+
+  it('carries the subtitle text', async () => {
+    const app = await setup();
+    const { body } = await tracksOf(app);
+    const embedded = body.subtitles.find((track) => track.source === 'embedded');
+
+    const response = await subtitle(app, { path: 'film.mkv', stream: embedded.index });
+
+    expect(response.text).toContain('Bonjour le monde');
+  });
+
+  /** A video element ignores anything not declared as text/vtt. */
+  it('declares itself as WebVTT', async () => {
+    const app = await setup();
+    const { body } = await tracksOf(app);
+    const embedded = body.subtitles.find((track) => track.source === 'embedded');
+
+    const response = await subtitle(app, { path: 'film.mkv', stream: embedded.index });
+
+    expect(response.headers['content-type']).toContain('text/vtt');
+  });
+
+  it('serves a sidecar file beside the video', async () => {
+    const app = await setup();
+    await fs.writeFile(
+      path.join(ctx.volumeDir, 'film.fr.srt'),
+      '1\n00:00:01,000 --> 00:00:02,000\nDepuis un fichier\n'
+    );
+
+    const response = await subtitle(app, { path: 'film.mkv', file: 'film.fr.srt' });
+
+    expect(response.text).toContain('Depuis un fichier');
+  });
+
+  it('refuses a stream that is not a subtitle track', async () => {
+    const app = await setup();
+
+    const response = await subtitle(app, { path: 'film.mkv', stream: 0 });
+
+    expect(response.status).toBe(404);
+  });
+
+  it('refuses a request that names no track', async () => {
+    const response = await subtitle(await setup(), { path: 'film.mkv' });
+
+    expect(response.status).toBe(400);
+  });
+
+  /**
+   * The parameter is a name from our own enumeration, not a path. A file that
+   * exists, is readable, and is a real subtitle is still refused when it is not
+   * this film's — otherwise the parameter is a way to read any file whose name
+   * ends in `.srt`.
+   */
+  it('refuses a subtitle file belonging to another video', async () => {
+    const app = await setup();
+    await fs.writeFile(path.join(ctx.volumeDir, 'other.fr.srt'), '1\n00:00:01,000 --> 00:00:02,000\nx\n');
+
+    const response = await subtitle(app, { path: 'film.mkv', file: 'other.fr.srt' });
+
+    expect(response.status).toBe(404);
+  });
+
+  it('refuses a filename that tries to climb out of the folder', async () => {
+    const app = await setup();
+
+    const response = await subtitle(app, { path: 'film.mkv', file: '../../../etc/passwd' });
+
+    expect(response.status).toBe(404);
+  });
+
+  it('refuses a stream index that is not a number', async () => {
+    const response = await subtitle(await setup(), { path: 'film.mkv', stream: 'first' });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/backend/tests/services/media-tracks.test.js
+++ b/backend/tests/services/media-tracks.test.js
@@ -1,0 +1,325 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Reading what is inside a video, against a real one.
+ *
+ * The complaint this answers was reported from production: several MKVs play
+ * with no sound, and the interface says nothing. The server logs named the
+ * files, and the filenames named the cause — `DDP5.1`, `AC3.2.0` — soundtracks
+ * no browser will decode. Nothing was broken; nothing said so either.
+ *
+ * A fixture is built here rather than mocked because the whole value of this
+ * service is what a container actually reports: ffprobe's field names, the
+ * two rival ISO codes for the same language, a disposition flag. A fake would
+ * agree with whatever the code expected and prove none of it.
+ */
+
+let tracksService;
+let fixtureDir;
+let hasFfmpeg = false;
+
+const ffmpegAvailable = async () => {
+  try {
+    await execFileAsync('ffmpeg', ['-version']);
+    return true;
+  } catch (_) {
+    return false;
+  }
+};
+
+/**
+ * A clip with a French AAC track, an English AC-3 track, and two subtitle
+ * streams — the shape of a film downloaded with more than one language.
+ *
+ * The audio codecs are the point: AAC is decodable everywhere and AC-3 is
+ * decodable nowhere but Safari, so one file exercises both answers.
+ */
+const buildFixture = async (dir) => {
+  const frSrt = path.join(dir, 'source-fr.srt');
+  const enSrt = path.join(dir, 'source-en.srt');
+  await fs.writeFile(frSrt, '1\n00:00:00,500 --> 00:00:02,000\nBonjour le monde\n');
+  await fs.writeFile(enSrt, '1\n00:00:00,500 --> 00:00:02,000\nHello world\n');
+
+  const output = path.join(dir, 'film.mkv');
+  await execFileAsync('ffmpeg', [
+    '-v', 'error', '-y',
+    '-f', 'lavfi', '-i', 'testsrc=size=160x120:rate=25:duration=3',
+    '-f', 'lavfi', '-i', 'sine=frequency=440:duration=3',
+    '-f', 'lavfi', '-i', 'sine=frequency=880:duration=3',
+    '-i', frSrt,
+    '-i', enSrt,
+    '-map', '0:v', '-map', '1:a', '-map', '2:a', '-map', '3:s', '-map', '4:s',
+    '-c:v', 'libx264', '-preset', 'ultrafast',
+    '-c:a:0', 'aac', '-c:a:1', 'ac3', '-c:s', 'srt',
+    // `fre` rather than `fra`: both are ISO 639-2 for French, and a container
+    // may carry either. A caption menu that shows them as two languages is the
+    // bug this tag exists to catch.
+    '-metadata:s:a:0', 'language=fre', '-metadata:s:a:0', 'title=VF',
+    '-metadata:s:a:1', 'language=eng',
+    '-metadata:s:s:0', 'language=fre',
+    '-metadata:s:s:1', 'language=eng',
+    output,
+  ]);
+  return output;
+};
+
+beforeAll(async () => {
+  hasFfmpeg = await ffmpegAvailable();
+  if (!hasFfmpeg) return;
+  fixtureDir = await fs.mkdtemp(path.join(os.tmpdir(), 'media-tracks-'));
+  await buildFixture(fixtureDir);
+  tracksService = require('../../src/services/mediaTracks');
+}, 60000);
+
+afterEach(async () => {
+  if (!fixtureDir) return;
+  // Sidecars are created per test; the film stays.
+  const entries = await fs.readdir(fixtureDir);
+  await Promise.all(
+    entries
+      .filter((name) => name.startsWith('film.') && name !== 'film.mkv')
+      .map((name) => fs.rm(path.join(fixtureDir, name), { force: true }))
+  );
+});
+
+const filmPath = () => path.join(fixtureDir, 'film.mkv');
+const read = () => tracksService.readMediaTracks(filmPath());
+
+describe.skipIf(!(await ffmpegAvailable()))('the tracks inside a video', () => {
+  it('finds both soundtracks', async () => {
+    const tracks = await read();
+
+    expect(tracks.audio).toHaveLength(2);
+  });
+
+  it('says the AAC one can be played', async () => {
+    const tracks = await read();
+
+    expect(tracks.audio.find((track) => track.codec === 'aac').playable).toBe(true);
+  });
+
+  /** The reported defect, in one assertion. */
+  it('says the AC-3 one cannot', async () => {
+    const tracks = await read();
+
+    expect(tracks.audio.find((track) => track.codec === 'ac3').playable).toBe(false);
+  });
+
+  it('carries the title the file gave the track', async () => {
+    const tracks = await read();
+
+    expect(tracks.audio[0].title).toBe('VF');
+  });
+
+  it('reports the channel count', async () => {
+    const tracks = await read();
+
+    expect(tracks.audio[0].channels).toBe(1);
+  });
+
+  it('finds the video stream and calls H.264 playable', async () => {
+    const tracks = await read();
+
+    expect(tracks.video).toEqual([expect.objectContaining({ codec: 'h264', playable: true })]);
+  });
+
+  it('finds both embedded subtitle streams', async () => {
+    const tracks = await read();
+
+    expect(tracks.subtitles.filter((track) => track.source === 'embedded')).toHaveLength(2);
+  });
+
+  it('marks a text subtitle as convertible', async () => {
+    const tracks = await read();
+
+    expect(tracks.subtitles.every((track) => track.convertible)).toBe(true);
+  });
+});
+
+describe.skipIf(!(await ffmpegAvailable()))('what the player is told about sound', () => {
+  it('reports a playable soundtrack when one exists', async () => {
+    const tracks = await read();
+
+    expect(tracks.hasPlayableAudio).toBe(true);
+  });
+
+  /**
+   * The whole reason this service exists: audio present, none of it decodable.
+   * Without the distinction the interface cannot tell a silent film from one
+   * the browser is refusing to play.
+   */
+  it('separates having audio from being able to play it', async () => {
+    const acThree = path.join(fixtureDir, 'ac3-only.mkv');
+    await execFileAsync('ffmpeg', [
+      '-v', 'error', '-y',
+      '-f', 'lavfi', '-i', 'testsrc=size=160x120:rate=25:duration=2',
+      '-f', 'lavfi', '-i', 'sine=frequency=440:duration=2',
+      '-map', '0:v', '-map', '1:a', '-c:v', 'libx264', '-preset', 'ultrafast', '-c:a', 'ac3',
+      acThree,
+    ]);
+
+    const tracks = await tracksService.readMediaTracks(acThree);
+
+    expect(tracks.hasAudio).toBe(true);
+    expect(tracks.hasPlayableAudio).toBe(false);
+  });
+
+  it('reports no audio at all for a video without any', async () => {
+    const silent = path.join(fixtureDir, 'silent.mkv');
+    await execFileAsync('ffmpeg', [
+      '-v', 'error', '-y',
+      '-f', 'lavfi', '-i', 'testsrc=size=160x120:rate=25:duration=2',
+      '-an', '-c:v', 'libx264', '-preset', 'ultrafast',
+      silent,
+    ]);
+
+    const tracks = await tracksService.readMediaTracks(silent);
+
+    expect(tracks.hasAudio).toBe(false);
+  });
+});
+
+describe.skipIf(!(await ffmpegAvailable()))('language tags', () => {
+  /**
+   * A container writes ISO 639-2 and a `<track srclang>` wants BCP 47. `fre`
+   * is not a tag a browser understands, and a caption menu built from it
+   * labels nothing.
+   */
+  it('turns the container ISO 639-2 code into the two-letter one', async () => {
+    const tracks = await read();
+
+    expect(tracks.audio.map((track) => track.language)).toEqual(['fr', 'en']);
+  });
+
+  it('gives a sidecar and an embedded track the same tag for the same language', async () => {
+    await fs.copyFile(path.join(fixtureDir, 'source-fr.srt'), path.join(fixtureDir, 'film.fr.srt'));
+
+    const tracks = await read();
+    const sidecar = tracks.subtitles.find((track) => track.source === 'sidecar');
+    const embedded = tracks.subtitles.find((track) => track.language === 'fr' && track.index !== null);
+
+    expect(sidecar.language).toBe(embedded.language);
+  });
+
+  it('leaves an untagged track without a language rather than inventing one', async () => {
+    const untagged = path.join(fixtureDir, 'untagged.mkv');
+    await execFileAsync('ffmpeg', [
+      '-v', 'error', '-y',
+      '-f', 'lavfi', '-i', 'testsrc=size=160x120:rate=25:duration=2',
+      '-f', 'lavfi', '-i', 'sine=frequency=440:duration=2',
+      '-map', '0:v', '-map', '1:a', '-c:v', 'libx264', '-preset', 'ultrafast', '-c:a', 'aac',
+      untagged,
+    ]);
+
+    const tracks = await tracksService.readMediaTracks(untagged);
+
+    expect(tracks.audio[0].language).toBeNull();
+  });
+});
+
+describe.skipIf(!(await ffmpegAvailable()))('subtitle files next to the video', () => {
+  it('finds one named after the film', async () => {
+    await fs.copyFile(path.join(fixtureDir, 'source-fr.srt'), path.join(fixtureDir, 'film.srt'));
+
+    const found = await tracksService.findSidecarSubtitles(filmPath());
+
+    expect(found.map((track) => track.fileName)).toEqual(['film.srt']);
+  });
+
+  it('reads the language out of the name', async () => {
+    await fs.copyFile(path.join(fixtureDir, 'source-fr.srt'), path.join(fixtureDir, 'film.fr.srt'));
+
+    const [found] = await tracksService.findSidecarSubtitles(filmPath());
+
+    expect(found.language).toBe('fr');
+  });
+
+  it('reads a forced marker out of the name too', async () => {
+    await fs.copyFile(
+      path.join(fixtureDir, 'source-en.srt'),
+      path.join(fixtureDir, 'film.en.forced.srt')
+    );
+
+    const [found] = await tracksService.findSidecarSubtitles(filmPath());
+
+    expect(found).toMatchObject({ language: 'en', forced: true });
+  });
+
+  it('ignores a subtitle belonging to a different film', async () => {
+    await fs.copyFile(
+      path.join(fixtureDir, 'source-fr.srt'),
+      path.join(fixtureDir, 'other-film.fr.srt')
+    );
+
+    const found = await tracksService.findSidecarSubtitles(filmPath());
+
+    expect(found).toEqual([]);
+  });
+
+  it('ignores a file that is not a subtitle', async () => {
+    await fs.writeFile(path.join(fixtureDir, 'film.nfo'), 'release notes');
+
+    const found = await tracksService.findSidecarSubtitles(filmPath());
+
+    expect(found).toEqual([]);
+  });
+
+  it('returns nothing rather than failing when the folder cannot be read', async () => {
+    const found = await tracksService.findSidecarSubtitles('/nonexistent/place/film.mkv');
+
+    expect(found).toEqual([]);
+  });
+});
+
+describe.skipIf(!(await ffmpegAvailable()))('converting a subtitle to WebVTT', () => {
+  const vttFrom = (options) => tracksService.extractWebVtt(filmPath(), options);
+
+  it('produces a WebVTT document', async () => {
+    const vtt = await vttFrom({ streamIndex: 3 });
+
+    expect(vtt.startsWith('WEBVTT')).toBe(true);
+  });
+
+  it('carries the text of the track it was asked for', async () => {
+    const vtt = await vttFrom({ streamIndex: 3 });
+
+    expect(vtt).toContain('Bonjour le monde');
+  });
+
+  it('takes the other track when asked for the other track', async () => {
+    const vtt = await vttFrom({ streamIndex: 4 });
+
+    expect(vtt).toContain('Hello world');
+    expect(vtt).not.toContain('Bonjour');
+  });
+
+  /** Accents survive the round trip, which a byte-level pipe would not promise. */
+  it('keeps non-ASCII text intact', async () => {
+    const accented = path.join(fixtureDir, 'film.es.srt');
+    await fs.writeFile(accented, '1\n00:00:00,500 --> 00:00:02,000\nEl niño está aquí\n');
+
+    const vtt = await tracksService.extractWebVtt(accented);
+
+    expect(vtt).toContain('El niño está aquí');
+  });
+
+  it('converts a whole sidecar file when given no stream', async () => {
+    const sidecar = path.join(fixtureDir, 'film.en.srt');
+    await fs.copyFile(path.join(fixtureDir, 'source-en.srt'), sidecar);
+
+    const vtt = await tracksService.extractWebVtt(sidecar);
+
+    expect(vtt).toContain('Hello world');
+  });
+
+  it('fails rather than returning an empty file when the stream is not there', async () => {
+    await expect(vttFrom({ streamIndex: 99 })).rejects.toThrow();
+  });
+});

--- a/frontend/src/plugins/preview/MediaPreview.spec.js
+++ b/frontend/src/plugins/preview/MediaPreview.spec.js
@@ -1,6 +1,22 @@
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createI18n } from 'vue-i18n';
 import MediaPreview from './MediaPreview.vue';
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      mediaPreview: {
+        download: 'Download media',
+        close: 'Close preview',
+        previous: 'Previous media',
+        next: 'Next media',
+      },
+    },
+  },
+});
 
 const media = [
   { name: 'first.jpg', kind: 'jpg', path: 'Test' },
@@ -34,6 +50,7 @@ const createWrapper = (item = media[0]) => {
       previewUrl: api.getPreviewUrl(item),
       api,
     },
+    global: { plugins: [i18n] },
   });
 
   return { api, wrapper };
@@ -60,6 +77,42 @@ const swipe = async (wrapper, startX, startY, endX, endY) => {
     ],
   });
 };
+
+const stage = (wrapper) => wrapper.get('[data-test="media-preview"]');
+
+const touch = (x, y, identifier = 1) => ({ clientX: x, clientY: y, identifier });
+
+/** Pinch with two fingers, from one separation to another. */
+const pinch = async (wrapper, from, to) => {
+  const element = stage(wrapper);
+  await element.trigger('touchstart', {
+    touches: [touch(500 - from / 2, 400, 1), touch(500 + from / 2, 400, 2)],
+    changedTouches: [touch(500 - from / 2, 400, 1)],
+  });
+  await element.trigger('touchmove', {
+    touches: [touch(500 - to / 2, 400, 1), touch(500 + to / 2, 400, 2)],
+  });
+  await element.trigger('touchend', {
+    touches: [],
+    changedTouches: [touch(500 - to / 2, 400, 1)],
+  });
+};
+
+/** Two taps in the same place, close together. */
+const doubleTap = async (wrapper, x = 400, y = 300) => {
+  const element = stage(wrapper);
+  for (let index = 0; index < 2; index += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await element.trigger('touchstart', {
+      touches: [touch(x, y)],
+      changedTouches: [touch(x, y)],
+    });
+    // eslint-disable-next-line no-await-in-loop
+    await element.trigger('touchend', { touches: [], changedTouches: [touch(x, y)] });
+  }
+};
+
+const imageTransform = (wrapper) => wrapper.get('img').attributes('style') || '';
 
 describe('MediaPreview', () => {
   it('navigates between images and videos with horizontal swipes', async () => {
@@ -120,5 +173,95 @@ describe('MediaPreview', () => {
 
     expect(event.defaultPrevented).toBe(false);
     expect(wrapper.get('source').attributes('src')).toBe('/api/preview/clip.mp4');
+  });
+});
+
+/**
+ * Zooming, and the rule that lets it coexist with swiping.
+ *
+ * The viewer this replaces moved the picture around when you dragged it, which
+ * is exactly what #354 asked to remove — but dropping the drag entirely would
+ * have cost zooming, which people expect on a phone. Both live here, separated
+ * by the only thing that can separate them: whether the picture is zoomed.
+ */
+describe('MediaPreview zoom', () => {
+  it('zooms a picture when pinched', async () => {
+    const { wrapper } = createWrapper();
+
+    await pinch(wrapper, 100, 300);
+
+    expect(imageTransform(wrapper)).toContain('scale(3)');
+  });
+
+  it('stops navigating once the picture is zoomed', async () => {
+    // The heart of it: the same gesture cannot both move the picture and turn
+    // the page. Zoomed in, it moves the picture.
+    const { wrapper } = createWrapper();
+    await pinch(wrapper, 100, 300);
+
+    await swipe(wrapper, 260, 120, 120, 120);
+
+    expect(wrapper.get('img').attributes('src')).toBe('/api/preview/first.jpg');
+  });
+
+  it('navigates again once the picture is back to natural size', async () => {
+    const { wrapper } = createWrapper();
+    await pinch(wrapper, 100, 300);
+    await pinch(wrapper, 300, 100);
+
+    await swipe(wrapper, 260, 120, 120, 120);
+
+    expect(wrapper.get('video').exists()).toBe(true);
+  });
+
+  it('zooms in and back out on a double tap', async () => {
+    const { wrapper } = createWrapper();
+
+    await doubleTap(wrapper);
+    expect(imageTransform(wrapper)).toContain('scale(2.5)');
+
+    await doubleTap(wrapper);
+    expect(imageTransform(wrapper)).not.toContain('scale(');
+  });
+
+  it('starts the next picture at natural size', async () => {
+    // Reached with the arrow while still zoomed — the only way to leave a
+    // zoomed picture, since swiping is busy panning it. Carrying that zoom over
+    // would land somewhere arbitrary in an unrelated image, and leave swiping
+    // dead there with no visible reason.
+    const { wrapper } = createWrapper();
+    await pinch(wrapper, 100, 300);
+    expect(imageTransform(wrapper)).toContain('scale(3)');
+
+    await wrapper.get('button[aria-label="Next media"]').trigger('click');
+    await wrapper.get('button[aria-label="Next media"]').trigger('click');
+
+    expect(imageTransform(wrapper)).not.toContain('scale(');
+  });
+
+  it('leaves videos alone, which have their own controls', async () => {
+    const { wrapper } = createWrapper(media[1]);
+
+    await pinch(wrapper, 100, 300);
+
+    expect(wrapper.get('video').attributes('style') || '').not.toContain('scale(');
+  });
+
+  it('zooms with ctrl and the wheel, and scrolls without it', async () => {
+    const { wrapper } = createWrapper();
+
+    const wheel = (ctrlKey) =>
+      stage(wrapper).element.dispatchEvent(
+        new WheelEvent('wheel', { deltaY: -200, ctrlKey, bubbles: true, cancelable: true })
+      );
+
+    wheel(true);
+    await wrapper.vm.$nextTick();
+    expect(imageTransform(wrapper)).toContain('scale(');
+
+    const zoomed = imageTransform(wrapper);
+    wheel(false);
+    await wrapper.vm.$nextTick();
+    expect(imageTransform(wrapper)).toBe(zoomed);
   });
 });

--- a/frontend/src/plugins/preview/MediaPreview.vue
+++ b/frontend/src/plugins/preview/MediaPreview.vue
@@ -7,11 +7,30 @@
       <span v-if="mediaItems.length > 1" class="text-xs text-neutral-300" aria-live="polite">
         {{ currentIndex + 1 }} / {{ mediaItems.length }}
       </span>
+      <!--
+        Only Safari implements audioTracks; Chrome and Firefox keep it behind a
+        flag. So this appears where switching actually works and is absent
+        everywhere else, rather than offering a control that does nothing.
+      -->
+      <label v-if="switchableAudio.length > 1" class="flex items-center gap-1.5 text-xs">
+        <span class="sr-only">{{ t('mediaPreview.audioTrack') }}</span>
+        <SpeakerWaveIcon class="h-4 w-4 text-neutral-300" />
+        <select
+          v-model="selectedAudioTrack"
+          class="max-w-40 rounded-md border border-white/20 bg-black/60 px-1.5 py-1 text-xs text-white"
+          :aria-label="t('mediaPreview.audioTrack')"
+        >
+          <option v-for="track in switchableAudio" :key="track.id" :value="track.id">
+            {{ track.label }}
+          </option>
+        </select>
+      </label>
+
       <button
         v-if="api.download"
         type="button"
         class="rounded-md p-2 text-neutral-200 transition hover:bg-white/15 hover:text-white"
-        aria-label="Download media"
+        :aria-label="t('mediaPreview.download')"
         @click="downloadCurrent"
       >
         <ArrowDownTrayIcon class="h-5 w-5" />
@@ -19,7 +38,7 @@
       <button
         type="button"
         class="rounded-md p-2 text-neutral-200 transition hover:bg-white/15 hover:text-white"
-        aria-label="Close preview"
+        :aria-label="t('mediaPreview.close')"
         @click="close"
       >
         <XMarkIcon class="h-5 w-5" />
@@ -27,21 +46,25 @@
     </header>
 
     <main
+      ref="stageRef"
       class="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden p-2"
       data-test="media-preview"
-      style="touch-action: pan-y"
+      :style="{ touchAction: zoom.isZoomed.value ? 'none' : 'pan-y' }"
       @pointerdown.capture="startSwipe"
       @pointerup.capture="finishSwipe"
       @pointercancel.capture="resetSwipe"
       @touchstart.capture="startTouchSwipe"
+      @touchmove.capture="moveTouch"
       @touchend.capture="finishTouchSwipe"
       @touchcancel.capture="resetSwipe"
+      @wheel="handleWheel"
+      @dblclick="canZoom && zoom.toggle(stageBounds())"
     >
       <button
         v-if="mediaItems.length > 1"
         type="button"
         class="absolute left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white shadow-sm transition hover:bg-black/80"
-        aria-label="Previous media"
+        :aria-label="t('mediaPreview.previous')"
         @pointerdown.stop
         @click.stop="previous"
       >
@@ -53,22 +76,54 @@
         :src="currentMedia.previewUrl"
         :alt="currentMedia.item.name"
         class="max-h-full max-w-full object-contain"
+        :class="zoom.isZoomed.value ? 'cursor-grab' : ''"
         draggable="false"
-        style="touch-action: pan-y"
+        :style="{
+          touchAction: zoom.isZoomed.value ? 'none' : 'pan-y',
+          transform: zoom.transform.value,
+          transformOrigin: 'center center',
+        }"
         @dragstart.prevent
       />
-      <div v-else class="relative max-h-full max-w-full">
+      <!--
+        A grid, so the video is actually contained.
+
+        `max-h-full` on the video used to resolve against this wrapper, whose
+        own height is content-driven — and a percentage against an indefinite
+        height computes to none. A portrait video therefore rendered at its
+        natural height and hung below the stage, which clips it: the control
+        bar was simply off-screen, and only fullscreen brought it back. A grid
+        area has a definite size, so the same percentage now means what it
+        says. Landscape videos, which fit either way, are laid out identically.
+      -->
+      <div v-else class="relative grid min-h-0 max-h-full max-w-full place-items-center">
         <video
           :key="currentMedia.key"
           ref="videoRef"
-          class="block max-h-full max-w-full bg-black"
+          class="block min-h-0 max-h-full max-w-full bg-black"
           controls
           autoplay
           playsinline
           :poster="currentMedia.item.thumbnail"
           style="touch-action: pan-y"
+          @loadedmetadata="handleVideoMetadata"
         >
           <source :src="currentMedia.previewUrl" :type="getVideoMimeType(currentMedia.extension)" />
+          <!--
+            Subtitles are converted to WebVTT server-side, because it is the
+            only format a video element accepts. Declaring them as tracks is
+            what makes the browser's own caption button appear — there is no
+            menu of ours to maintain.
+          -->
+          <track
+            v-for="track in subtitleTracks"
+            :key="`${track.source}-${track.index ?? track.fileName}`"
+            kind="subtitles"
+            :src="track.url"
+            :srclang="track.language || undefined"
+            :label="subtitleLabel(track)"
+            :default="track.isDefault || undefined"
+          />
           Your browser does not support the video tag.
         </video>
         <div
@@ -78,11 +133,24 @@
         ></div>
       </div>
 
+      <!--
+        Why a film plays in silence. Placed over the stage rather than beneath
+        the video so it changes no layout, and it cannot be clicked through to
+        — the controls underneath stay reachable.
+      -->
+      <p
+        v-if="showAudioNotice"
+        class="pointer-events-none absolute inset-x-4 top-3 z-10 mx-auto max-w-lg rounded-md bg-amber-500/90 px-3 py-2 text-center text-xs font-medium text-black shadow-lg"
+        role="status"
+      >
+        {{ noticeText }}
+      </p>
+
       <button
         v-if="mediaItems.length > 1"
         type="button"
         class="absolute right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white shadow-sm transition hover:bg-black/80"
-        aria-label="Next media"
+        :aria-label="t('mediaPreview.next')"
         @pointerdown.stop
         @click.stop="next"
       >
@@ -94,13 +162,19 @@
 
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import {
   ArrowDownTrayIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  SpeakerWaveIcon,
   XMarkIcon,
 } from '@heroicons/vue/24/outline';
 import { isPreviewableImage, isPreviewableVideo } from '@/config/media';
+import { useMediaZoom } from './useMediaZoom';
+import { useMediaTracks, languageName } from './useMediaTracks';
+
+const { t, locale } = useI18n();
 
 const props = defineProps({
   item: { type: Object, required: true },
@@ -111,8 +185,26 @@ const props = defineProps({
 });
 
 const SWIPE_THRESHOLD = 48;
+// Two taps further apart than this are two taps, not a double tap.
+const DOUBLE_TAP_MS = 300;
+const DOUBLE_TAP_SLOP = 30;
+// A trackpad pinch arrives as a wheel event with ctrlKey; this turns its
+// delta into a factor gentle enough to be controllable.
+const WHEEL_ZOOM_SENSITIVITY = 0.005;
+
 const swipeStart = ref(null);
 const videoRef = ref(null);
+const stageRef = ref(null);
+const zoom = useMediaZoom();
+const pinchStart = ref(null);
+const lastTap = ref(null);
+
+const stageBounds = () => stageRef.value?.getBoundingClientRect() || null;
+
+const touchDistance = (touches) => {
+  const [first, second] = touches;
+  return Math.hypot(second.clientX - first.clientX, second.clientY - first.clientY);
+};
 
 const getItemKey = (item) => `${item.path || ''}/${item.name || ''}`;
 
@@ -162,6 +254,133 @@ const currentIndex = computed(() => {
 
 const currentMedia = computed(() => mediaItems.value[currentIndex.value] || null);
 
+/** Videos keep their own controls; only pictures zoom. */
+const canZoom = computed(
+  () => Boolean(currentMedia.value) && isPreviewableImage(currentMedia.value.extension)
+);
+
+/**
+ * What the file holds, and what this browser will refuse.
+ *
+ * Only worth asking for the things played through a video element; a picture
+ * has no tracks.
+ */
+const isPlayedAsVideo = computed(
+  () => Boolean(currentMedia.value) && !isPreviewableImage(currentMedia.value.extension)
+);
+
+const {
+  subtitleTracks,
+  audioTracks,
+  hasUnplayableAudio,
+  unplayableCodecs,
+  hasUnplayableVideo,
+  unplayableVideoCodecs,
+} = useMediaTracks(currentMedia, props.api, isPlayedAsVideo);
+
+/**
+ * A caption's name in the reader's own language, and where it came from.
+ *
+ * A file next to the video and a track inside it can carry the same language,
+ * so the source is part of the name — otherwise the menu offers "French"
+ * twice and picking one is a guess.
+ */
+const subtitleLabel = (track) => {
+  const named = track.title || languageName(track.language, locale.value) || track.label;
+  const parts = [named];
+  if (track.forced) parts.push(t('mediaPreview.subtitleForced'));
+  if (track.source === 'sidecar') parts.push(t('mediaPreview.subtitleExternal'));
+  return parts.join(' · ');
+};
+
+/**
+ * The audio notice, which says its piece and then gets out of the way.
+ *
+ * It answers a question asked in the first seconds — why is this silent — and
+ * has no business sitting over a film for two hours afterwards.
+ */
+const AUDIO_NOTICE_MS = 10000;
+const noticeVisible = ref(false);
+let noticeTimer = null;
+
+/**
+ * One sentence, and the picture comes first: a video that does not play at all
+ * makes a remark about its soundtrack beside the point.
+ */
+const noticeText = computed(() => {
+  if (hasUnplayableVideo.value) {
+    return t('mediaPreview.noPlayableVideo', {
+      codecs: unplayableVideoCodecs.value.join(', ').toUpperCase(),
+    });
+  }
+  if (hasUnplayableAudio.value) {
+    return t('mediaPreview.noPlayableAudio', {
+      codecs: unplayableCodecs.value.join(', ').toUpperCase(),
+    });
+  }
+  return '';
+});
+
+const showAudioNotice = computed(() => Boolean(noticeText.value) && noticeVisible.value);
+
+watch(noticeText, (text) => {
+  if (noticeTimer) clearTimeout(noticeTimer);
+  noticeVisible.value = Boolean(text);
+  if (!text) return;
+  noticeTimer = setTimeout(() => {
+    noticeVisible.value = false;
+  }, AUDIO_NOTICE_MS);
+});
+
+/**
+ * Audio tracks this browser will let anyone switch between.
+ *
+ * `audioTracks` is Safari's alone — Chrome and Firefox keep it behind a flag —
+ * so this is empty nearly everywhere, and the control that reads it is absent
+ * rather than present and inert. What the file contains is still reported by
+ * the notice above, which needs no browser support at all.
+ */
+const switchableAudio = ref([]);
+const selectedAudioTrack = ref('');
+
+const readSwitchableAudio = () => {
+  const native = videoRef.value?.audioTracks;
+  if (!native || typeof native.length !== 'number' || native.length < 2) {
+    switchableAudio.value = [];
+    return;
+  }
+
+  const list = [];
+  for (let index = 0; index < native.length; index += 1) {
+    const track = native[index];
+    // Prefer what the server read from the container: ffprobe reports titles
+    // and languages the browser's own track objects often leave empty.
+    const described = audioTracks.value[index];
+    const language = described?.language || track.language;
+    list.push({
+      id: track.id || String(index),
+      index,
+      label:
+        described?.title ||
+        languageName(language, locale.value) ||
+        track.label ||
+        t('mediaPreview.audioTrackNumbered', { number: index + 1 }),
+    });
+    if (track.enabled) selectedAudioTrack.value = track.id || String(index);
+  }
+  switchableAudio.value = list;
+};
+
+watch(selectedAudioTrack, (id) => {
+  const native = videoRef.value?.audioTracks;
+  if (!native || !id) return;
+  for (let index = 0; index < native.length; index += 1) {
+    // Exactly one enabled at a time is what the specification allows, and what
+    // Safari enforces anyway.
+    native[index].enabled = (native[index].id || String(index)) === id;
+  }
+});
+
 watch(
   mediaItems,
   (items) => {
@@ -179,6 +398,12 @@ watch(
   }
 );
 
+/**
+ * The browser only knows what tracks exist once it has read the container's
+ * header, so the list is taken then rather than on mount.
+ */
+const handleVideoMetadata = () => readSwitchableAudio();
+
 const pauseVideo = () => {
   if (!videoRef.value) return;
 
@@ -189,6 +414,13 @@ const pauseVideo = () => {
 watch(currentMedia, (nextMedia, previousMedia) => {
   if (previousMedia?.key !== nextMedia?.key) {
     pauseVideo();
+    // The previous video's tracks are not this one's; the element is rebuilt
+    // and will report its own through loadedmetadata.
+    switchableAudio.value = [];
+    selectedAudioTrack.value = '';
+    // A new picture starts at natural size — carrying the previous one's zoom
+    // over would land somewhere arbitrary in an unrelated image.
+    zoom.reset();
   }
 });
 
@@ -214,6 +446,17 @@ const startSwipe = (event) => {
 };
 
 const startTouchSwipe = (event) => {
+  // Two fingers are never a swipe — on a picture they pinch, and on a video
+  // they do nothing at all. Letting one of them arm the swipe would turn a
+  // pinch on a video into a page turn.
+  if (event.touches?.length === 2) {
+    swipeStart.value = null;
+    pinchStart.value = canZoom.value
+      ? { distance: touchDistance(event.touches), scale: zoom.scale.value }
+      : null;
+    return;
+  }
+
   const touch = event.changedTouches[0];
   if (!touch) return;
 
@@ -221,14 +464,76 @@ const startTouchSwipe = (event) => {
     pointerId: touch.identifier,
     x: touch.clientX,
     y: touch.clientY,
+    // Panning a zoomed picture moves it under the finger, so each move is
+    // measured from the last rather than from where the gesture began.
+    lastX: touch.clientX,
+    lastY: touch.clientY,
   };
+};
+
+const moveTouch = (event) => {
+  if (pinchStart.value && event.touches?.length === 2) {
+    event.preventDefault();
+    const distance = touchDistance(event.touches);
+    if (pinchStart.value.distance > 0) {
+      zoom.zoomTo((pinchStart.value.scale * distance) / pinchStart.value.distance, stageBounds());
+    }
+    return;
+  }
+
+  // One finger on a zoomed picture moves the picture. At natural size it is
+  // left alone, so the gallery can read it as a swipe when it ends.
+  const start = swipeStart.value;
+  if (!start || !zoom.isZoomed.value) return;
+
+  const touch = Array.from(event.touches || []).find((item) => item.identifier === start.pointerId);
+  if (!touch) return;
+
+  event.preventDefault();
+  zoom.panBy(touch.clientX - start.lastX, touch.clientY - start.lastY, stageBounds());
+  start.lastX = touch.clientX;
+  start.lastY = touch.clientY;
+};
+
+/** Two quick taps in the same spot zoom in, or all the way back out. */
+const registerTap = (touch) => {
+  if (!canZoom.value || !touch) return false;
+
+  const now = Date.now();
+  const previous = lastTap.value;
+  lastTap.value = { at: now, x: touch.clientX, y: touch.clientY };
+
+  if (
+    previous &&
+    now - previous.at < DOUBLE_TAP_MS &&
+    Math.abs(touch.clientX - previous.x) < DOUBLE_TAP_SLOP &&
+    Math.abs(touch.clientY - previous.y) < DOUBLE_TAP_SLOP
+  ) {
+    lastTap.value = null;
+    zoom.toggle(stageBounds());
+    return true;
+  }
+
+  return false;
+};
+
+/** A trackpad pinch, or ctrl with a wheel — the desktop way in. */
+const handleWheel = (event) => {
+  if (!canZoom.value || !event.ctrlKey) return;
+  event.preventDefault();
+  zoom.zoomBy(Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY), stageBounds());
 };
 
 const resetSwipe = () => {
   swipeStart.value = null;
+  pinchStart.value = null;
 };
 
 const navigateForSwipe = (start, event) => {
+  // Zoomed in, the same movement was panning the picture and must not also
+  // turn the page — that conflation is what made the old viewer unusable.
+  if (zoom.isZoomed.value) return false;
+
   const deltaX = event.clientX - start.x;
   const deltaY = event.clientY - start.y;
 
@@ -256,11 +561,22 @@ const finishSwipe = (event) => {
 };
 
 const finishTouchSwipe = (event) => {
+  if (pinchStart.value && (event.touches?.length ?? 0) < 2) {
+    pinchStart.value = null;
+    return;
+  }
+
   const start = swipeStart.value;
-  const touch = Array.from(event.changedTouches).find((item) => item.identifier === start?.pointerId);
+  const touch = Array.from(event.changedTouches || []).find(
+    (item) => item.identifier === start?.pointerId
+  );
   resetSwipe();
 
   if (!start || !touch) return;
+
+  const travelled = Math.hypot(touch.clientX - start.x, touch.clientY - start.y);
+  if (travelled < DOUBLE_TAP_SLOP && registerTap(touch)) return;
+
   navigateForSwipe(start, touch);
 };
 
@@ -308,6 +624,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  if (noticeTimer) clearTimeout(noticeTimer);
   pauseVideo();
   window.removeEventListener('keydown', handleKeydown);
 });

--- a/frontend/src/plugins/preview/MediaTracks.spec.js
+++ b/frontend/src/plugins/preview/MediaTracks.spec.js
@@ -1,0 +1,286 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { flushPromises } from '@vue/test-utils';
+import MediaPreview from './MediaPreview.vue';
+
+/**
+ * Saying what a video holds, and offering the subtitles it holds.
+ *
+ * The player does not transcode, so a soundtrack the browser cannot decode
+ * simply produces nothing — reported from production as several films playing
+ * in silence with nothing on screen to explain it. These cover the two halves
+ * of the answer: the sentence that explains the silence, and the caption tracks
+ * that the browser's own controls then offer.
+ */
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      mediaPreview: {
+        download: 'Download media',
+        close: 'Close preview',
+        previous: 'Previous media',
+        next: 'Next media',
+        noPlayableAudio: 'Soundtrack is {codecs}, which your browser cannot decode.',
+        noPlayableVideo: 'This video is {codecs}; play it in a media player.',
+        audioTrack: 'Audio track',
+        audioTrackNumbered: 'Track {number}',
+        subtitleForced: 'forced',
+        subtitleExternal: 'external file',
+      },
+    },
+  },
+});
+
+const media = [
+  { name: 'clip.mp4', kind: 'mp4', path: 'Test' },
+  { name: 'other.mkv', kind: 'mkv', path: 'Test' },
+  { name: 'photo.jpg', kind: 'jpg', path: 'Test' },
+];
+
+const tracksWith = (overrides = {}) => ({
+  available: true,
+  video: [{ index: 0, codec: 'h264', label: 'Track 1', playable: true }],
+  audio: [],
+  subtitles: [],
+  hasAudio: false,
+  hasPlayableAudio: false,
+  ...overrides,
+});
+
+const AC3 = { index: 1, codec: 'ac3', language: 'fr', title: null, label: 'fr', playable: false };
+const AAC = { index: 2, codec: 'aac', language: 'en', title: null, label: 'en', playable: true };
+
+const subtitle = (overrides = {}) => ({
+  index: 3,
+  codec: 'subrip',
+  language: 'fr',
+  title: null,
+  label: 'fr',
+  isDefault: false,
+  forced: false,
+  source: 'embedded',
+  convertible: true,
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+const mountWith = async (tracks, item = media[0]) => {
+  const getMediaTracks = vi.fn().mockResolvedValue(tracks);
+  const api = {
+    close: vi.fn(),
+    download: vi.fn(),
+    getPreviewUrl: (target) => `/api/preview/${target.name}`,
+    getSiblings: () => media,
+    getMediaTracks,
+    getSubtitleUrl: (target, track) =>
+      `/api/media/subtitle?path=${target.name}&${track.file ? `file=${track.file}` : `stream=${track.stream}`}`,
+  };
+
+  const wrapper = mount(MediaPreview, {
+    props: {
+      item,
+      extension: item.kind,
+      filePath: `${item.path}/${item.name}`,
+      previewUrl: api.getPreviewUrl(item),
+      api,
+    },
+    global: { plugins: [i18n] },
+  });
+
+  await flushPromises();
+  return { wrapper, api, getMediaTracks };
+};
+
+describe('explaining a silent video', () => {
+  it('says so when the only soundtrack is one the browser cannot decode', async () => {
+    const { wrapper } = await mountWith(
+      tracksWith({ audio: [AC3], hasAudio: true, hasPlayableAudio: false })
+    );
+
+    expect(wrapper.text()).toContain('cannot decode');
+  });
+
+  it('names the codec, so the message says something actionable', async () => {
+    const { wrapper } = await mountWith(
+      tracksWith({ audio: [AC3], hasAudio: true, hasPlayableAudio: false })
+    );
+
+    expect(wrapper.text()).toContain('AC3');
+  });
+
+  it('stays quiet when a soundtrack can be played', async () => {
+    const { wrapper } = await mountWith(
+      tracksWith({ audio: [AC3, AAC], hasAudio: true, hasPlayableAudio: true })
+    );
+
+    expect(wrapper.text()).not.toContain('cannot decode');
+  });
+
+  /** A video with no soundtrack is not broken, and saying so would be noise. */
+  it('stays quiet about a video with no soundtrack at all', async () => {
+    const { wrapper } = await mountWith(tracksWith({ hasAudio: false }));
+
+    expect(wrapper.text()).not.toContain('cannot decode');
+  });
+
+  it('says nothing when the server could not read the file', async () => {
+    const { wrapper } = await mountWith(null);
+
+    expect(wrapper.text()).not.toContain('cannot decode');
+  });
+
+  /**
+   * It answers a question asked in the first seconds and has no business
+   * sitting over a film for two hours.
+   */
+  it('gets out of the way after a while', async () => {
+    vi.useFakeTimers();
+    const { wrapper } = await mountWith(
+      tracksWith({ audio: [AC3], hasAudio: true, hasPlayableAudio: false })
+    );
+    expect(wrapper.text()).toContain('cannot decode');
+
+    vi.advanceTimersByTime(11000);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).not.toContain('cannot decode');
+  });
+
+  /** Nothing to explain about a picture, so nothing is asked. */
+  it('does not ask about an image', async () => {
+    const { getMediaTracks } = await mountWith(tracksWith(), media[2]);
+
+    expect(getMediaTracks).not.toHaveBeenCalled();
+  });
+});
+
+describe('explaining a video that will not play at all', () => {
+  const HEVC = { index: 0, codec: 'hevc', label: 'Track 1', playable: false };
+
+  /**
+   * The case the production log showed: an `x265.10bit.HEVC.mkv`, which a
+   * browser plays only from an MP4, only with hardware support, and never in
+   * ten bits — so it shows nothing whatever.
+   */
+  it('says the picture is one the browser cannot decode', async () => {
+    const { wrapper } = await mountWith(tracksWith({ video: [HEVC] }));
+
+    expect(wrapper.text()).toContain('play it in a media player');
+  });
+
+  it('names the video codec', async () => {
+    const { wrapper } = await mountWith(tracksWith({ video: [HEVC] }));
+
+    expect(wrapper.text()).toContain('HEVC');
+  });
+
+  /** Nothing is playing, so a remark about the soundtrack is beside the point. */
+  it('says that instead of talking about the sound', async () => {
+    const { wrapper } = await mountWith(
+      tracksWith({ video: [HEVC], audio: [AC3], hasAudio: true, hasPlayableAudio: false })
+    );
+
+    expect(wrapper.text()).not.toContain('Soundtrack is');
+  });
+
+  it('stays quiet about a video the browser can decode', async () => {
+    const { wrapper } = await mountWith(tracksWith());
+
+    expect(wrapper.text()).not.toContain('play it in a media player');
+  });
+});
+
+describe('offering subtitles', () => {
+  const trackElements = (wrapper) => wrapper.findAll('track');
+
+  it('declares a track element for a subtitle in the file', async () => {
+    const { wrapper } = await mountWith(tracksWith({ subtitles: [subtitle()] }));
+
+    expect(trackElements(wrapper)).toHaveLength(1);
+  });
+
+  it('points it at the endpoint that converts that stream', async () => {
+    const { wrapper } = await mountWith(tracksWith({ subtitles: [subtitle({ index: 3 })] }));
+
+    expect(trackElements(wrapper)[0].attributes('src')).toContain('stream=3');
+  });
+
+  it('points a sidecar at the endpoint by filename', async () => {
+    const { wrapper } = await mountWith(
+      tracksWith({
+        subtitles: [subtitle({ index: null, source: 'sidecar', fileName: 'clip.fr.srt' })],
+      })
+    );
+
+    expect(trackElements(wrapper)[0].attributes('src')).toContain('file=clip.fr.srt');
+  });
+
+  it('declares the language, so the browser can label the menu', async () => {
+    const { wrapper } = await mountWith(tracksWith({ subtitles: [subtitle({ language: 'fr' })] }));
+
+    expect(trackElements(wrapper)[0].attributes('srclang')).toBe('fr');
+  });
+
+  /** A code is not a name; a caption menu should read as words. */
+  it('names the language rather than showing its tag', async () => {
+    const { wrapper } = await mountWith(tracksWith({ subtitles: [subtitle({ language: 'fr' })] }));
+
+    expect(trackElements(wrapper)[0].attributes('label')).toContain('French');
+  });
+
+  /**
+   * A file beside the video and a track inside it can carry the same language,
+   * and a menu offering "French" twice makes the choice a guess.
+   */
+  it('says which of two same-language tracks came from a separate file', async () => {
+    const { wrapper } = await mountWith(
+      tracksWith({
+        subtitles: [
+          subtitle({ index: null, source: 'sidecar', fileName: 'clip.fr.srt' }),
+          subtitle({ index: 3 }),
+        ],
+      })
+    );
+
+    const labels = trackElements(wrapper).map((track) => track.attributes('label'));
+    expect(labels.filter((label) => label.includes('external file'))).toHaveLength(1);
+  });
+
+  it('marks a forced track as forced', async () => {
+    const { wrapper } = await mountWith(tracksWith({ subtitles: [subtitle({ forced: true })] }));
+
+    expect(trackElements(wrapper)[0].attributes('label')).toContain('forced');
+  });
+
+  /**
+   * A Blu-ray subtitle is a picture of words. Offering it as a caption track
+   * would produce a menu entry that shows nothing when chosen.
+   */
+  it('leaves out an image-based subtitle it cannot convert', async () => {
+    const { wrapper } = await mountWith(
+      tracksWith({
+        subtitles: [subtitle({ codec: 'hdmv_pgs_subtitle', convertible: false })],
+      })
+    );
+
+    expect(trackElements(wrapper)).toHaveLength(0);
+  });
+
+  it('declares no tracks when the file has none', async () => {
+    const { wrapper } = await mountWith(tracksWith());
+
+    expect(trackElements(wrapper)).toHaveLength(0);
+  });
+});

--- a/frontend/src/plugins/preview/PreviewHost.vue
+++ b/frontend/src/plugins/preview/PreviewHost.vue
@@ -73,14 +73,36 @@
 
           <!-- Content -->
           <main class="flex-1 overflow-hidden bg-neutral-50 dark:bg-zinc-950/40">
-            <!-- Minimal floating close button -->
+            <!--
+              Fallback close button, shown only until the plugin reports that
+              its own viewer draws one.
+
+              A plugin rendering third-party chrome — ONLYOFFICE — asks that
+              viewer for a close button and clears this flag once the document
+              is ready. Until then, and for anything that never gets there,
+              this is the only way out of a header-less overlay.
+
+              Sized and placed to sit over the editor's own logo in the top left
+              corner, hiding it: the right-hand side belongs to the editor's
+              toolbar, where a floating button sat among real controls and read
+              as one of them. The offset was trimmed against the running editor
+              rather than computed, so adjust it the same way. Any larger and it
+              spills onto the File menu underneath.
+
+              Solid fill in the app's primary blue with a white ring, so it
+              stays visible against a toolbar that is light in one theme and
+              dark in the other — the previous translucent grey disappeared into
+              both.
+            -->
             <button
-              v-if="isMinimal"
+              v-if="isMinimal && !hasNativeClose"
               type="button"
-              class="absolute right-12 top-0 z-2100 rounded-md bg-black/50 p-1 text-white shadow-sm transition hover:bg-black/70"
+              :title="$t('common.close')"
+              :aria-label="$t('common.close')"
+              class="absolute left-1.75 top-0.5 z-2100 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-blue-600 text-white shadow-md ring-1 ring-white/80 transition hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 dark:ring-zinc-900/80"
               @click="handleClose"
             >
-              <XMarkIcon class="h-5 w-5" />
+              <XMarkSolidIcon class="h-4 w-4" />
             </button>
 
             <component v-if="component" :is="component" v-bind="activeItem" class="h-full" />
@@ -106,6 +128,9 @@ import {
   PencilSquareIcon,
   ArrowTopRightOnSquareIcon,
 } from '@heroicons/vue/24/outline';
+// Solid, only for the floating button: an outline glyph on a filled circle
+// reads as thin at that size.
+import { XMarkIcon as XMarkSolidIcon } from '@heroicons/vue/24/solid';
 import { usePreviewManager } from '@/plugins/preview/manager';
 import LoadingIcon from '@/icons/LoadingIcon.vue';
 
@@ -115,6 +140,8 @@ const { isOpen, activeItem, activePlugin } = storeToRefs(manager);
 // Derived state
 const isStandalone = computed(() => activePlugin.value?.standalone ?? false);
 const isMinimal = computed(() => activePlugin.value?.minimalHeader ?? false);
+// Set by plugins whose embedded viewer provides its own close control.
+const hasNativeClose = computed(() => activeItem.value?.previewState?.hasNativeClose === true);
 
 const actions = computed(() => {
   if (!activePlugin.value || !activeItem.value || isStandalone.value || isMinimal.value) {
@@ -146,9 +173,9 @@ watch(
 );
 
 // Handlers
-const handleClose = () => {
+const handleClose = async () => {
   if (!isStandalone.value) {
-    manager.close();
+    await manager.close();
   }
 };
 

--- a/frontend/src/plugins/preview/manager.js
+++ b/frontend/src/plugins/preview/manager.js
@@ -1,6 +1,13 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
-import { getPreviewUrl, normalizePath, downloadItems, fetchFileContent } from '@/api';
+import {
+  getPreviewUrl,
+  normalizePath,
+  downloadItems,
+  fetchFileContent,
+  fetchMediaTracks,
+  getSubtitleUrl,
+} from '@/api';
 import { useFileStore } from '@/stores/fileStore';
 import router from '@/router';
 
@@ -9,6 +16,7 @@ export const usePreviewManager = defineStore('preview-manager', () => {
   const activeItem = ref(null);
   const activePlugin = ref(null);
   const isOpen = computed(() => !!activeItem.value);
+  let pendingClose = null;
 
   const getExtension = (item) => {
     if (!item) return '';
@@ -36,6 +44,8 @@ export const usePreviewManager = defineStore('preview-manager', () => {
 
   const createApi = (item) => ({
     getPreviewUrl: (targetItem) => getPreviewUrl(getFullPath(targetItem || item)),
+    getMediaTracks: (targetItem) => fetchMediaTracks(getFullPath(targetItem || item)),
+    getSubtitleUrl: (targetItem, track) => getSubtitleUrl(getFullPath(targetItem || item), track),
     fetchContent: () => fetchFileContent(getFullPath(item)),
     getSiblings: (target) => getSiblings(target || item),
     openEditor: () => {
@@ -98,6 +108,9 @@ export const usePreviewManager = defineStore('preview-manager', () => {
       extension,
       filePath: fullPath,
       previewUrl,
+      // Preview components can keep small, ephemeral state which their
+      // lifecycle hooks need when the preview is about to close.
+      previewState: {},
       api,
     };
 
@@ -134,16 +147,37 @@ export const usePreviewManager = defineStore('preview-manager', () => {
   };
 
   const close = () => {
+    if (pendingClose) return pendingClose;
     if (!activePlugin.value || !activeItem.value) return;
 
-    try {
-      activePlugin.value.onClose?.(activeItem.value);
-    } catch (error) {
-      console.error(`Plugin ${activePlugin.value.id} onClose error:`, error);
-    }
+    const plugin = activePlugin.value;
+    const item = activeItem.value;
 
-    activeItem.value = null;
-    activePlugin.value = null;
+    pendingClose = Promise.resolve(plugin.onBeforeClose?.(item))
+      .catch((error) => {
+        // A preview must always remain closable. Plugins can use this hook for
+        // best-effort cleanup such as asking ONLYOFFICE to flush changes.
+        console.warn(`Plugin ${plugin.id} onBeforeClose error:`, error);
+      })
+      .then(() => {
+        try {
+          plugin.onClose?.(item);
+        } catch (error) {
+          console.error(`Plugin ${plugin.id} onClose error:`, error);
+        }
+
+        // A new preview may have been opened while an asynchronous close hook
+        // was pending; never close that newer preview by accident.
+        if (activePlugin.value === plugin && activeItem.value === item) {
+          activeItem.value = null;
+          activePlugin.value = null;
+        }
+      })
+      .finally(() => {
+        pendingClose = null;
+      });
+
+    return pendingClose;
   };
 
   return {

--- a/frontend/src/plugins/preview/manager.spec.js
+++ b/frontend/src/plugins/preview/manager.spec.js
@@ -1,0 +1,372 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+
+/**
+ * Which viewer opens a file, and what happens when it closes.
+ *
+ * This is the registry the whole preview layer hangs off — image, video, audio,
+ * PDF, Markdown, ONLYOFFICE, Collabora — and it sat at 1%. Three things in it
+ * are worth more than the rest put together:
+ *
+ * A plugin that throws while deciding whether it matches must not take the
+ * preview down with it; the next one still gets asked.
+ *
+ * `close()` awaits a hook that plugins use to flush unsaved work, so it is
+ * asynchronous, and a *new* preview can be opened while the old one is still
+ * closing. Closing must then leave the newer one alone.
+ *
+ * And priority decides ties. ONLYOFFICE and the built-in PDF viewer both claim
+ * a .pdf; whichever sorts first is the one people actually get.
+ */
+
+const getPreviewUrl = vi.fn((p) => `https://files.example.com/api/preview?path=${p}`);
+const downloadItems = vi.fn();
+const fetchFileContent = vi.fn();
+const routerPush = vi.fn();
+let currentPathItems = [];
+
+vi.mock('@/api', () => ({
+  getPreviewUrl: (...a) => getPreviewUrl(...a),
+  downloadItems: (...a) => downloadItems(...a),
+  fetchFileContent: (...a) => fetchFileContent(...a),
+  normalizePath: (p = '') => String(p).replace(/^\/+|\/+$/g, ''),
+}));
+vi.mock('@/stores/fileStore', () => ({
+  useFileStore: () => ({
+    get getCurrentPathItems() {
+      return currentPathItems;
+    },
+  }),
+}));
+vi.mock('@/router', () => ({ default: { push: (...a) => routerPush(...a) } }));
+
+import { usePreviewManager } from './manager';
+
+const plugin = (id, overrides = {}) => ({
+  id,
+  match: () => true,
+  component: () => Promise.resolve({}),
+  ...overrides,
+});
+
+const IMAGE = { name: 'photo.jpg', path: 'Media', kind: 'jpg' };
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  [getPreviewUrl, downloadItems, fetchFileContent, routerPush].forEach((m) => m.mockClear());
+  currentPathItems = [];
+});
+
+describe('the register', () => {
+  it('opens nothing when no plugin claims the file', () => {
+    const manager = usePreviewManager();
+    manager.register(plugin('nothing', { match: () => false }));
+
+    expect(manager.open(IMAGE)).toBe(false);
+    expect(manager.isOpen).toBe(false);
+  });
+
+  it('ignores a plugin with no id, which could never be unregistered', () => {
+    const manager = usePreviewManager();
+
+    manager.register({ match: () => true });
+
+    expect(manager.open(IMAGE)).toBe(false);
+  });
+
+  /** Registering the same id twice is a reload, not a duplicate. */
+  it('replaces a plugin registered under an id already in use', () => {
+    const manager = usePreviewManager();
+    const first = vi.fn(() => true);
+    const second = vi.fn(() => true);
+    manager.register(plugin('image', { match: first }));
+    manager.register(plugin('image', { match: second }));
+
+    manager.open(IMAGE);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalled();
+  });
+
+  it('unregisters by id', () => {
+    const manager = usePreviewManager();
+    manager.register(plugin('image'));
+
+    manager.unregister('image');
+
+    expect(manager.open(IMAGE)).toBe(false);
+  });
+
+  it('gives the higher priority the file when two claim it', () => {
+    const manager = usePreviewManager();
+    manager.register(plugin('builtin-pdf', { priority: 25 }));
+    manager.register(plugin('onlyoffice', { priority: 90 }));
+
+    manager.open(IMAGE);
+
+    expect(manager.activePlugin.id).toBe('onlyoffice');
+  });
+
+  it('breaks a tie by id, so the choice is at least the same every time', () => {
+    const manager = usePreviewManager();
+    manager.register(plugin('zebra', { priority: 10 }));
+    manager.register(plugin('alpha', { priority: 10 }));
+
+    manager.open(IMAGE);
+
+    expect(manager.activePlugin.id).toBe('alpha');
+  });
+
+  it('treats a plugin with no priority as the lowest', () => {
+    const manager = usePreviewManager();
+    manager.register(plugin('unranked'));
+    manager.register(plugin('ranked', { priority: 1 }));
+
+    manager.open(IMAGE);
+
+    expect(manager.activePlugin.id).toBe('ranked');
+  });
+
+  /**
+   * A third-party plugin is a third party's bug. One that throws while matching
+   * must not stop the file opening in something else.
+   */
+  it('keeps asking the others when one throws while matching', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const manager = usePreviewManager();
+    manager.register(
+      plugin('broken', {
+        priority: 99,
+        match: () => {
+          throw new Error('bad plugin');
+        },
+      })
+    );
+    manager.register(plugin('image', { priority: 1 }));
+
+    expect(manager.open(IMAGE)).toBe(true);
+    expect(manager.activePlugin.id).toBe('image');
+    vi.restoreAllMocks();
+  });
+});
+
+describe('what a plugin is handed', () => {
+  const contextFor = (item) => {
+    const manager = usePreviewManager();
+    let seen = null;
+    manager.register(
+      plugin('spy', {
+        match: (context) => {
+          seen = context;
+          return true;
+        },
+      })
+    );
+    manager.open(item);
+    return { manager, context: seen };
+  };
+
+  it('the extension, from the kind the listing gave', () => {
+    expect(contextFor(IMAGE).context.extension).toBe('jpg');
+  });
+
+  it('the extension from the name when the kind is missing', () => {
+    expect(contextFor({ name: 'photo.PNG', path: 'Media' }).context.extension).toBe('png');
+  });
+
+  /** A folder has a kind of its own; treating it as an extension matches nothing. */
+  it('no extension at all for a directory', () => {
+    expect(contextFor({ name: 'Media', path: '', kind: 'directory' }).context.extension).toBe('');
+  });
+
+  it('an empty extension for a name with no dot', () => {
+    expect(contextFor({ name: 'LICENSE', path: 'Docs' }).context.extension).toBe('');
+  });
+
+  it('the full path, joined from the parent and the name', () => {
+    expect(contextFor(IMAGE).context.filePath).toBe('Media/photo.jpg');
+  });
+
+  it('a copy of the item, not the listing’s own object', () => {
+    const { context } = contextFor(IMAGE);
+
+    expect(context.item).not.toBe(IMAGE);
+    expect(context.item).toEqual(IMAGE);
+  });
+
+  it('a place to keep state a lifecycle hook will need later', () => {
+    expect(contextFor(IMAGE).context.previewState).toEqual({});
+  });
+});
+
+describe('the api handed to a plugin', () => {
+  const apiFor = (item = IMAGE) => {
+    const manager = usePreviewManager();
+    let api = null;
+    manager.register(
+      plugin('spy', {
+        match: (context) => {
+          api = context.api;
+          return true;
+        },
+      })
+    );
+    manager.open(item);
+    return { manager, api };
+  };
+
+  it('builds a preview url for the file', () => {
+    apiFor().api.getPreviewUrl();
+
+    expect(getPreviewUrl).toHaveBeenCalledWith('Media/photo.jpg');
+  });
+
+  it('builds one for a neighbour when a gallery asks', () => {
+    apiFor().api.getPreviewUrl({ name: 'other.jpg', path: 'Media' });
+
+    expect(getPreviewUrl).toHaveBeenLastCalledWith('Media/other.jpg');
+  });
+
+  it('hands back the folder’s items so a gallery can step through them', () => {
+    currentPathItems = [IMAGE, { name: 'b.jpg', path: 'Media' }];
+
+    expect(apiFor().api.getSiblings()).toHaveLength(2);
+  });
+
+  /** `#` in a filename is a fragment unless every segment is encoded. */
+  it('encodes each path segment when routing to the editor', () => {
+    apiFor({ name: 'notes #1.md', path: 'Docs/My Folder' }).api.openEditor();
+
+    expect(routerPush).toHaveBeenCalledWith({
+      path: '/editor/Docs/My%20Folder/notes%20%231.md',
+    });
+  });
+
+  it('closes the preview through the same door as everything else', async () => {
+    const { manager, api } = apiFor();
+
+    await api.close();
+
+    expect(manager.isOpen).toBe(false);
+  });
+});
+
+describe('opening and closing', () => {
+  it('runs the open hook, and survives it throwing', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const manager = usePreviewManager();
+    manager.register(
+      plugin('image', {
+        onOpen: () => {
+          throw new Error('hook exploded');
+        },
+      })
+    );
+
+    expect(manager.open(IMAGE)).toBe(true);
+    expect(manager.isOpen).toBe(true);
+    vi.restoreAllMocks();
+  });
+
+  it('waits for the hook a plugin uses to flush unsaved work', async () => {
+    const manager = usePreviewManager();
+    let flushed = false;
+    manager.register(
+      plugin('office', {
+        onBeforeClose: async () => {
+          await Promise.resolve();
+          flushed = true;
+        },
+      })
+    );
+    manager.open(IMAGE);
+
+    await manager.close();
+
+    expect(flushed).toBe(true);
+    expect(manager.isOpen).toBe(false);
+  });
+
+  /** A preview that cannot be closed is a trapped user. */
+  it('closes anyway when that hook rejects', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const manager = usePreviewManager();
+    manager.register(plugin('office', { onBeforeClose: () => Promise.reject(new Error('no')) }));
+    manager.open(IMAGE);
+
+    await manager.close();
+
+    expect(manager.isOpen).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  it('closes anyway when the close hook throws', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const manager = usePreviewManager();
+    manager.register(
+      plugin('image', {
+        onClose: () => {
+          throw new Error('boom');
+        },
+      })
+    );
+    manager.open(IMAGE);
+
+    await manager.close();
+
+    expect(manager.isOpen).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * The race this exists for: somebody closes a document, the flush is still in
+   * flight, and they open the next file. When the flush finishes it must not
+   * close what they are now looking at.
+   */
+  it('does not close a preview opened while the previous one was still closing', async () => {
+    const manager = usePreviewManager();
+    let release;
+    manager.register(
+      plugin('office', {
+        priority: 5,
+        match: (c) => c.extension === 'docx',
+        onBeforeClose: () => new Promise((resolve) => (release = resolve)),
+      })
+    );
+    manager.register(plugin('image', { priority: 5, match: (c) => c.extension === 'jpg' }));
+
+    manager.open({ name: 'report.docx', path: 'Docs', kind: 'docx' });
+    const closing = manager.close();
+    manager.open(IMAGE);
+
+    release();
+    await closing;
+
+    expect(manager.isOpen).toBe(true);
+    expect(manager.activePlugin.id).toBe('image');
+  });
+
+  /**
+   * Closing twice — a click and the Escape key arriving together — must not run
+   * the flush hook twice. Pinia wraps actions, so the two calls do not return
+   * the identical promise; what matters is that the work happens once.
+   */
+  it('runs the close hooks once when close is called twice', async () => {
+    const manager = usePreviewManager();
+    const beforeClose = vi.fn(() => Promise.resolve());
+    const onClose = vi.fn();
+    manager.register(plugin('office', { onBeforeClose: beforeClose, onClose }));
+    manager.open(IMAGE);
+
+    await Promise.all([manager.close(), manager.close()]);
+
+    expect(beforeClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closing when nothing is open is harmless', () => {
+    const manager = usePreviewManager();
+
+    expect(() => manager.close()).not.toThrow();
+  });
+});

--- a/frontend/src/plugins/preview/useMediaTracks.js
+++ b/frontend/src/plugins/preview/useMediaTracks.js
@@ -1,0 +1,118 @@
+import { ref, computed, watch } from 'vue';
+
+/**
+ * What a media file contains, and what this browser will do with it.
+ *
+ * The player hands files to a `<video>` element and never transcodes — that is
+ * a media server's job. The consequence is invisible from the outside: a film
+ * whose only soundtrack is AC-3 plays perfectly, in silence, and nothing says
+ * why. This asks the server what is in the file so the interface can say it.
+ *
+ * @param {import('vue').Ref} media the media item currently on screen
+ * @param {object} api the preview plugin API
+ * @param {import('vue').Ref<boolean>} enabled whether this item is a video at all
+ */
+export function useMediaTracks(media, api, enabled) {
+  const tracks = ref(null);
+
+  // Responses can arrive after the person has moved to the next video. Each
+  // request carries the key it was made for, and a stale one is dropped rather
+  // than shown against the wrong file.
+  let pending = null;
+
+  const load = async (current) => {
+    tracks.value = null;
+    if (!current || !enabled.value || typeof api.getMediaTracks !== 'function') return;
+
+    const token = current.key;
+    pending = token;
+    let result = null;
+    try {
+      result = await api.getMediaTracks(current.item);
+    } catch (_) {
+      result = null;
+    }
+    if (pending !== token) return;
+    tracks.value = result?.available ? result : null;
+  };
+
+  watch(media, (current) => load(current), { immediate: true });
+
+  /**
+   * The subtitle tracks a `<track>` element can actually show.
+   *
+   * Image-based subtitles — a Blu-ray's PGS, a DVD's VobSub — are pictures of
+   * words and would need OCR, so they are dropped here rather than offered as
+   * captions that never appear.
+   */
+  const subtitleTracks = computed(() => {
+    const list = tracks.value?.subtitles || [];
+    return list
+      .filter((track) => track.convertible)
+      .map((track) => ({
+        ...track,
+        url: api.getSubtitleUrl?.(media.value?.item, {
+          stream: track.source === 'embedded' ? track.index : undefined,
+          file: track.source === 'sidecar' ? track.fileName : undefined,
+        }),
+      }))
+      .filter((track) => track.url);
+  });
+
+  const audioTracks = computed(() => tracks.value?.audio || []);
+
+  /**
+   * The picture itself is one this browser will not decode.
+   *
+   * HEVC is the case that matters: a browser plays it only from an MP4, only
+   * with hardware support, and never in ten-bit — so an `x265.10bit.HEVC.mkv`
+   * shows nothing at all. That is a different sentence from a silent film and
+   * it takes precedence over it, because there is no point explaining the
+   * sound of something that is not playing.
+   */
+  const hasUnplayableVideo = computed(() => {
+    const streams = tracks.value?.video || [];
+    return streams.length > 0 && !streams.some((stream) => stream.playable);
+  });
+
+  const unplayableVideoCodecs = computed(() => [
+    ...new Set((tracks.value?.video || []).map((stream) => stream.codec)),
+  ]);
+
+  /** Soundtracks exist, and this browser can decode none of them. */
+  const hasUnplayableAudio = computed(
+    () => Boolean(tracks.value) && tracks.value.hasAudio && !tracks.value.hasPlayableAudio
+  );
+
+  /** The codecs to name in that message, each once. */
+  const unplayableCodecs = computed(() => [
+    ...new Set(audioTracks.value.filter((track) => !track.playable).map((track) => track.codec)),
+  ]);
+
+  return {
+    tracks,
+    subtitleTracks,
+    audioTracks,
+    hasUnplayableAudio,
+    unplayableCodecs,
+    hasUnplayableVideo,
+    unplayableVideoCodecs,
+  };
+}
+
+/**
+ * A language's name in the reader's own language.
+ *
+ * The file says `fr`; a caption menu should say "français" to a French reader
+ * and "French" to an English one. `Intl.DisplayNames` does exactly this, and
+ * anything it cannot name falls back to the tag itself, which is still more
+ * use than nothing.
+ */
+export function languageName(tag, locale) {
+  if (!tag) return '';
+  try {
+    return new Intl.DisplayNames([locale || 'en'], { type: 'language' }).of(tag) || tag;
+  } catch (_) {
+    return tag;
+  }
+}

--- a/frontend/src/plugins/preview/useMediaZoom.js
+++ b/frontend/src/plugins/preview/useMediaZoom.js
@@ -1,0 +1,106 @@
+import { computed, reactive, ref } from 'vue';
+
+/**
+ * Zooming into a picture, and moving around inside it once you have.
+ *
+ * The gallery this belongs to navigates by swiping, which is what people asked
+ * for — the old viewer dragged the image around instead, and that was the
+ * complaint. Both gestures are a finger moving across a picture, so they cannot
+ * both be live at once. The rule here is the one Photos and Google Photos use,
+ * and it is the whole point of this file: at natural size a drag belongs to the
+ * gallery, and only once the picture is zoomed does it move the picture.
+ *
+ * Panning is bounded, because a picture dragged off-screen with no way back is
+ * worse than one that will not move.
+ */
+
+const MAX_SCALE = 4;
+const MIN_SCALE = 1;
+const DOUBLE_TAP_SCALE = 2.5;
+
+// Below this, floating-point drift from a pinch would leave a picture
+// "zoomed" at 1.0001 and quietly swallow every swipe.
+const ZOOMED_EPSILON = 0.01;
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+export function useMediaZoom({ maxScale = MAX_SCALE, doubleTapScale = DOUBLE_TAP_SCALE } = {}) {
+  const scale = ref(MIN_SCALE);
+  const offset = reactive({ x: 0, y: 0 });
+
+  const isZoomed = computed(() => scale.value > MIN_SCALE + ZOOMED_EPSILON);
+
+  const reset = () => {
+    scale.value = MIN_SCALE;
+    offset.x = 0;
+    offset.y = 0;
+  };
+
+  /**
+   * Keep the picture overlapping its frame.
+   *
+   * At scale s, the picture overflows its frame by (s-1)/2 of the frame on each
+   * side; allowing more than that would drag it into empty space.
+   */
+  const clampOffset = (bounds) => {
+    const width = Number(bounds?.width) || 0;
+    const height = Number(bounds?.height) || 0;
+    const limitX = (width * (scale.value - 1)) / 2;
+    const limitY = (height * (scale.value - 1)) / 2;
+
+    offset.x = clamp(offset.x, -limitX, limitX);
+    offset.y = clamp(offset.y, -limitY, limitY);
+  };
+
+  const zoomTo = (next, bounds) => {
+    scale.value = clamp(Number(next) || MIN_SCALE, MIN_SCALE, maxScale);
+    if (!isZoomed.value) {
+      // Back to natural size: centred again, and swipes belong to the gallery.
+      offset.x = 0;
+      offset.y = 0;
+      return;
+    }
+    clampOffset(bounds);
+  };
+
+  /** Zoom by a factor — what a pinch and a wheel both produce. */
+  const zoomBy = (factor, bounds) => {
+    const multiplier = Number(factor);
+    if (!Number.isFinite(multiplier) || multiplier <= 0) return;
+    zoomTo(scale.value * multiplier, bounds);
+  };
+
+  /** Double tap: all the way in, or all the way back out. */
+  const toggle = (bounds) => {
+    if (isZoomed.value) {
+      reset();
+      return;
+    }
+    zoomTo(doubleTapScale, bounds);
+  };
+
+  /** Move within the picture. Does nothing at natural size, by design. */
+  const panBy = (deltaX, deltaY, bounds) => {
+    if (!isZoomed.value) return;
+    offset.x += Number(deltaX) || 0;
+    offset.y += Number(deltaY) || 0;
+    clampOffset(bounds);
+  };
+
+  const transform = computed(() =>
+    isZoomed.value ? `translate(${offset.x}px, ${offset.y}px) scale(${scale.value})` : 'none'
+  );
+
+  return {
+    scale,
+    offset,
+    isZoomed,
+    reset,
+    zoomTo,
+    zoomBy,
+    toggle,
+    panBy,
+    transform,
+    maxScale,
+  };
+}

--- a/frontend/src/plugins/preview/useMediaZoom.spec.js
+++ b/frontend/src/plugins/preview/useMediaZoom.spec.js
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { useMediaZoom } from './useMediaZoom';
+
+/**
+ * The rule that lets swiping and zooming share one finger.
+ *
+ * The gallery navigates by dragging, and the old viewer moved the picture
+ * around instead — which is what people complained about. Both gestures are the
+ * same movement, so what decides between them is whether the picture is zoomed.
+ * Everything here is about that boundary being exact: a picture that stays
+ * fractionally zoomed after a pinch would swallow every swipe, and one that can
+ * be dragged off-screen has no way back.
+ */
+
+const frame = { width: 1000, height: 800 };
+
+describe('useMediaZoom', () => {
+  it('starts at natural size, where drags belong to the gallery', () => {
+    const zoom = useMediaZoom();
+
+    expect(zoom.scale.value).toBe(1);
+    expect(zoom.isZoomed.value).toBe(false);
+    expect(zoom.transform.value).toBe('none');
+  });
+
+  it('refuses to pan at natural size, so a swipe stays a swipe', () => {
+    const zoom = useMediaZoom();
+
+    zoom.panBy(120, 40, frame);
+
+    expect(zoom.offset.x).toBe(0);
+    expect(zoom.offset.y).toBe(0);
+  });
+
+  it('pans once zoomed', () => {
+    const zoom = useMediaZoom();
+    zoom.zoomTo(2, frame);
+
+    zoom.panBy(100, 50, frame);
+
+    expect(zoom.offset.x).toBe(100);
+    expect(zoom.offset.y).toBe(50);
+  });
+
+  it('does not let the picture be dragged out of its frame', () => {
+    // At 2x the picture overflows by half the frame on each side; further than
+    // that is empty space, and a picture lost there cannot be brought back.
+    const zoom = useMediaZoom();
+    zoom.zoomTo(2, frame);
+
+    zoom.panBy(5000, 5000, frame);
+
+    expect(zoom.offset.x).toBe(500);
+    expect(zoom.offset.y).toBe(400);
+  });
+
+  it('treats a pinch that lands just above 1 as not zoomed', () => {
+    // Fingers never return a picture to exactly 1.0. Left alone, a scale of
+    // 1.001 would keep every later swipe from navigating.
+    const zoom = useMediaZoom();
+
+    zoom.zoomTo(1.001, frame);
+
+    expect(zoom.isZoomed.value).toBe(false);
+    expect(zoom.transform.value).toBe('none');
+  });
+
+  it('recentres the picture when it comes back to natural size', () => {
+    const zoom = useMediaZoom();
+    zoom.zoomTo(3, frame);
+    zoom.panBy(200, 100, frame);
+
+    zoom.zoomTo(1, frame);
+
+    expect(zoom.offset.x).toBe(0);
+    expect(zoom.offset.y).toBe(0);
+  });
+
+  it('pulls the picture back into frame when zooming out', () => {
+    // Panned to the edge at 4x, the same offset is off-screen at 1.5x.
+    const zoom = useMediaZoom();
+    zoom.zoomTo(4, frame);
+    zoom.panBy(1500, 1200, frame);
+    expect(zoom.offset.x).toBe(1500);
+
+    zoom.zoomTo(1.5, frame);
+
+    expect(zoom.offset.x).toBe(250);
+    expect(zoom.offset.y).toBe(200);
+  });
+
+  it('stops at the maximum, however hard the pinch', () => {
+    const zoom = useMediaZoom({ maxScale: 4 });
+
+    zoom.zoomBy(100, frame);
+
+    expect(zoom.scale.value).toBe(4);
+  });
+
+  it('never goes below natural size', () => {
+    // Pinching out on an unzoomed picture must not shrink it into the frame.
+    const zoom = useMediaZoom();
+
+    zoom.zoomBy(0.2, frame);
+
+    expect(zoom.scale.value).toBe(1);
+    expect(zoom.isZoomed.value).toBe(false);
+  });
+
+  it('toggles all the way in and all the way back out', () => {
+    const zoom = useMediaZoom({ doubleTapScale: 2.5 });
+
+    zoom.toggle(frame);
+    expect(zoom.scale.value).toBe(2.5);
+
+    zoom.toggle(frame);
+    expect(zoom.scale.value).toBe(1);
+    expect(zoom.offset.x).toBe(0);
+  });
+
+  it('ignores a factor that is not a usable number', () => {
+    const zoom = useMediaZoom();
+    zoom.zoomTo(2, frame);
+
+    zoom.zoomBy(Number.NaN, frame);
+    zoom.zoomBy(0, frame);
+    zoom.zoomBy(-1, frame);
+
+    expect(zoom.scale.value).toBe(2);
+  });
+
+  it('survives being panned without a frame to measure against', () => {
+    // The element may not be laid out yet when the first gesture arrives.
+    const zoom = useMediaZoom();
+    zoom.zoomTo(2, null);
+
+    zoom.panBy(100, 100, null);
+
+    expect(zoom.offset.x).toBe(0);
+    expect(zoom.offset.y).toBe(0);
+  });
+
+  it('describes itself as a transform only while zoomed', () => {
+    const zoom = useMediaZoom();
+    zoom.zoomTo(2, frame);
+    zoom.panBy(10, 20, frame);
+
+    expect(zoom.transform.value).toBe('translate(10px, 20px) scale(2)');
+
+    zoom.reset();
+    expect(zoom.transform.value).toBe('none');
+  });
+});


### PR DESCRIPTION
Batch 4 of #373. Rebased onto `main` at `a50f6e1` (which includes #375 and #376), so it should merge clean.

**~1 100 lines of code, ~1 900 of tests. 114 tests, all passing.**

## The problem

Playback hands the file to the browser and never transcodes — that is a media server's job, not a file explorer's. The limit is right; it was **invisible**.

A film whose soundtrack is AC-3, E-AC-3, DTS or TrueHD plays perfectly with **no sound at all** in Chrome or Firefox, because neither will decode those — a licensing decision, not a technical one. Nothing on screen said so. The only conclusion available to the person watching was that the file was broken, or that we were.

## What it does

**Names what the browser will refuse.** The player reads what the container holds and says which parts cannot be decoded, for the soundtrack and the picture alike. For a ten-bit HEVC file that is the more useful sentence, since nothing was going to appear at all. Safari decodes AC-3, so this is reported rather than asserted.

**Offers the subtitles.** Text tracks inside the file, and subtitle files sitting beside it — `film.srt`, `film.fr.srt`, `film.en.forced.srt` — converted to WebVTT on demand and listed in the browser's own captions menu. Language tags go through `Intl.getCanonicalLocales`, so `fre` and `fra` stop showing up as two separate French entries. Blu-ray and DVD subtitles are pictures of words: they are listed as unconvertible rather than offered as captions that would show nothing. Turning those into text needs OCR, which is a different project.

**Bounded**, because extraction spawns ffmpeg: a timeout, a size ceiling, and one stream mapped rather than the file re-encoded.

## Two things worth flagging

**The zoom and gallery navigation come with it.** Pinch, double-tap and ctrl-wheel zoom, and arrow-key navigation between pictures and videos, landed in the same component as the track handling. Separating them would have meant hand-writing a version of `MediaPreview.vue` that never ran anywhere, which seemed worse than a slightly wider PR. Say the word if you would rather have them apart and I will do the work.

**`heldRequests` arrives whole.** The media route marks subtitle extraction as a long poll, because it legitimately takes several seconds. Only `markLongPoll` is used here; the logger half is wired by a later batch and is inert until then.

## Tests

114 pass — 42 backend, 72 frontend. The 15 pre-existing failures on `main` are unchanged and none is new.