### PR TITLE
[5/14] Search index: answer from an index rather than by reading the tree

### DIFF
--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -73,6 +73,14 @@ module.exports = {
   MAX_EXTRACTED_ARCHIVE_SIZE: process.env.MAX_EXTRACTED_ARCHIVE_SIZE?.trim() || null,
   MAX_ARCHIVE_ENTRIES: Number(process.env.MAX_ARCHIVE_ENTRIES) || 100000,
   ARCHIVE_EXTENSIONS: process.env.ARCHIVE_EXTENSIONS || '',
+  // --- Search index ---
+  SEARCH_INDEX: normalizeBoolean(process.env.SEARCH_INDEX) ?? false,
+  SEARCH_INDEX_BATCH: Number(process.env.SEARCH_INDEX_BATCH) || null,
+  SEARCH_INDEX_CPU_PERCENT: Number(process.env.SEARCH_INDEX_CPU_PERCENT) || null,
+  SEARCH_INDEX_MEMORY_MB: Number(process.env.SEARCH_INDEX_MEMORY_MB) || null,
+  SEARCH_INDEX_EXCLUDE: process.env.SEARCH_INDEX_EXCLUDE?.trim() || null,
+  SEARCH_INDEX_REBUILD: normalizeBoolean(process.env.SEARCH_INDEX_REBUILD) ?? false,
+  SEARCH_INDEX_RECONCILE_MS: Number(process.env.SEARCH_INDEX_RECONCILE_MS) || null,
   SEARCH_TIMEOUT_MS: Number(process.env.SEARCH_TIMEOUT_MS) || null,
   SEARCH_MAX_FILESIZE: process.env.SEARCH_MAX_FILESIZE?.trim() || null,
 

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -429,6 +429,62 @@ module.exports = {
       Number.isFinite(env.SEARCH_TIMEOUT_MS) && env.SEARCH_TIMEOUT_MS > 0
         ? env.SEARCH_TIMEOUT_MS
         : 5000,
+    index: {
+      // Off unless asked for: an index is a promise to keep something up to
+      // date, and that is a decision rather than a default.
+      enabled: env.SEARCH_INDEX === true,
+      // Throw the index away at startup and read everything again. For when
+      // the index is suspected rather than trusted: it is derived data, so
+      // there is nothing in it that the files themselves do not say.
+      rebuild: env.SEARCH_INDEX_REBUILD === true,
+      // How many documents share one transaction. Small on purpose: a long
+      // transaction is a long stretch of the only thread the server has.
+      batch:
+        Number.isFinite(env.SEARCH_INDEX_BATCH) && env.SEARCH_INDEX_BATCH > 0
+          ? Math.floor(env.SEARCH_INDEX_BATCH)
+          : 25,
+      // The share of one core a pass may take. This replaces a pause counted
+      // per batch, which paced nothing: the cost of a batch is the cost of the
+      // files in it, and a fixed pause after an unbounded amount of work is
+      // not a limit on anything. A share of time is.
+      cpuPercent:
+        Number.isFinite(env.SEARCH_INDEX_CPU_PERCENT) &&
+        env.SEARCH_INDEX_CPU_PERCENT > 0 &&
+        env.SEARCH_INDEX_CPU_PERCENT <= 100
+          ? env.SEARCH_INDEX_CPU_PERCENT
+          : 25,
+      // Folders the index has no business reading. The volume is the user's,
+      // and what is worth searching in it is theirs to say: a build tree, a
+      // mail spool, a backup of a machine — hundreds of thousands of files
+      // each, none of them anything anyone searches for by content.
+      //
+      // Named rather than guessed at. A list of "obviously noise" directories
+      // baked in here would decide, for everyone, that something is not worth
+      // finding — and with the index answering in place of the live scan, that
+      // decision would be invisible.
+      exclude: String(env.SEARCH_INDEX_EXCLUDE || '')
+        .split(/[\n,]/)
+        .map((entry) => entry.trim().replace(/^\/+|\/+$/g, ''))
+        .filter(Boolean),
+      // What a pass may add to the process before it gives up and waits for
+      // the next one. Every other bound is a belief about what a file costs;
+      // this is what holds when one of those beliefs is wrong.
+      //
+      // Only consulted when the container enforces no limit of its own; where
+      // it does, that limit is the ceiling and this is ignored. A pass over
+      // two hundred thousand documents was measured growing sixty megabytes,
+      // but the figure this is compared against is the whole process, so it
+      // has to leave room for everything else that runs during the twenty-odd
+      // minutes a pass takes.
+      memoryBudgetBytes:
+        Number.isFinite(env.SEARCH_INDEX_MEMORY_MB) && env.SEARCH_INDEX_MEMORY_MB > 0
+          ? env.SEARCH_INDEX_MEMORY_MB * 1024 * 1024
+          : 256 * 1024 * 1024,
+      reconcileMs:
+        Number.isFinite(env.SEARCH_INDEX_RECONCILE_MS) && env.SEARCH_INDEX_RECONCILE_MS > 0
+          ? env.SEARCH_INDEX_RECONCILE_MS
+          : 60 * 60 * 1000,
+    },
   },
 
   thumbnails: { size: 200, quality: 70 },

--- a/backend/src/routes/search.js
+++ b/backend/src/routes/search.js
@@ -6,7 +6,12 @@ const readline = require('readline');
 
 const { normalizeRelativePath } = require('../utils/pathUtils');
 const { pathExists } = require('../utils/fsUtils');
-const { excludedFiles, hiddenFiles, search: searchConfig } = require('../config/index');
+const {
+  excludedFiles,
+  hiddenFiles,
+  search: searchConfig,
+  directories,
+} = require('../config/index');
 const { resolvePathWithAccess, getAccessInfo } = require('../services/accessManager');
 const asyncHandler = require('../utils/asyncHandler');
 const { ValidationError, NotFoundError, ForbiddenError } = require('../errors/AppError');
@@ -17,10 +22,13 @@ const {
   isSearchableDocument,
   SEARCHABLE_EXTENSIONS: DOCUMENT_EXTENSIONS,
 } = require('../services/documentText');
+const searchIndexStore = require('../services/searchIndexStore');
 const { collectResults, buildPage } = require('../services/searchCollector');
 const { parseSearchTerm } = require('../services/searchTerm');
 const { ripgrepIgnoreGlobs, isIgnoredDirectory } = require('../services/searchIgnore');
 const { whenClientDisconnects } = require('../utils/clientDisconnect');
+const searchIndexExclusions = require('../services/searchIndexExclusions');
+const { getDb } = require('../services/db');
 const logger = require('../utils/logger');
 const { getSettings, getUserSettings } = require('../services/settingsService');
 
@@ -143,7 +151,13 @@ const buildRipgrepArgs = (includeHiddenFiles = false, relBasePath = '') => [
  * Reading the list every time rather than once: an administrator changing it
  * in Settings expects the next search to obey, not the next restart.
  */
-const excludedSearchPaths = () => [];
+const excludedSearchPaths = () => {
+  try {
+    return searchIndexExclusions.effectivePaths();
+  } catch {
+    return [];
+  }
+};
 
 const normalizePath = (p, relBasePath) => {
   const normalized = p.replace(/\\/g, '/');
@@ -412,6 +426,69 @@ async function* mergeResults(...generators) {
 }
 
 /**
+ * Matches the index already knows about.
+ *
+ * It stores terms and not text, so the line to show is read back from the file
+ * — which costs one read per result rather than one per document, and only for
+ * the handful actually returned. That is the whole bargain of a contentless
+ * index, and it is a good one.
+ *
+ * It covers the volume root. A search based anywhere else — a personal folder,
+ * an assigned volume — falls back to reading as it goes, because the index
+ * does not hold those.
+ */
+async function* streamIndexMatches(relBasePath, term, seenPaths, shouldInclude, limit) {
+  let paths;
+  try {
+    const db = await getDb();
+    // Over-fetch: permissions are applied after the query, since the index
+    // does not know who may read what.
+    paths = searchIndexStore.search(db, term, Math.max(limit * 3, 50));
+  } catch (error) {
+    logger.debug({ err: error }, 'Search index query failed; falling back to reading as we go');
+    return;
+  }
+
+  const needle = term.toLowerCase();
+  const prefix = relBasePath ? `${relBasePath}/` : '';
+
+  for (const rel of paths) {
+    if (prefix && !rel.startsWith(prefix) && rel !== relBasePath) continue;
+    if (seenPaths.has(rel)) continue;
+
+    const absolutePath = path.join(directories.volume, rel);
+    let line = '';
+    let lineNumber = null;
+
+    if (isSearchableDocument(absolutePath)) {
+      // eslint-disable-next-line no-await-in-loop
+      const match = await findDocumentTextMatch(absolutePath, needle);
+      if (match) {
+        line = match.line;
+        lineNumber = match.lineNumber;
+      }
+    } else {
+      // eslint-disable-next-line no-await-in-loop
+      const match = await findPlainTextMatch(absolutePath, needle);
+      if (match) {
+        line = match.line;
+        lineNumber = match.lineNumber;
+      }
+    }
+
+    // The file changed since it was indexed and no longer says this. The next
+    // pass will notice; this one simply does not offer it.
+    if (!lineNumber) continue;
+
+    seenPaths.add(rel);
+    // eslint-disable-next-line no-await-in-loop
+    if (await shouldInclude(rel)) {
+      yield formatResult(rel, 'file', line, lineNumber);
+    }
+  }
+}
+
+/**
  * Matches inside documents whose text has to be extracted first.
  *
  * Office files are zip archives and PDFs are compressed streams, so ripgrep
@@ -495,7 +572,7 @@ async function* generateRipgrepResults(
   shouldInclude,
   deep = true,
   includeHiddenFiles = false,
-  { onContentSources, onContentSourceDone } = {}
+  { useIndex = false, limit = 100, onContentSources, onContentSourceDone } = {}
 ) {
   const matcher = parseSearchTerm(term);
   const seenPaths = new Set();
@@ -524,14 +601,18 @@ async function* generateRipgrepResults(
     shouldInclude,
     includeHiddenFiles
   );
-  const contentGen = streamContentMatches(
-    baseAbsPath,
-    relBasePath,
-    term,
-    seenPaths,
-    shouldInclude,
-    includeHiddenFiles
-  );
+  // With an index in place the live content scan is not run at all: doing both
+  // would be exactly the cost an index exists to remove.
+  const contentGen = useIndex
+    ? streamIndexMatches(relBasePath, term, seenPaths, shouldInclude, limit)
+    : streamContentMatches(
+        baseAbsPath,
+        relBasePath,
+        term,
+        seenPaths,
+        shouldInclude,
+        includeHiddenFiles
+      );
 
   const documentGen = streamDocumentMatches(
     baseAbsPath,
@@ -542,6 +623,8 @@ async function* generateRipgrepResults(
     includeHiddenFiles
   );
 
+  // The document pass reads Office files and PDFs one by one; the index has
+  // already read them.
   //
   // The content sources announce their own exhaustion, because the collector
   // has to know when a reserve it is holding the page open for can no longer
@@ -550,7 +633,11 @@ async function* generateRipgrepResults(
   // A wildcard term describes filenames and nothing else: no file contains
   // the characters `*.ps1`, so reading the tree for them costs the whole
   // budget to return files that merely mention the pattern in their text.
-  const contentSources = !matcher.readsFileContents ? [] : [contentGen, documentGen];
+  const contentSources = !matcher.readsFileContents
+    ? []
+    : useIndex
+      ? [contentGen]
+      : [contentGen, documentGen];
   if (!matcher.readsFileContents) {
     await contentGen.return?.();
     await documentGen.return?.();
@@ -570,7 +657,8 @@ async function* generateFallbackResults(
   term,
   shouldInclude,
   deep = true,
-  includeHiddenFiles = false
+  includeHiddenFiles = false,
+  { useIndex = false, limit = 100 } = {}
 ) {
   const seenPaths = new Set();
   const matcher = parseSearchTerm(term);
@@ -638,6 +726,16 @@ async function* generateFallbackResults(
       }
     }
   };
+
+  // With an index in place the walk stops reading files: it looks at names,
+  // and the index answers for what is inside them.
+  if (useIndex && !matcher.isGlob) {
+    yield* mergeResults(
+      walk(baseAbsPath, relBasePath),
+      streamIndexMatches(relBasePath, term, seenPaths, shouldInclude, limit)
+    );
+    return;
+  }
 
   yield* walk(baseAbsPath, relBasePath);
 }
@@ -717,6 +815,16 @@ router.get(
     // answers with the part of the volume it happens to have read — a term
     // found yesterday goes missing today, with nothing in the answer to say
     // why. Reading the tree meanwhile is slower and right.
+    const indexReady = await (async () => {
+      if (!(deepEnabled && searchConfig?.index?.enabled === true)) return false;
+      try {
+        return searchIndexStore.isReady(await getDb());
+      } catch {
+        return false;
+      }
+    })();
+
+    const useIndex = indexReady && baseAbs.startsWith(directories.volume);
 
     // Nothing can produce a content match once every content source has
     // finished, and that is the moment a reserve stops being worth waiting for.
@@ -731,6 +839,7 @@ router.get(
           deepEnabled,
           includeHiddenFiles,
           {
+            useIndex,
             limit,
             onContentSources: (count) => {
               contentSourcesLeft = count;
@@ -744,9 +853,12 @@ router.get(
           baseAbs,
           relBase,
           q,
+          // With an index the walk does not read files; the index answers for
+          // their contents.
           shouldInclude,
-          deepEnabled,
-          includeHiddenFiles
+          deepEnabled && !useIndex,
+          includeHiddenFiles,
+          { useIndex, limit }
         );
 
     // Counted apart and only put together at the end: sharing one running

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -8,6 +8,7 @@ const { port, http, features, address } = require('./config/index');
 const logger = require('./utils/logger');
 const { printStartupBanner } = require('./utils/startupBanner');
 const terminalService = require('./services/terminalService');
+const searchIndexManager = require('./services/searchIndexManager');
 
 let server = null;
 
@@ -45,10 +46,15 @@ const startServer = async () => {
     logger.warn('Terminal disabled at runtime');
   }
 
+  // Deliberately not awaited: a server does not wait for its index to be
+  // ready, it answers from the live search until it is.
+  searchIndexManager.start();
+
   // Cleanup on process termination
   const cleanup = () => {
     logger.info('Shutting down server...');
     terminalService.cleanup();
+    searchIndexManager.stop();
     server.close(() => {
       logger.info('Server closed');
       process.exit(0);

--- a/backend/src/services/db.js
+++ b/backend/src/services/db.js
@@ -353,6 +353,16 @@ const migrate = (db) => {
       );
       version = 8;
     }
+    if (version < 9) {
+      logger.info('[DB Migration] Migrating to v9: Full-text search index...');
+      // eslint-disable-next-line global-require
+      db.exec(require('./searchIndexStore').SEARCH_INDEX_DDL);
+      db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run(
+        'schema_version',
+        String(9)
+      );
+      version = 9;
+    }
   })();
 };
 

--- a/backend/src/services/pathExclusions.js
+++ b/backend/src/services/pathExclusions.js
@@ -1,0 +1,114 @@
+const path = require('path');
+
+const { normalizeRelativePath } = require('../utils/pathUtils');
+
+/**
+ * Two lists of folders a background pass should leave alone.
+ *
+ * One comes from the environment and the interface cannot touch it: an
+ * operator who wrote a path into their compose file did not mean it to be
+ * removable by anyone who can reach Settings. The other belongs to whoever
+ * administers the instance, is kept in the database, and is edited from a
+ * settings page.
+ *
+ * Written once because it was written twice. The folder-size index and the
+ * search index each had their own copy — eighty-two per cent identical, and
+ * differing only in which setting they read and which environment variable
+ * feeds them. Two copies of a rule about what may be excluded is two places
+ * for it to drift, and a difference nobody chose.
+ *
+ * Each caller gets its own state: the factory closes over `adminPaths` rather
+ * than sharing a module-level one, so the two indexes cannot overwrite each
+ * other's list.
+ */
+
+const unique = (paths) => [...new Set(paths)].sort((left, right) => left.localeCompare(right));
+
+const sanitizePaths = (value) => {
+  const values = Array.isArray(value)
+    ? value
+    : String(value || '')
+        .split(/[\n,]/)
+        .map((item) => item.trim());
+
+  return unique(
+    values
+      .filter((item) => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .map((item) => normalizeRelativePath(item))
+      .filter(Boolean)
+  );
+};
+
+/**
+ * @param {object} options
+ * @param {string} options.settingsCategory   where the admin list is stored
+ * @param {string} options.settingsKey        and under which key
+ * @param {() => unknown} options.readEnvironmentPaths  the environment's list,
+ *   read on every call rather than captured, so a test that rebuilds the
+ *   configuration is seen without rebuilding this too
+ */
+const createPathExclusions = ({ settingsCategory, settingsKey, readEnvironmentPaths }) => {
+  let adminPaths = [];
+
+  const environmentPaths = () => sanitizePaths(readEnvironmentPaths());
+  const effectivePaths = () => unique([...environmentPaths(), ...adminPaths]);
+
+  const loadFromDatabase = (db) => {
+    const row = db
+      .prepare('SELECT value FROM system_settings WHERE category = ? AND key = ?')
+      .get(settingsCategory, settingsKey);
+    if (!row) {
+      adminPaths = [];
+      return adminPaths;
+    }
+    try {
+      adminPaths = sanitizePaths(JSON.parse(row.value)?.excludedPaths || []);
+    } catch {
+      adminPaths = [];
+    }
+    return adminPaths;
+  };
+
+  const setAdminPaths = (paths) => {
+    const previous = effectivePaths();
+    const environment = environmentPaths();
+    adminPaths = sanitizePaths(paths).filter((value) => !environment.includes(value));
+    const next = effectivePaths();
+    return {
+      excludedPaths: adminPaths,
+      environmentExcludedPaths: environmentPaths(),
+      added: next.filter((value) => !previous.includes(value)),
+      removed: previous.filter((value) => !next.includes(value)),
+    };
+  };
+
+  /** Whether an absolute path sits at or under one of the excluded folders. */
+  const isExcluded = (absolutePath, scope) => {
+    if (!absolutePath || !scope?.root) return false;
+    const candidate = path.resolve(absolutePath);
+    return effectivePaths().some((relativePath) => {
+      const excluded = path.resolve(scope.root, relativePath);
+      return candidate === excluded || candidate.startsWith(`${excluded}${path.sep}`);
+    });
+  };
+
+  const snapshot = () => ({
+    excludedPaths: adminPaths,
+    environmentExcludedPaths: environmentPaths(),
+  });
+
+  return {
+    SETTINGS_CATEGORY: settingsCategory,
+    SETTINGS_KEY: settingsKey,
+    sanitizePaths,
+    loadFromDatabase,
+    setAdminPaths,
+    effectivePaths,
+    isExcluded,
+    snapshot,
+  };
+};
+
+module.exports = { createPathExclusions, sanitizePaths };

--- a/backend/src/services/searchIndexExclusions.js
+++ b/backend/src/services/searchIndexExclusions.js
@@ -1,0 +1,16 @@
+const config = require('../config');
+const { createPathExclusions } = require('./pathExclusions');
+
+/**
+ * Folders the search index has no business reading.
+ *
+ * Nothing is excluded by default. With the index answering in place of the
+ * live content scan, a folder left out is a folder that cannot be found by
+ * what is inside it — that decision belongs to whoever owns the volume, not to
+ * a list of names someone thought looked like noise.
+ */
+module.exports = createPathExclusions({
+  settingsCategory: 'system',
+  settingsKey: 'searchIndex',
+  readEnvironmentPaths: () => config.search?.index?.exclude || [],
+});

--- a/backend/src/services/searchIndexManager.js
+++ b/backend/src/services/searchIndexManager.js
@@ -1,0 +1,345 @@
+const path = require('path');
+
+const { search: searchConfig, directories } = require('../config/index');
+const { getDb } = require('./db');
+const store = require('./searchIndexStore');
+const exclusions = require('./searchIndexExclusions');
+const { indexTree, indexFile } = require('./searchIndexer');
+const logger = require('../utils/logger');
+
+/**
+ * When the index is built, and when it gets out of the way.
+ *
+ * One run at a time, abortable, and the abort is what shutdown uses: a walk
+ * still going when the process is asked to stop would either hold it open or
+ * be killed mid-transaction.
+ *
+ * Files change under the application as well as through it — an rsync, a
+ * network share, someone at the console — so an incremental update is not
+ * enough on its own. A periodic pass catches the rest, and it is the same walk
+ * as the first one: everything unchanged is skipped without being opened, so
+ * the cost of running it again is a stat per file.
+ *
+ * All of it goes through one worker, and that is the point rather than a
+ * detail. The per-file updates are announced by the application and were
+ * awaited by nobody, so copying a large folder started as many file reads as
+ * there were files, all at once, on top of whatever pass was already running.
+ * A background service gets one thread of work and a backlog with a bottom to
+ * it; when the backlog is full the update is dropped, because the periodic
+ * pass is exactly the thing that finds what was missed.
+ */
+
+let running = false;
+let stopped = false;
+let controller = null;
+let timer = null;
+
+/** How soon a pass that stopped on memory picks up where it left off. */
+const RESUME_AFTER_MEMORY_MS = 2 * 60 * 1000;
+
+/** The backlog of per-file work, and the single worker that drains it. */
+const MAX_PENDING_UPDATES = 1000;
+const pending = [];
+let draining = false;
+let dropped = 0;
+
+const drain = async () => {
+  if (draining) return;
+  draining = true;
+  try {
+    // `enqueue` already refuses work once the service is stopped, so this only
+    // catches a stop that lands while the loop is running: the backlog is
+    // abandoned rather than finished after shutdown was asked for.
+    while (pending.length > 0 && !stopped) {
+      const job = pending.shift();
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await job();
+      } catch (error) {
+        logger.debug({ err: error }, 'A search index update failed');
+      }
+    }
+  } finally {
+    draining = false;
+  }
+};
+
+const enqueue = (job) => {
+  // The one place that refuses new work after a stop. The callers used to
+  // check this themselves, which meant four copies of the rule and no way to
+  // tell from a test which of them held it.
+  if (stopped) return Promise.resolve();
+
+  if (pending.length >= MAX_PENDING_UPDATES) {
+    dropped += 1;
+    if (dropped === 1 || dropped % 1000 === 0) {
+      logger.info({ dropped }, 'Search index updates dropped; the next pass will catch them');
+    }
+    return Promise.resolve();
+  }
+  pending.push(job);
+  return drain();
+};
+
+const enabled = () => searchConfig?.index?.enabled === true;
+
+/** The path the index knows a file by, or null when it is outside its scope. */
+const relativeToVolume = (absolutePath) => {
+  if (!absolutePath) return null;
+
+  const relative = path.relative(directories.volume, absolutePath);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+};
+
+/**
+ * Replace the exclusions an administrator set, and act on what changed.
+ *
+ * A folder newly excluded is forgotten straight away rather than at the next
+ * pass: leaving its documents in the index would go on answering searches from
+ * a folder somebody just said not to read. A folder no longer excluded is
+ * simply picked up by the next pass, which is what a pass is for.
+ */
+const setAdminExclusions = async (paths) => {
+  const changed = exclusions.setAdminPaths(paths);
+  if (!enabled() || changed.added.length === 0) return { ...changed };
+
+  await enqueue(async () => {
+    const db = await getDb();
+    let removed = 0;
+    for (const relativePath of changed.added) removed += store.removeUnder(db, relativePath);
+    if (removed > 0) {
+      logger.info({ paths: changed.added, removed }, 'Search index forgot newly excluded folders');
+    }
+  });
+
+  return { ...changed };
+};
+
+/** A pass over the whole volume. Never throws, never overlaps another. */
+const reconcile = async ({ reason = 'scheduled' } = {}) => {
+  if (!enabled() || running || stopped) return null;
+
+  running = true;
+  controller = new AbortController();
+  const startedAt = Date.now();
+
+  try {
+    // Nothing else touching the index while a pass runs: the pass is already
+    // the whole budget, and a read racing it is a read nobody accounted for.
+    await drain();
+    const db = await getDb();
+    const result = await indexTree({
+      db,
+      rootAbs: directories.volume,
+      signal: controller.signal,
+      batchSize: searchConfig.index.batch,
+      cpuPercent: searchConfig.index.cpuPercent,
+      memoryBudgetBytes: searchConfig.index.memoryBudgetBytes,
+      exclude: exclusions.effectivePaths(),
+      onProgress: (progress) => {
+        logger.info({ ...progress, batches: undefined, reason }, 'Search index still building');
+      },
+    });
+
+    // Only a pass that reached the end can promise the index answers for the
+    // whole volume, and that promise is what lets search stop reading the tree.
+    if (!result.interrupted) store.markPassComplete(db);
+
+    // A pass that stopped on memory has made real progress — what it wrote is
+    // kept and skipped next time — but waiting the full interval to continue
+    // would mean an index that takes days to become usable, or never does on a
+    // volume large enough to hit the ceiling every time. It carries on shortly.
+    if (result.stoppedForMemory && !stopped) {
+      logger.info(
+        { indexed: result.indexed, resumeInMs: RESUME_AFTER_MEMORY_MS },
+        'Search index paused on memory and will carry on from where it stopped'
+      );
+      const resume = setTimeout(() => {
+        reconcile({ reason: 'resume-after-memory' });
+      }, RESUME_AFTER_MEMORY_MS);
+      resume.unref?.();
+    }
+
+    // Separated from the summary: a handful of records is worth reading, and
+    // it only appears when there is a disagreement to explain.
+    if (result.rereadSamples?.length) {
+      logger.info(
+        {
+          reindexedKnown: result.reindexedKnown,
+          byField: result.rereadByField,
+          topMtimeDeltas: result.topMtimeDeltas,
+          topFolders: result.topRereadDirs,
+          samples: result.rereadSamples,
+          reason,
+        },
+        'Search index re-read files it already knew; here is what disagreed'
+      );
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    const { rereadSamples: _s, topMtimeDeltas: _d, topRereadDirs: _f, ...summary } = result;
+
+    logger.info(
+      {
+        ...summary,
+        excluded: exclusions.effectivePaths(),
+        reason,
+        ms: Date.now() - startedAt,
+        documents: store.stats(db).documents,
+        ready: store.isReady(db),
+      },
+      'Search index updated'
+    );
+    return result;
+  } catch (error) {
+    logger.warn({ err: error, reason }, 'Search index pass failed');
+    return null;
+  } finally {
+    running = false;
+    controller = null;
+  }
+};
+
+/** Start the first pass and schedule the ones after it. */
+const start = () => {
+  if (!enabled() || timer) return;
+
+  stopped = false;
+
+  // The administrator's list lives in the database, so it has to be read
+  // before the first pass rather than after it.
+  //
+  // And said out loud once it is read. An index holding nine thousand
+  // documents where the volume has six hundred thousand is either a working
+  // exclusion or a silent hole, and nothing in the log told them apart — the
+  // question had to be asked and answered by hand.
+  enqueue(async () => {
+    const db = await getDb();
+    exclusions.loadFromDatabase(db);
+    const { environmentExcludedPaths, excludedPaths } = exclusions.snapshot();
+    if (environmentExcludedPaths.length || excludedPaths.length) {
+      logger.info(
+        { fromEnvironment: environmentExcludedPaths, fromSettings: excludedPaths },
+        'Search index will not read these folders'
+      );
+    }
+  });
+
+  if (searchConfig.index.rebuild) {
+    // Deliberately before the first pass, so the rebuild is the pass rather
+    // than a second one after it.
+    enqueue(async () => {
+      const db = await getDb();
+      store.clear(db);
+      logger.warn(
+        'SEARCH_INDEX_REBUILD is set: the search index was emptied and will be read again ' +
+          'from the files. Unset it once the rebuild has finished, or it happens every start.'
+      );
+    });
+  }
+
+  // Deliberately not awaited: a server does not wait for its index to be
+  // ready, it answers from the live search until it is.
+  reconcile({ reason: 'startup' });
+
+  timer = setInterval(() => {
+    reconcile({ reason: 'scheduled' });
+  }, searchConfig.index.reconcileMs);
+  // Never a reason to keep the process alive.
+  timer.unref?.();
+
+  logger.info(
+    { reconcileMs: searchConfig.index.reconcileMs, cpuPercent: searchConfig.index.cpuPercent },
+    'Search index started'
+  );
+};
+
+/** Stop, and cut short whatever pass is in flight. */
+const stop = () => {
+  stopped = true;
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  controller?.abort();
+};
+
+/**
+ * A file the application itself changed. Cheap enough to do inline: one stat,
+ * and a read only where something actually moved.
+ */
+const onFileChanged = async (absolutePath) => {
+  if (!enabled()) return;
+
+  const relative = relativeToVolume(absolutePath);
+  if (!relative) return;
+
+  await enqueue(async () => {
+    const db = await getDb();
+    await indexFile(db, relative, absolutePath);
+  });
+};
+
+/** A file or folder the application removed. */
+const onPathRemoved = async (absolutePath) => {
+  if (!enabled()) return;
+
+  const relative = relativeToVolume(absolutePath);
+  if (!relative) return;
+
+  await enqueue(async () => {
+    const db = await getDb();
+    store.removeUnder(db, relative);
+  });
+};
+
+/** A rename or a move: the words did not change, only where they live. */
+const onPathMoved = async (fromAbsolutePath, toAbsolutePath) => {
+  if (!enabled()) return;
+
+  const from = relativeToVolume(fromAbsolutePath);
+  const to = relativeToVolume(toAbsolutePath);
+  if (!from && !to) return;
+
+  await enqueue(async () => {
+    const db = await getDb();
+    if (from && to) {
+      store.movePath(db, from, to);
+      return;
+    }
+    // Out of scope on one side: forget what left, read what arrived.
+    if (from) store.removeUnder(db, from);
+    if (to) await indexFile(db, to, toAbsolutePath);
+  });
+};
+
+/** What the index holds, for diagnostics. */
+const status = async () => {
+  if (!enabled()) return { enabled: false };
+
+  try {
+    const db = await getDb();
+    return {
+      enabled: true,
+      running,
+      ready: store.isReady(db),
+      pending: pending.length,
+      dropped,
+      ...store.stats(db),
+    };
+  } catch {
+    return { enabled: true, running, pending: pending.length, dropped, documents: 0 };
+  }
+};
+
+module.exports = {
+  setAdminExclusions,
+  start,
+  stop,
+  reconcile,
+  onFileChanged,
+  onPathRemoved,
+  onPathMoved,
+  status,
+};

--- a/backend/src/services/searchIndexStore.js
+++ b/backend/src/services/searchIndexStore.js
@@ -1,0 +1,267 @@
+const logger = require('../utils/logger');
+
+/**
+ * Where the words are kept, and nothing else.
+ *
+ * The index stores terms, not text. FTS5's contentless mode keeps only what it
+ * needs to answer a query, which is a fraction of the size of the documents —
+ * and the matched line, which results show, is read back from the file when a
+ * result is actually returned. The path is right there, and only a page of
+ * results is ever read, so storing every document a second time to save that
+ * would be paying a lot for very little.
+ *
+ * `contentless_delete=1` is what makes it maintainable: without it, removing a
+ * row requires handing FTS5 the original text back, which is exactly what is
+ * not kept. It needs SQLite 3.43 or newer; the bundled one is well past that.
+ */
+
+const SEARCH_INDEX_DDL = `
+  CREATE TABLE IF NOT EXISTS search_documents (
+    id INTEGER PRIMARY KEY,
+    path TEXT NOT NULL UNIQUE,
+    dir TEXT NOT NULL DEFAULT '',
+    mtime_ms INTEGER NOT NULL,
+    size INTEGER NOT NULL,
+    indexed_at TEXT NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_search_documents_path ON search_documents(path);
+  -- Asking what a folder holds has to be a lookup rather than a scan: it is
+  -- what lets a pass forget a directory as soon as it leaves it, instead of
+  -- carrying every path it has ever seen to the end.
+  CREATE INDEX IF NOT EXISTS idx_search_documents_dir ON search_documents(dir);
+
+  CREATE VIRTUAL TABLE IF NOT EXISTS search_terms
+    USING fts5(text, content='', contentless_delete=1, tokenize='unicode61 remove_diacritics 2');
+`;
+
+/**
+ * Prepared-statement cache, keyed by the db handle then the SQL text.
+ *
+ * Preparing a statement compiles it. A reconcile over a large volume runs these
+ * queries several times per document and hundreds of times per second, and
+ * compiling each one again every time burns CPU and churns native handles for
+ * nothing. The folder-size index learned this on the same scale; this is the
+ * same cache. The WeakMap lets it be collected with its connection.
+ */
+const stmtCache = new WeakMap();
+const prep = (db, sql) => {
+  let bySql = stmtCache.get(db);
+  if (!bySql) {
+    bySql = new Map();
+    stmtCache.set(db, bySql);
+  }
+  let stmt = bySql.get(sql);
+  if (!stmt) {
+    stmt = db.prepare(sql);
+    bySql.set(sql, stmt);
+  }
+  return stmt;
+};
+
+/** What the index believes about a path, or null. */
+const getIndexedDocument = (db, path) =>
+  prep(db, 'SELECT id, mtime_ms AS mtimeMs, size FROM search_documents WHERE path = ?').get(
+    path
+  ) || null;
+
+/** Whether the file on disk is the one already indexed. */
+const isUpToDate = (indexed, { mtimeMs, size }) =>
+  Boolean(indexed) && indexed.mtimeMs === Math.floor(mtimeMs) && indexed.size === size;
+
+/**
+ * Put a document's words in the index, replacing whatever was there.
+ * Both tables move together or not at all.
+ */
+const parentOf = (documentPath) => {
+  const at = documentPath.lastIndexOf('/');
+  return at === -1 ? '' : documentPath.slice(0, at);
+};
+
+const upsertDocument = (db, { path, mtimeMs, size, text }) => {
+  const now = new Date().toISOString();
+  const existing = getIndexedDocument(db, path);
+
+  if (existing) {
+    prep(db, 'DELETE FROM search_terms WHERE rowid = ?').run(existing.id);
+    prep(
+      db,
+      'UPDATE search_documents SET dir = ?, mtime_ms = ?, size = ?, indexed_at = ? WHERE id = ?'
+    ).run(parentOf(path), Math.floor(mtimeMs), size, now, existing.id);
+    prep(db, 'INSERT INTO search_terms(rowid, text) VALUES (?, ?)').run(existing.id, text);
+    return existing.id;
+  }
+
+  const result = prep(
+    db,
+    'INSERT INTO search_documents (path, dir, mtime_ms, size, indexed_at) VALUES (?, ?, ?, ?, ?)'
+  ).run(path, parentOf(path), Math.floor(mtimeMs), size, now);
+  prep(db, 'INSERT INTO search_terms(rowid, text) VALUES (?, ?)').run(
+    result.lastInsertRowid,
+    text
+  );
+  return result.lastInsertRowid;
+};
+
+/** Forget a document. */
+const removeDocument = (db, path) => {
+  const existing = getIndexedDocument(db, path);
+  if (!existing) return false;
+
+  prep(db, 'DELETE FROM search_terms WHERE rowid = ?').run(existing.id);
+  prep(db, 'DELETE FROM search_documents WHERE id = ?').run(existing.id);
+  return true;
+};
+
+/** Forget a folder and everything under it. Answers how many went. */
+const removeUnder = (db, prefix) => {
+  const rows = prep(
+    db,
+    'SELECT id FROM search_documents WHERE path = ? OR path LIKE ? ESCAPE ?'
+  ).all(prefix, `${prefix.replace(/[\\%_]/g, '\\$&')}/%`, '\\');
+
+  for (const row of rows) {
+    prep(db, 'DELETE FROM search_terms WHERE rowid = ?').run(row.id);
+    prep(db, 'DELETE FROM search_documents WHERE id = ?').run(row.id);
+  }
+  return rows.length;
+};
+
+/**
+ * Follow a rename. The words do not change, so only the path does — which is
+ * the whole reason a move is cheap and a rewrite is not.
+ */
+const movePath = (db, fromPath, toPath) => {
+  const like = `${fromPath.replace(/[\\%_]/g, '\\$&')}/%`;
+  const moved = prep(
+    db,
+    `UPDATE search_documents
+       SET path = ? || substr(path, ?),
+           dir = rtrim(? || substr(path, ?), replace(? || substr(path, ?), rtrim(? || substr(path, ?), replace(? || substr(path, ?), '/', '')), ''))
+       WHERE path LIKE ? ESCAPE '\\'`
+  ).run(
+    toPath,
+    fromPath.length + 1,
+    toPath,
+    fromPath.length + 1,
+    toPath,
+    fromPath.length + 1,
+    toPath,
+    fromPath.length + 1,
+    toPath,
+    fromPath.length + 1,
+    like
+  );
+
+  const movedSelf = prep(
+    db,
+    'UPDATE search_documents SET path = ?, dir = ? WHERE path = ?'
+  ).run(toPath, parentOf(toPath), fromPath);
+
+  return moved.changes + movedSelf.changes;
+};
+
+/**
+ * Paths whose words match, best first.
+ *
+ * The query is what FTS5 understands, so a bare word is a prefix-free term
+ * match. Callers pass a term the user typed, so it is quoted: someone
+ * searching `NOT` or `a-b` is looking for those characters, not writing an
+ * expression.
+ */
+const search = (db, term, limit = 100) => {
+  const quoted = `"${String(term).replace(/"/g, '""')}"`;
+  try {
+    return prep(
+      db,
+      `SELECT d.path AS path
+         FROM search_terms t
+         JOIN search_documents d ON d.id = t.rowid
+         WHERE search_terms MATCH ?
+         ORDER BY rank
+         LIMIT ?`
+    )
+      .all(quoted, limit)
+      .map((row) => row.path);
+  } catch (error) {
+    logger.debug({ err: error, term }, 'Full-text query failed');
+    return [];
+  }
+};
+
+/**
+ * What a folder holds, by name, and nothing about what is under it.
+ *
+ * This is the query that replaced carrying every path seen so far in memory:
+ * fifty megabytes for two hundred thousand files, held from the first
+ * directory to the last, on a container whose whole working set is sixty.
+ */
+const listDirectoryPaths = (db, dir) =>
+  prep(db, 'SELECT path FROM search_documents WHERE dir = ?')
+    .pluck()
+    .all(dir);
+
+/** Every folder the index has something in. Streamed, never materialised. */
+const iterateIndexedDirectories = (db) =>
+  prep(db, 'SELECT DISTINCT dir FROM search_documents ORDER BY dir').pluck().iterate();
+
+/**
+ * Whether the index has ever been finished.
+ *
+ * It matters because the index does not supplement the live content search, it
+ * replaces it. Half an index therefore answers half a search and says nothing
+ * about the half it did not look at — a term that was found yesterday is simply
+ * absent today, which is worse than a slow answer and much harder to explain.
+ * Until a pass has run to the end, searches read the tree as they always did.
+ *
+ * Kept in the database rather than in memory because a restart does not
+ * invalidate the index: what was read is still read, and the mtime check is
+ * what decides whether it is still true.
+ */
+const READY_KEY = 'search_index_complete_at';
+
+const markPassComplete = (db, at = new Date().toISOString()) => {
+  prep(db, 'INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run(READY_KEY, at);
+};
+
+const isReady = (db) => {
+  try {
+    return Boolean(prep(db, 'SELECT value FROM meta WHERE key = ?').pluck().get(READY_KEY));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Throw the whole index away.
+ *
+ * Safe at any time: every row in it was read from a file that is still there,
+ * so the only cost of being wrong about needing this is one pass.
+ */
+const clear = (db) => {
+  db.exec('DELETE FROM search_terms');
+  db.exec('DELETE FROM search_documents');
+  prep(db, 'DELETE FROM meta WHERE key = ?').run(READY_KEY);
+};
+
+/** How much is in there, for the diagnostics page and for tests. */
+const stats = (db) => {
+  const row = prep(db, 'SELECT COUNT(*) AS documents FROM search_documents').get();
+  return { documents: row?.documents ?? 0 };
+};
+
+module.exports = {
+  SEARCH_INDEX_DDL,
+  getIndexedDocument,
+  isUpToDate,
+  upsertDocument,
+  removeDocument,
+  removeUnder,
+  movePath,
+  search,
+  stats,
+  clear,
+  listDirectoryPaths,
+  iterateIndexedDirectories,
+  markPassComplete,
+  isReady,
+};

--- a/backend/src/services/searchIndexer.js
+++ b/backend/src/services/searchIndexer.js
@@ -1,0 +1,569 @@
+const path = require('path');
+const fs = require('fs/promises');
+
+const { search: searchConfig, directories, extensions } = require('../config/index');
+const { extractPdfTextLines } = require('./pdfTextExtract');
+const { extractOfficeTextLines, isOfficeDocument } = require('./officeTextExtract');
+const store = require('./searchIndexStore');
+const { containerMemoryLimitBytes } = require('../utils/containerMemory');
+
+/**
+ * Building the index without being noticed.
+ *
+ * The rule this borrows from the folder-size index: work in small batches
+ * inside one transaction each, hand the event loop back between them, and
+ * check an abort signal at every step. A walk that cannot be interrupted is a
+ * walk that decides for itself when the server is free, and it is always
+ * wrong about that.
+ *
+ * What it did not borrow, and had to learn: pacing on a count of items paces
+ * nothing here. The folder-size walk costs a `stat` per item, so pausing every
+ * two hundred of them is a real pause. Indexing costs a file read, an
+ * extraction and a tokenisation per item, so pausing every twenty-five of them
+ * was fifty milliseconds of rest for seconds of work — a core held at half
+ * load for as long as the pass ran. The pause is taken on elapsed time now, so
+ * the share of a core is what is chosen and it holds whatever the files are.
+ *
+ * Reading a file is the expensive part, so nothing is read twice: a document
+ * whose size and modification time match what was indexed is skipped without
+ * being opened.
+ */
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const IGNORED_DIRECTORIES = new Set(['.git', 'node_modules', 'dist', 'build', '.cache']);
+
+/**
+ * How much of one document is worth indexing, and how much may be held at once.
+ *
+ * A batch used to be counted in documents, which says nothing about memory: a
+ * file of a few megabytes becomes a JavaScript string twice that size, and
+ * twenty-five of them held together while FTS5 tokenises each is hundreds of
+ * megabytes for a background task nobody asked to be noticed. Both are bounded
+ * in bytes now.
+ *
+ * A megabyte of text is some two hundred thousand words. A search that cannot
+ * be answered by those is not one a bigger index would have answered either.
+ */
+const MAX_TEXT_PER_DOCUMENT = 1024 * 1024;
+const MAX_TEXT_PER_BATCH = 4 * 1024 * 1024;
+
+/**
+ * Files that are never going to yield a search term.
+ *
+ * Reading one to find that out costs the same as reading a document: the sniff
+ * below only rules a file out after it has been opened and read. A volume is
+ * mostly photos, video and archives, so deciding from the name first is what
+ * keeps a pass proportional to the documents rather than to the disk.
+ */
+const NON_TEXT_EXTENSIONS = new Set([
+  ...extensions.images,
+  ...extensions.rawImages,
+  ...extensions.videos,
+  ...extensions.audios,
+  'zip', 'rar', '7z', 'gz', 'bz2', 'xz', 'zst', 'tar', 'tgz', 'iso', 'dmg', 'jar',
+  'exe', 'dll', 'so', 'dylib', 'bin', 'o', 'a', 'class', 'pyc', 'wasm',
+  'ttf', 'otf', 'woff', 'woff2', 'eot',
+  'db', 'sqlite', 'sqlite3', 'mdb', 'pack', 'idx',
+]);
+
+const extensionOf = (absolutePath) => path.extname(absolutePath).slice(1).toLowerCase();
+
+/** Whether the name alone is enough to leave a file unopened. */
+const isProbablyNotText = (absolutePath) => NON_TEXT_EXTENSIONS.has(extensionOf(absolutePath));
+
+/** Enough of a file to tell prose from a binary. */
+const SNIFF_BYTES = 4096;
+
+const looksBinary = (buffer) => {
+  const length = Math.min(buffer.length, SNIFF_BYTES);
+  if (!length) return false;
+
+  let suspicious = 0;
+  for (let index = 0; index < length; index += 1) {
+    const byte = buffer[index];
+    if (byte === 0) return true;
+    if (byte < 7 || (byte > 13 && byte < 32)) suspicious += 1;
+  }
+  return suspicious / length > 0.3;
+};
+
+/**
+ * The head of a plain file, as text — never more of it than will be kept.
+ *
+ * Read in two steps on purpose. The first is a few kilobytes, enough to tell
+ * prose from a binary; a file that fails that test is closed having cost one
+ * small read. Reading the whole file first and deciding afterwards is what
+ * turned a pass over a volume into gigabytes of buffers and strings allocated
+ * and thrown away, at whatever rate the disk could sustain.
+ */
+const readPlainTextHead = async (absolutePath, size, scratch = null) => {
+  let handle = null;
+  try {
+    handle = await fs.open(absolutePath, 'r');
+
+    const sniffLength = Math.min(size, SNIFF_BYTES);
+    const sniff = scratch ? scratch.subarray(0, sniffLength) : Buffer.allocUnsafe(sniffLength);
+    const { bytesRead } = await handle.read(sniff, 0, sniffLength, 0);
+    if (!bytesRead) return null;
+    if (looksBinary(sniff.subarray(0, bytesRead))) return null;
+
+    if (size <= bytesRead) return sniff.subarray(0, bytesRead).toString('utf8');
+
+    const wanted = Math.min(size, MAX_TEXT_PER_DOCUMENT);
+    const buffer = scratch ? scratch.subarray(0, wanted) : Buffer.allocUnsafe(wanted);
+    const full = await handle.read(buffer, 0, wanted, 0);
+    return buffer.subarray(0, full.bytesRead).toString('utf8');
+  } catch {
+    return null;
+  } finally {
+    await handle?.close().catch(() => {});
+  }
+};
+
+/**
+ * The words in a file, or null where there are none to take — a binary, an
+ * unreadable file, a document with no text layer.
+ */
+const readIndexableText = async (absolutePath, size, scratch = null) => {
+  if (isOfficeDocument(absolutePath)) {
+    const lines = extractOfficeTextLines(absolutePath);
+    return lines ? lines.join('\n') : null;
+  }
+
+  if (extensionOf(absolutePath) === 'pdf') {
+    const lines = await extractPdfTextLines(absolutePath);
+    return lines ? lines.join('\n') : null;
+  }
+
+  if (isProbablyNotText(absolutePath)) return null;
+
+  return readPlainTextHead(absolutePath, size, scratch);
+};
+
+/** As much of a document as is worth keeping terms for. */
+const capText = (text) =>
+  text.length > MAX_TEXT_PER_DOCUMENT ? text.slice(0, MAX_TEXT_PER_DOCUMENT) : text;
+
+const createAbortedError = () => {
+  const error = new Error('Indexing was interrupted.');
+  error.code = 'SEARCH_INDEX_ABORTED';
+  return error;
+};
+
+/**
+ * Walk a tree and bring the index up to date with it.
+ *
+ * Returns what it did, and what it did not: an interrupted run reports its
+ * progress rather than throwing it away, so the next one is shorter.
+ */
+const indexTree = async ({
+  db,
+  rootAbs = directories.volume,
+  rootRel = '',
+  signal,
+  batchSize = 25,
+  cpuPercent = 25,
+  workSliceMs = 50,
+  memoryBudgetBytes = 256 * 1024 * 1024,
+  exclude = searchConfig?.index?.exclude ?? [],
+  readMemory = () => process.memoryUsage().rss,
+  maxFileSizeBytes = searchConfig?.maxFileSizeBytes ?? 5 * 1024 * 1024,
+  removeMissing = true,
+  onProgress,
+  progressMs = 30 * 1000,
+} = {}) => {
+  // Directories visited, not files seen. The difference is the whole point: a
+  // volume has a few tens of thousands of folders and a few hundred thousand
+  // files, and only one of those numbers can be carried to the end of a pass
+  // on a container whose working set is sixty megabytes.
+  const seenDirs = new Set(['']);
+  const pending = [];
+  let pendingBytes = 0;
+  let indexed = 0;
+  let skipped = 0;
+  let batches = 0;
+  let interrupted = false;
+
+  const throwIfAborted = () => {
+    if (signal?.aborted) throw createAbortedError();
+  };
+
+  /**
+   * One buffer for the whole pass, rather than one per file.
+   *
+   * A megabyte allocated and freed per document is not a leak — the memory is
+   * released — but the allocator keeps the ground it took, and a pass over a
+   * volume with large documents in it leaves the process holding a hundred
+   * megabytes it will not give back. What the user sees is a container that
+   * never returns to what it used before indexing, and no amount of collecting
+   * brings it down, because there is nothing left to collect.
+   *
+   * Safe because index work is serialised: one worker drains the per-file
+   * queue, and a pass holds it for its duration. Nothing else reads into this.
+   */
+  const scratch = Buffer.allocUnsafe(MAX_TEXT_PER_DOCUMENT);
+
+  /**
+   * Files re-read although the index already knew them.
+   *
+   * A count alone cannot tell a volume that really is that active from a skip
+   * check its storage answers differently each time, so three shapes of the
+   * same fact are kept: which field moved, by how much, and where. A constant
+   * offset in the dates, one noisy folder, or genuine activity spread over the
+   * whole tree each look completely different in those three, and identical in
+   * a total.
+   *
+   * All three are bounded. This is a diagnostic on a volume with six hundred
+   * thousand documents in it; it does not get to be the thing that runs the
+   * machine out of memory.
+   */
+  const MAX_REREAD_SAMPLES = 10;
+  const MAX_TRACKED_KEYS = 500;
+  const rereadSamples = [];
+  const rereadByField = { mtime: 0, size: 0, both: 0 };
+  const deltaCounts = new Map();
+  const dirCounts = new Map();
+  let reindexedKnown = 0;
+
+  const countCapped = (map, key) => {
+    const seenKey = map.get(key);
+    if (seenKey !== undefined) map.set(key, seenKey + 1);
+    else if (map.size < MAX_TRACKED_KEYS) map.set(key, 1);
+  };
+
+  const topOf = (map, limit = 5) =>
+    [...map.entries()]
+      .sort((left, right) => right[1] - left[1])
+      .slice(0, limit)
+      .map(([value, count]) => ({ value, count }));
+
+  let removed = 0;
+  const forgetPaths = db.transaction((paths) => {
+    for (const gonePath of paths) store.removeDocument(db, gonePath);
+  });
+
+  const excluded = exclude.filter(Boolean);
+  const isExcluded = (relativePath) =>
+    excluded.some((entry) => relativePath === entry || relativePath.startsWith(`${entry}/`));
+
+  // Work for a slice, then stand aside for as long as the chosen share says.
+  // At 25% that is 50 ms of work and 150 ms of rest, whether those 50 ms went
+  // into one large PDF or forty small text files.
+  const share = Math.min(100, Math.max(1, cpuPercent));
+  const restMs = Math.round((workSliceMs * (100 - share)) / share);
+  let sliceStartedAt = Date.now();
+  let pauses = 0;
+
+  // A ceiling on the pass, checked once a slice.
+  //
+  // Two of them, because two different things are being protected against.
+  // What actually kills a container is the process passing the limit its
+  // cgroup enforces, so where there is one that is the ceiling — three
+  // quarters of it, leaving room for the request that arrives while the pass
+  // is between checks. Where there is none, the fallback is what the pass
+  // itself has added, which is all that can be known without a limit to
+  // compare against.
+  //
+  // The delta is a blunt instrument and worth being honest about: it is the
+  // whole process's growth since the pass began, so a thumbnail sweep or a
+  // folder-size reconcile running alongside is counted against the index. A
+  // single reading is therefore not enough to stop on — it takes two in a row,
+  // so a spike belonging to something else does not end the pass.
+  //
+  // Stopping is safe either way: what was written stays written, and the next
+  // pass skips it and carries on from there.
+  const memoryAtStart = readMemory();
+  const containerLimit = containerMemoryLimitBytes();
+  const containerCeiling = containerLimit ? containerLimit * 0.75 : null;
+  let consecutiveOverBudget = 0;
+  const cpuAtStart = process.cpuUsage();
+  const startedAt = Date.now();
+  let stoppedForMemory = false;
+
+  const overMemoryBudget = () => {
+    const rss = readMemory();
+
+    if (containerCeiling) return rss > containerCeiling;
+
+    if (!(memoryBudgetBytes > 0)) return false;
+    if (rss - memoryAtStart > memoryBudgetBytes) {
+      consecutiveOverBudget += 1;
+      return consecutiveOverBudget >= 2;
+    }
+    consecutiveOverBudget = 0;
+    return false;
+  };
+
+  const growthMb = () => Math.round((readMemory() - memoryAtStart) / (1024 * 1024));
+
+  /**
+   * What the pass has cost so far, as opposed to what the container is using.
+   *
+   * `rssMb` is the whole process — sessions, thumbnails, the folder-size index
+   * — and says nothing on its own about who is holding it. `addedMb` is this
+   * pass's own share, and `cpuPercent` is measured against the wall clock, so
+   * a quarter of a core reads as 25 whatever else the machine is doing.
+   */
+  const cost = () => {
+    const cpu = process.cpuUsage(cpuAtStart);
+    const cpuMs = Math.round((cpu.user + cpu.system) / 1000);
+    const elapsedMs = Math.max(1, Date.now() - startedAt);
+    return {
+      addedMb: growthMb(),
+      rssMb: Math.round(readMemory() / (1024 * 1024)),
+      cpuMs,
+      cpuPercent: Math.round((cpuMs / elapsedMs) * 100),
+      pauses,
+    };
+  };
+
+  const payForTimeUsed = async () => {
+    if (Date.now() - sliceStartedAt < workSliceMs) return;
+
+    if (overMemoryBudget()) {
+      stoppedForMemory = true;
+      throw createAbortedError();
+    }
+    if (restMs > 0) {
+      pauses += 1;
+      await sleep(restMs);
+    }
+    sliceStartedAt = Date.now();
+  };
+
+  // A first pass over a large library takes minutes, and silence for minutes
+  // is indistinguishable from nothing happening. Progress is reported on a
+  // timer rather than per batch, so the log says how it is going without
+  // becoming the noisiest thing in it.
+  let lastReport = Date.now();
+
+  // Built once. `db.transaction()` compiles its own statements every time it is
+  // called, and it is called once per batch — the same compile-in-a-loop that
+  // made the queries below expensive.
+  const writeBatch = db.transaction((batch) => {
+    for (const document of batch) store.upsertDocument(db, document);
+  });
+
+  const flush = () => {
+    if (pending.length === 0) return;
+
+    const batch = pending.splice(0, pending.length);
+    pendingBytes = 0;
+    writeBatch(batch);
+    indexed += batch.length;
+    batches += 1;
+
+    if (typeof onProgress === 'function' && Date.now() - lastReport >= progressMs) {
+      lastReport = Date.now();
+      // What this pass has added to the process, which is the only number that
+      // says whether the index is the thing using the memory. Without it the
+      // question can only be answered by argument.
+      // The re-read report used to arrive only at the end, which on a volume
+      // this size means waiting half an hour to find out which folder is
+      // responsible. The count and the folder leading it travel with every
+      // progress line instead.
+      const [worstFolder] = topOf(dirCounts, 1);
+      onProgress({
+        indexed,
+        skipped,
+        batches,
+        reindexed: reindexedKnown,
+        ...(worstFolder ? { rereadTopFolder: worstFolder.value, rereadTopCount: worstFolder.count } : {}),
+        ...cost(),
+      });
+    }
+  };
+
+  const walk = async (dirAbs, dirRel) => {
+    throwIfAborted();
+    seenDirs.add(dirRel);
+
+    let entries;
+    try {
+      entries = await fs.readdir(dirAbs, { withFileTypes: true });
+    } catch {
+      return; // A directory we cannot read is not a reason to stop.
+    }
+
+    // What this directory holds, forgotten as soon as it is left.
+    const seenHere = new Set();
+
+    for (const entry of entries) {
+      throwIfAborted();
+
+      if (entry.name.startsWith('.') || IGNORED_DIRECTORIES.has(entry.name)) continue;
+
+      const absolutePath = path.join(dirAbs, entry.name);
+      const relativePath = dirRel ? `${dirRel}/${entry.name}` : entry.name;
+
+      if (isExcluded(relativePath)) continue;
+
+      if (entry.isDirectory()) {
+        // eslint-disable-next-line no-await-in-loop
+        await walk(absolutePath, relativePath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+
+      // eslint-disable-next-line no-await-in-loop
+      const stats = await fs.stat(absolutePath).catch(() => null);
+      if (!stats) continue;
+      if (maxFileSizeBytes && stats.size > maxFileSizeBytes) continue;
+
+      seenHere.add(relativePath);
+
+      // Already indexed, unchanged: not opened at all. This is what makes the
+      // second run cost almost nothing.
+      const known = store.getIndexedDocument(db, relativePath);
+      if (store.isUpToDate(known, stats)) {
+        skipped += 1;
+        // eslint-disable-next-line no-await-in-loop
+        await payForTimeUsed();
+        continue;
+      }
+
+      // A pass that re-reads tens of thousands of files nobody touched is
+      // either looking at a volume that really does change that much, or
+      // asking a question its storage cannot answer the same way twice. The
+      // two look identical from a count, so the first few disagreements are
+      // reported in full: what was stored, what the disk says now, and which
+      // of the two fields differs.
+      if (known) {
+        const diskMtimeMs = Math.floor(stats.mtimeMs);
+        const mtimeMoved = known.mtimeMs !== diskMtimeMs;
+        const sizeMoved = known.size !== stats.size;
+        const differs = mtimeMoved ? (sizeMoved ? 'both' : 'mtime') : 'size';
+
+        reindexedKnown += 1;
+        rereadByField[differs] += 1;
+        if (mtimeMoved) countCapped(deltaCounts, diskMtimeMs - known.mtimeMs);
+        countCapped(dirCounts, dirRel || '/');
+
+        if (rereadSamples.length < MAX_REREAD_SAMPLES) {
+          rereadSamples.push({
+            path: relativePath,
+            storedMtimeMs: known.mtimeMs,
+            diskMtimeMs,
+            mtimeDeltaMs: diskMtimeMs - known.mtimeMs,
+            storedSize: known.size,
+            diskSize: stats.size,
+            differs,
+          });
+        }
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const text = await readIndexableText(absolutePath, stats.size, scratch);
+      if (text === null || !text.trim()) continue;
+
+      const indexable = capText(text);
+      pending.push({
+        path: relativePath,
+        mtimeMs: stats.mtimeMs,
+        size: stats.size,
+        text: indexable,
+      });
+      pendingBytes += indexable.length;
+
+      // Whichever ceiling is reached first. The byte one is what keeps a
+      // handful of large documents from being held together.
+      if (pending.length >= batchSize || pendingBytes >= MAX_TEXT_PER_BATCH) flush();
+
+      // eslint-disable-next-line no-await-in-loop
+      await payForTimeUsed();
+    }
+
+    // Everything the index holds for this folder that is no longer in it. The
+    // listing above is complete, so this is safe even if the pass is stopped
+    // before it reaches the next folder — an interrupted run keeps the
+    // deletions it was sure of, rather than throwing them away.
+    if (removeMissing) {
+      const goneHere = store.listDirectoryPaths(db, dirRel).filter((known) => !seenHere.has(known));
+      if (goneHere.length > 0) {
+        forgetPaths(goneHere);
+        removed += goneHere.length;
+      }
+    }
+  };
+
+  try {
+    await walk(rootAbs, rootRel);
+    flush();
+  } catch (error) {
+    flush();
+    if (error?.code !== 'SEARCH_INDEX_ABORTED') throw error;
+    interrupted = true;
+  }
+
+  // A folder deleted outright is never walked, so nothing above ever asks what
+  // it held. Only a run that reached the end can tell that apart from a folder
+  // it simply had not got to yet.
+  if (removeMissing && !interrupted) {
+    const goneDirs = [];
+    for (const dir of store.iterateIndexedDirectories(db)) {
+      if (!seenDirs.has(dir)) goneDirs.push(dir);
+    }
+    for (const dir of goneDirs) {
+      const paths = store.listDirectoryPaths(db, dir);
+      if (paths.length > 0) {
+        forgetPaths(paths);
+        removed += paths.length;
+      }
+    }
+  }
+
+  return {
+    indexed,
+    skipped,
+    removed,
+    batches,
+    pauses,
+    interrupted,
+    stoppedForMemory,
+    reindexedKnown,
+    rereadByField,
+    topMtimeDeltas: topOf(deltaCounts),
+    topRereadDirs: topOf(dirCounts),
+    rereadSamples,
+    ...cost(),
+  };
+};
+
+/** Bring one file up to date, or forget it if it is gone. */
+const indexFile = async (db, relativePath, absolutePath) => {
+  const stats = await fs.stat(absolutePath).catch(() => null);
+  if (!stats || !stats.isFile()) {
+    store.removeDocument(db, relativePath);
+    return { removed: true };
+  }
+
+  const maxBytes = searchConfig?.maxFileSizeBytes ?? 0;
+  if (maxBytes && stats.size > maxBytes) {
+    store.removeDocument(db, relativePath);
+    return { skipped: true };
+  }
+
+  if (store.isUpToDate(store.getIndexedDocument(db, relativePath), stats)) {
+    return { unchanged: true };
+  }
+
+  const text = await readIndexableText(absolutePath, stats.size);
+  if (text === null || !text.trim()) {
+    store.removeDocument(db, relativePath);
+    return { skipped: true };
+  }
+
+  store.upsertDocument(db, {
+    path: relativePath,
+    mtimeMs: stats.mtimeMs,
+    size: stats.size,
+    text: capText(text),
+  });
+  return { indexed: true };
+};
+
+module.exports = { indexTree, indexFile, readIndexableText };
+
+// Exported for tests: telling prose from a binary is the one judgement here.
+module.exports.looksBinary = looksBinary;

--- a/backend/src/utils/containerMemory.js
+++ b/backend/src/utils/containerMemory.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+
+/**
+ * How much memory this process is allowed, when something is enforcing it.
+ *
+ * A background task that must not be the reason a container dies needs to know
+ * what "too much" is, and the only authority on that is the cgroup the
+ * container runs in. Without one — a bare process, a host with no limit — there
+ * is no answer, and callers fall back to a budget of their own.
+ *
+ * Read once: a limit does not change under a running container, and reading it
+ * on every check would put two file reads in a loop that exists to be cheap.
+ */
+const readNumber = (filePath) => {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8').trim();
+    if (raw === 'max') return null;
+    const value = Number(raw);
+    return Number.isFinite(value) && value > 0 ? value : null;
+  } catch {
+    return null;
+  }
+};
+
+let cached;
+
+const containerMemoryLimitBytes = () => {
+  if (cached !== undefined) return cached;
+
+  const limit =
+    readNumber('/sys/fs/cgroup/memory.max') ??
+    readNumber('/sys/fs/cgroup/memory/memory.limit_in_bytes');
+
+  // A "limit" larger than any machine is how an unlimited cgroup reports
+  // itself on v1, and it is not a limit anyone set.
+  cached = limit != null && limit < 1024 * 1024 * 1024 * 1024 ? limit : null;
+  return cached;
+};
+
+/** Only for tests, which need to ask more than once. */
+const resetContainerMemoryLimit = () => {
+  cached = undefined;
+};
+
+module.exports = { containerMemoryLimitBytes, resetContainerMemoryLimit };

--- a/backend/src/utils/ids.js
+++ b/backend/src/utils/ids.js
@@ -1,0 +1,22 @@
+const crypto = require('crypto');
+
+/**
+ * Identifiers and timestamps for the records this app stores.
+ *
+ * Seven services carried a byte-identical copy of generateId and five of
+ * nowIso. Nothing had drifted yet, but every copy is a chance for one of them
+ * to — and a random-identifier helper is the wrong place to discover that.
+ */
+
+/**
+ * randomUUID exists on every Node version this app supports; the fallback is
+ * kept for the odd runtime that exposes an incomplete crypto module.
+ */
+const generateId = () =>
+  typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now().toString(36)}-${crypto.randomBytes(8).toString('hex')}`;
+
+const nowIso = () => new Date().toISOString();
+
+module.exports = { generateId, nowIso };

--- a/backend/tests/routes/search-content.test.js
+++ b/backend/tests/routes/search-content.test.js
@@ -286,6 +286,122 @@ describe('searching inside PDFs', () => {
  * reading the tree again. The point of the whole thing is that the second
  * search costs nothing the first one did not already pay.
  */
+describe('searching through the index', () => {
+  // A pass, and the mark that says it reached the end — which is what the
+  // manager records, and what lets search stop reading the tree for itself.
+  const buildIndex = async ({ complete = true } = {}) => {
+    const dbService = envContext.requireFresh('src/services/db');
+    const db = await dbService.getDb();
+    const { indexTree } = envContext.requireFresh('src/services/searchIndexer');
+    const store = envContext.requireFresh('src/services/searchIndexStore');
+    const result = await indexTree({ db, rootAbs: envContext.volumeDir, cpuPercent: 100 });
+    if (complete) store.markPassComplete(db);
+    return result;
+  };
+
+  it('finds a word inside a document', async () => {
+    const dir = await seed({ SEARCH_INDEX: 'true' });
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'notes.md'), '# Notes\n\nthe word pangolin is here\n');
+    await buildIndex();
+
+    const items = await search('pangolin');
+
+    const hit = items.find((item) => item.name === 'notes.md');
+    expect(hit).toBeTruthy();
+    expect(hit.matchLine).toContain('pangolin');
+    expect(hit.matchLineNumber).toBe(3);
+  });
+
+  it('finds one inside a Word document', async () => {
+    const dir = await seed({ SEARCH_INDEX: 'true' });
+    await fs.mkdir(dir, { recursive: true });
+    const zip = new AdmZip();
+    zip.addFile(
+      'word/document.xml',
+      Buffer.from(
+        '<w:document><w:body><w:p><w:r><w:t>a pangolin appears</w:t></w:r></w:p></w:body></w:document>'
+      )
+    );
+    zip.writeZip(path.join(dir, 'report.docx'));
+    await buildIndex();
+
+    expect((await search('pangolin')).some((item) => item.name === 'report.docx')).toBe(true);
+  });
+
+  // The index says a file matches; the file is what says where. A document
+  // edited since the last pass must not be offered on the strength of words it
+  // no longer contains.
+  it('does not offer a file that no longer says it', async () => {
+    const dir = await seed({ SEARCH_INDEX: 'true' });
+    await fs.mkdir(dir, { recursive: true });
+    const file = path.join(dir, 'notes.md');
+    await fs.writeFile(file, 'the word pangolin is here\n');
+    await buildIndex();
+
+    await fs.writeFile(file, 'it says something else entirely now\n');
+
+    expect((await search('pangolin')).map((item) => item.name)).not.toContain('notes.md');
+  });
+
+  // What proves the answer came from the index rather than from reading the
+  // tree again: a file the index has never seen is not found by its contents,
+  // because with the index on nothing reads contents live. It is also the
+  // honest description of the trade — results are as fresh as the last pass.
+  it('answers from the index, and only from it', async () => {
+    const dir = await seed({ SEARCH_INDEX: 'true' });
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'indexed.md'), 'the word pangolin is here\n');
+    await buildIndex();
+    await fs.writeFile(path.join(dir, 'later.md'), 'a pangolin arrived after the pass\n');
+
+    // Stated before the real assertion, because the failure otherwise reads as
+    // 'the index returned too much' when the cause is 'the index was not used':
+    // an index that is not ready sends the search back to reading the tree,
+    // which finds the later file for an entirely different reason.
+    const dbService = envContext.requireFresh('src/services/db');
+    const store = envContext.requireFresh('src/services/searchIndexStore');
+    expect(store.isReady(await dbService.getDb())).toBe(true);
+
+    const names = (await search('pangolin')).map((item) => item.name);
+
+    expect(names).toContain('indexed.md');
+    expect(names).not.toContain('later.md');
+  });
+
+  /**
+   * The index replaces the live content scan rather than adding to it, so an
+   * index that has not finished answers with whatever part of the volume it
+   * happens to have read — and a term that was found yesterday is simply gone,
+   * with nothing in the answer to say why.
+   */
+  it('reads the tree itself until a pass has finished', async () => {
+    const dir = await seed({ SEARCH_INDEX: 'true' });
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'indexed.md'), 'the word pangolin is here\n');
+    await buildIndex({ complete: false });
+    await fs.writeFile(path.join(dir, 'later.md'), 'a pangolin arrived after the pass\n');
+
+    const names = (await search('pangolin')).map((item) => item.name);
+
+    expect(names).toContain('indexed.md');
+    expect(names).toContain('later.md');
+  });
+
+  it('still matches on names, which the index is not for', async () => {
+    const dir = await seed({ SEARCH_INDEX: 'true' });
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'pangolin-notes.md'), 'nothing relevant\n');
+    await buildIndex();
+
+    expect((await search('pangolin')).some((item) => item.name === 'pangolin-notes.md')).toBe(true);
+  });
+});
+
+/**
+ * A search that keeps looking to be sure there is nothing more is a search
+ * nobody waits for. What it has when the budget runs out is the answer.
+ */
 describe('how long a search may take', () => {
   it('says so when the budget ended it', async () => {
     const dir = await seed({ SEARCH_TIMEOUT_MS: '1' });

--- a/backend/tests/routes/search-glob.test.js
+++ b/backend/tests/routes/search-glob.test.js
@@ -112,3 +112,36 @@ describe('searching for a filename pattern', () => {
  * overlay is most of a volume — so no search finished inside its budget, and
  * the same question came back truncated at a different point each time.
  */
+describe('a folder the search is told to leave alone', () => {
+  const seedWithExcluded = async () => {
+    const dir = await seed();
+    const excluded = path.join(envContext.volumeDir, 'Stacks', 'docker');
+    await fs.mkdir(excluded, { recursive: true });
+    await fs.writeFile(path.join(excluded, 'overlay.ps1'), 'Write-Host "inside docker"\n');
+    return dir;
+  };
+
+  it('is not walked by a filename search', async () => {
+    await seedWithExcluded();
+    const searchIndexExclusions = envContext.requireFresh('src/services/searchIndexExclusions');
+    searchIndexExclusions.setAdminPaths(['Stacks/docker']);
+
+    const names = (await search('*.ps1')).items.map((item) => item.name);
+
+    expect(names).not.toContain('overlay.ps1');
+    expect(names).toContain('deploy.ps1');
+  });
+
+  it('is searched when it is the folder the search was pointed at', async () => {
+    await seedWithExcluded();
+    const searchIndexExclusions = envContext.requireFresh('src/services/searchIndexExclusions');
+    searchIndexExclusions.setAdminPaths(['Stacks/docker']);
+
+    const response = await request(buildApp())
+      .get('/api/search')
+      .query({ q: '*.ps1', path: 'Stacks/docker' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.items.map((item) => item.name)).toContain('overlay.ps1');
+  });
+});

--- a/backend/tests/services/path-exclusions.test.js
+++ b/backend/tests/services/path-exclusions.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+
+const { createPathExclusions } = require('../../src/services/pathExclusions');
+
+/**
+ * Written once because it was written twice: the folder-size index and the
+ * search index each carried their own copy, eighty-two per cent identical and
+ * differing only in which setting they read. Two copies of a rule about what
+ * may be excluded is two places for it to drift.
+ */
+const build = (environment = []) =>
+  createPathExclusions({
+    settingsCategory: 'system',
+    settingsKey: 'test',
+    readEnvironmentPaths: () => environment,
+  });
+
+describe('two lists of folders to leave alone', () => {
+  it('keeps the environment separate from the administrator', () => {
+    const exclusions = build(['Stacks/docker']);
+    exclusions.setAdminPaths(['Backups/2024']);
+
+    expect(exclusions.snapshot()).toEqual({
+      excludedPaths: ['Backups/2024'],
+      environmentExcludedPaths: ['Stacks/docker'],
+    });
+    expect(exclusions.effectivePaths()).toEqual(['Backups/2024', 'Stacks/docker']);
+  });
+
+  // An operator who wrote a path into their compose file did not mean it to be
+  // removable by anyone who can reach Settings.
+  it('does not let an administrator take back what the environment set', () => {
+    const exclusions = build(['Stacks/docker']);
+
+    exclusions.setAdminPaths(['Stacks/docker', 'Backups/2024']);
+
+    expect(exclusions.snapshot().excludedPaths).toEqual(['Backups/2024']);
+    expect(exclusions.effectivePaths()).toContain('Stacks/docker');
+  });
+
+  it('says what changed, which is what tells a caller to act', () => {
+    const exclusions = build();
+    exclusions.setAdminPaths(['Photos/RAW']);
+
+    const changed = exclusions.setAdminPaths(['Backups/2024']);
+
+    expect(changed.added).toEqual(['Backups/2024']);
+    expect(changed.removed).toEqual(['Photos/RAW']);
+  });
+
+  it('matches a folder and everything under it, and nothing beside it', () => {
+    const exclusions = build(['Stacks/docker']);
+    const scope = { root: path.resolve('/volume') };
+
+    expect(exclusions.isExcluded(path.resolve('/volume/Stacks/docker'), scope)).toBe(true);
+    expect(exclusions.isExcluded(path.resolve('/volume/Stacks/docker/overlay2'), scope)).toBe(true);
+    // A sibling whose name merely starts the same way is not inside it.
+    expect(exclusions.isExcluded(path.resolve('/volume/Stacks/docker-compose'), scope)).toBe(false);
+    expect(exclusions.isExcluded(path.resolve('/volume/Stacks'), scope)).toBe(false);
+  });
+
+  // Each index has its own list; one must not be able to overwrite the other's.
+  it('gives each caller its own state', () => {
+    const first = build(['A']);
+    const second = build(['B']);
+
+    first.setAdminPaths(['first-only']);
+
+    expect(second.snapshot().excludedPaths).toEqual([]);
+    expect(second.effectivePaths()).toEqual(['B']);
+  });
+});

--- a/backend/tests/services/search-index.test.js
+++ b/backend/tests/services/search-index.test.js
@@ -1,0 +1,731 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+import { buildPdf } from '../helpers/pdf-fixture.js';
+
+/**
+ * The index keeps terms, not text, and is built by a walk that has to be
+ * interruptible: one that cannot be stopped decides for itself when the server
+ * is free, and it is always wrong about that.
+ */
+
+let envContext;
+let db;
+let store;
+let indexer;
+
+const volumePath = (...parts) => path.join(envContext.volumeDir, ...parts);
+
+const build = async (env = {}) => {
+  envContext = await setupTestEnv({ tag: 'search-index-', env });
+  const dbService = envContext.requireFresh('src/services/db');
+  db = await dbService.getDb();
+  store = envContext.requireFresh('src/services/searchIndexStore');
+  indexer = envContext.requireFresh('src/services/searchIndexer');
+};
+
+const indexAll = (options = {}) =>
+  indexer.indexTree({ db, rootAbs: envContext.volumeDir, cpuPercent: 100, ...options });
+
+afterEach(async () => {
+  if (envContext) await envContext.cleanup();
+  envContext = null;
+});
+
+describe('what the index knows', () => {
+  beforeEach(async () => {
+    await build();
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+    await fs.writeFile(
+      volumePath('Docs', 'notes.md'),
+      '# Notes\n\nle pangolin mange des fourmis\n'
+    );
+    await fs.writeFile(volumePath('Docs', 'other.txt'), 'rien de particulier ici\n');
+  });
+
+  it('finds a document by a word inside it', async () => {
+    await indexAll();
+
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/notes.md']);
+  });
+
+  // The schema asks for it, and it is what makes a French index usable.
+  it('ignores accents and case', async () => {
+    await indexAll();
+
+    expect(store.search(db, 'FOURMIS')).toEqual(['Docs/notes.md']);
+    expect(store.search(db, 'pangolín')).toEqual(['Docs/notes.md']);
+  });
+
+  it('says nothing for a word nobody wrote', async () => {
+    await indexAll();
+
+    expect(store.search(db, 'tatou')).toEqual([]);
+  });
+
+  it('reads Office documents and PDFs too', async () => {
+    await fs.writeFile(volumePath('Docs', 'report.pdf'), buildPdf('the pangolin report'));
+    await indexAll();
+
+    expect(store.search(db, 'report')).toContain('Docs/report.pdf');
+  });
+
+  // A term the user typed is a term, not an expression: someone searching for
+  // `NOT` or a quote is looking for those characters.
+  it('takes a query that would otherwise be FTS syntax', async () => {
+    await fs.writeFile(volumePath('Docs', 'odd.txt'), 'the word NOT appears here\n');
+    await indexAll();
+
+    expect(store.search(db, 'NOT')).toContain('Docs/odd.txt');
+    expect(() => store.search(db, '"')).not.toThrow();
+  });
+});
+
+describe('keeping up with the files', () => {
+  beforeEach(async () => {
+    await build();
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+    await fs.writeFile(volumePath('Docs', 'notes.md'), 'le pangolin est là\n');
+  });
+
+  // The second run is what has to be cheap, or an index is a tax.
+  it('does not open a file it has already read', async () => {
+    const first = await indexAll();
+    expect(first.indexed).toBe(1);
+
+    const second = await indexAll();
+    expect(second.indexed).toBe(0);
+    expect(second.skipped).toBe(1);
+  });
+
+  it('notices a file that changed', async () => {
+    await indexAll();
+    await fs.writeFile(volumePath('Docs', 'notes.md'), 'le tatou a pris sa place\n');
+
+    const again = await indexAll();
+
+    expect(again.indexed).toBe(1);
+    expect(store.search(db, 'pangolin')).toEqual([]);
+    expect(store.search(db, 'tatou')).toEqual(['Docs/notes.md']);
+  });
+
+  it('forgets a file that is gone', async () => {
+    await indexAll();
+    await fs.rm(volumePath('Docs', 'notes.md'));
+
+    const again = await indexAll();
+
+    expect(again.removed).toBe(1);
+    expect(store.search(db, 'pangolin')).toEqual([]);
+  });
+
+  it('follows a rename without reading anything again', async () => {
+    await indexAll();
+
+    store.movePath(db, 'Docs', 'Archive');
+
+    expect(store.search(db, 'pangolin')).toEqual(['Archive/notes.md']);
+  });
+});
+
+describe('being interruptible', () => {
+  beforeEach(async () => {
+    await build();
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+    for (let index = 0; index < 60; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', `file-${index}.txt`), `document ${index} pangolin\n`);
+    }
+  });
+
+  it('stops when asked and says so', async () => {
+    const controller = new AbortController();
+    const running = indexAll({ signal: controller.signal, batchSize: 5, cpuPercent: 1, workSliceMs: 1 });
+    // Long enough to have started, far short of sixty files.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    controller.abort();
+
+    const result = await running;
+
+    expect(result.interrupted).toBe(true);
+    expect(result.indexed).toBeLessThan(60);
+  });
+
+  // What it did get through is kept: the next run has that much less to do.
+  it('keeps the work it had already done', async () => {
+    const controller = new AbortController();
+    const running = indexAll({ signal: controller.signal, batchSize: 5, cpuPercent: 1, workSliceMs: 1 });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    controller.abort();
+    const first = await running;
+
+    expect(store.stats(db).documents).toBe(first.indexed);
+
+    const second = await indexAll();
+    expect(second.skipped).toBe(first.indexed);
+    expect(store.stats(db).documents).toBe(60);
+  });
+
+  // An interrupted walk has not seen the whole tree, so it cannot know what is
+  // missing from it — deleting on that basis would empty the index.
+  it('does not decide what is missing when it was cut short', async () => {
+    await indexAll();
+    expect(store.stats(db).documents).toBe(60);
+
+    const controller = new AbortController();
+    controller.abort();
+    const result = await indexAll({ signal: controller.signal });
+
+    expect(result.interrupted).toBe(true);
+    expect(result.removed).toBe(0);
+    expect(store.stats(db).documents).toBe(60);
+  });
+});
+
+describe('what it leaves out', () => {
+  beforeEach(async () => {
+    await build({ SEARCH_MAX_FILESIZE: '2K' });
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+  });
+
+  it('leaves a file bigger than the limit alone', async () => {
+    await fs.writeFile(volumePath('Docs', 'big.txt'), `${'x'.repeat(4096)}\npangolin\n`);
+    await fs.writeFile(volumePath('Docs', 'small.txt'), 'pangolin\n');
+
+    await indexAll();
+
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/small.txt']);
+  });
+
+  // A null byte is the giveaway, and it has to be the one that decides: the
+  // rest of this file is perfectly ordinary text, which is what a real binary
+  // with embedded strings looks like. The extension is one nothing rules out,
+  // so the sniff is the only thing that can be doing the work here.
+  it('leaves binaries alone', async () => {
+    await fs.writeFile(
+      volumePath('Docs', 'blob.dat'),
+      Buffer.from(
+        'pangolin\u0000pangolin\u0000pangolin and a great deal of ordinary text',
+        'binary'
+      )
+    );
+    await fs.writeFile(volumePath('Docs', 'text.txt'), 'pangolin\n');
+
+    await indexAll();
+
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/text.txt']);
+    expect(store.stats(db).documents).toBe(1);
+  });
+});
+
+/**
+ * A background task must not be the reason a container runs out of memory. A
+ * batch counted in documents says nothing about how much is being held: a file
+ * of a few megabytes becomes a string twice that size, and a handful of them
+ * together is hundreds of megabytes while FTS5 tokenises each in turn.
+ */
+describe('how much it holds at once', () => {
+  beforeEach(async () => {
+    await build({ SEARCH_MAX_FILESIZE: '20M' });
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+  });
+
+  it('writes in smaller batches when the documents are large', async () => {
+    // Six documents of two megabytes each: counted in documents that is one
+    // batch, counted in bytes it cannot be.
+    for (let index = 0; index < 6; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(
+        volumePath('Docs', `big-${index}.txt`),
+        `pangolin ${'lorem ipsum dolor sit amet '.repeat(80000)}`
+      );
+    }
+
+    const result = await indexAll({ batchSize: 25 });
+
+    expect(result.indexed).toBe(6);
+    expect(result.batches).toBeGreaterThan(1);
+    expect(store.search(db, 'pangolin').length).toBe(6);
+  });
+
+  // Terms are what is kept, and a megabyte of them is two hundred thousand
+  // words. Beyond that an index is carrying weight it cannot be asked about.
+  it('keeps only as much of one document as is worth searching', async () => {
+    const padding = 'lorem ipsum dolor sit amet '.repeat(60000);
+    await fs.writeFile(volumePath('Docs', 'huge.txt'), `pangolin ${padding} tatou`);
+
+    await indexAll();
+
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/huge.txt']);
+    // Past the cap, so never taken in.
+    expect(store.search(db, 'tatou')).toEqual([]);
+  });
+});
+
+/**
+ * What a pass costs the machine it runs on.
+ *
+ * Every defect below was found running against a real volume of some three
+ * hundred thousand files, where a background task settled at half a core and
+ * two gigabytes of resident memory. None of them are visible on a small tree,
+ * which is why each one is pinned by an observable rather than by a timing.
+ */
+describe('what a pass costs', () => {
+  beforeEach(async () => {
+    await build({ SEARCH_MAX_FILESIZE: '20M' });
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+  });
+
+  // Deciding from the name is the difference between a pass proportional to
+  // the documents and one proportional to the disk. The content here is plain
+  // text, so the sniff would have taken it: only the extension can refuse it.
+  it('does not open what its name says is not text', async () => {
+    await fs.writeFile(volumePath('Docs', 'holiday.mp4'), 'pangolin in plain text\n');
+    await fs.writeFile(volumePath('Docs', 'archive.zip'), 'pangolin in plain text\n');
+    await fs.writeFile(volumePath('Docs', 'notes.txt'), 'pangolin in plain text\n');
+
+    await indexAll();
+
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/notes.txt']);
+  });
+
+  // Reading a file to find out it is a binary costs the same as reading a
+  // document. At a few hundred files a second that was gigabytes of buffers
+  // allocated and thrown away, which is what the memory graph was made of.
+  it('reads a few kilobytes of a binary, not all of it', async () => {
+    const megabyte = Buffer.alloc(4 * 1024 * 1024, 0x41);
+    megabyte[10] = 0;
+    await fs.writeFile(volumePath('Docs', 'opaque.dat'), megabyte);
+
+    let bytesRead = 0;
+    const realOpen = fs.open;
+    fs.open = async (...args) => {
+      const handle = await realOpen(...args);
+      const realRead = handle.read.bind(handle);
+      handle.read = async (...readArgs) => {
+        const result = await realRead(...readArgs);
+        bytesRead += result.bytesRead;
+        return result;
+      };
+      return handle;
+    };
+
+    try {
+      await indexAll();
+    } finally {
+      fs.open = realOpen;
+    }
+
+    expect(store.stats(db).documents).toBe(0);
+    // Both halves matter: reading none of it through this path would pass the
+    // ceiling below while reading all four megabytes some other way.
+    expect(bytesRead).toBeGreaterThan(0);
+    expect(bytesRead).toBeLessThanOrEqual(4096);
+  });
+
+  // The pause used to be taken when a batch was written, so a batch large
+  // enough never to be written was a walk that never stood aside. Time is what
+  // it costs the machine, so time is what it has to be paid in.
+  it('stands aside on elapsed time, not on how many files went by', async () => {
+    for (let index = 0; index < 40; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', `note-${index}.txt`), `pangolin ${index}\n`);
+    }
+
+    // A batch this size is never reached, so nothing is written until the end.
+    const paced = await indexAll({ batchSize: 10000, cpuPercent: 50, workSliceMs: 1 });
+    expect(paced.batches).toBe(1);
+    expect(paced.pauses).toBeGreaterThan(0);
+
+    const flatOut = await indexAll({ batchSize: 10000, cpuPercent: 100 });
+    expect(flatOut.pauses).toBe(0);
+  });
+
+  // The volume is the user's, and what is worth searching in it is theirs to
+  // say. A build tree or a machine backup is hundreds of thousands of files
+  // nobody searches by content, and reading them is the whole overhead.
+  it('leaves out what it was told to leave out', async () => {
+    await fs.mkdir(volumePath('Docs', 'machine-backup'), { recursive: true });
+    await fs.writeFile(volumePath('Docs', 'machine-backup', 'output.txt'), 'pangolin\n');
+    await fs.writeFile(volumePath('Docs', 'kept.txt'), 'pangolin\n');
+
+    const result = await indexAll({ exclude: ['Docs/machine-backup'] });
+
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/kept.txt']);
+    expect(result.indexed).toBe(1);
+  });
+
+  it('reads the same tree when it was told nothing', async () => {
+    await fs.mkdir(volumePath('Docs', 'machine-backup'), { recursive: true });
+    await fs.writeFile(volumePath('Docs', 'machine-backup', 'output.txt'), 'pangolin\n');
+    await fs.writeFile(volumePath('Docs', 'kept.txt'), 'pangolin\n');
+
+    const result = await indexAll({ exclude: [] });
+
+    expect(result.indexed).toBe(2);
+  });
+
+  // Compiling a statement holds kilobytes of native memory that V8 cannot see,
+  // so nothing pushes back and nothing is collected. Three per document over a
+  // large volume is where the two gigabytes came from.
+  it('compiles its queries once, not once per document', async () => {
+    for (let index = 0; index < 40; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', `note-${index}.txt`), `pangolin ${index}\n`);
+    }
+
+    let compiled = 0;
+    const realPrepare = db.prepare.bind(db);
+    db.prepare = (...args) => {
+      compiled += 1;
+      return realPrepare(...args);
+    };
+
+    try {
+      await indexAll();
+    } finally {
+      db.prepare = realPrepare;
+    }
+
+    expect(store.stats(db).documents).toBe(40);
+    // A handful of distinct queries. Per document it would be over a hundred.
+    expect(compiled).toBeLessThan(12);
+  });
+
+  // A single reading is not enough: the figure is the whole process, so a
+  // thumbnail sweep or a folder-size pass running alongside would otherwise
+  // end the indexing that happens to be running at the same moment.
+  it('does not stop on one reading that another task caused', async () => {
+    for (let index = 0; index < 40; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', `note-${index}.txt`), `pangolin ${index}\n`);
+    }
+
+    // One spike well over the budget, then back to normal.
+    let reading = 0;
+    const result = await indexAll({
+      batchSize: 1,
+      workSliceMs: 0,
+      memoryBudgetBytes: 1000,
+      readMemory: () => {
+        reading += 1;
+        return reading === 4 ? 100000 : 500;
+      },
+    });
+
+    expect(result.stoppedForMemory).toBe(false);
+    expect(result.indexed).toBe(40);
+  });
+
+  // The last line of defence. Every bound above is a belief about what a file
+  // costs; this one holds when a belief turns out to be wrong.
+  it('stops rather than let the process grow without end', async () => {
+    for (let index = 0; index < 40; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', `note-${index}.txt`), `pangolin ${index}\n`);
+    }
+
+    let reading = 0;
+    const result = await indexAll({
+      batchSize: 1,
+      workSliceMs: 0,
+      memoryBudgetBytes: 1000,
+      // Growing by a kilobyte each time it is asked, so the budget is passed
+      // partway through rather than at the first file or not at all.
+      readMemory: () => {
+        reading += 1;
+        return reading * 500;
+      },
+    });
+
+    expect(result.stoppedForMemory).toBe(true);
+    expect(result.interrupted).toBe(true);
+    expect(result.indexed).toBeGreaterThan(0);
+    expect(result.indexed).toBeLessThan(40);
+    // What it wrote before stopping is kept, so the next pass carries on.
+    expect(store.stats(db).documents).toBe(result.indexed);
+  });
+});
+
+/**
+ * The application announces what it writes, and nobody waits for the answer.
+ * Copying a folder of ten thousand files therefore used to start ten thousand
+ * file reads at once, on top of whatever pass was already running — which is
+ * how a background task came to hold more of a machine than the application it
+ * was serving.
+ */
+describe('how much runs at once', () => {
+  let manager;
+
+  beforeEach(async () => {
+    await build({ SEARCH_INDEX: 'true' });
+    manager = envContext.requireFresh('src/services/searchIndexManager');
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+  });
+
+  afterEach(() => {
+    manager?.stop();
+  });
+
+  it('reads one announced file at a time, however many are announced', async () => {
+    for (let index = 0; index < 30; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', `note-${index}.txt`), `pangolin ${index}\n`);
+    }
+
+    let openNow = 0;
+    let openAtMost = 0;
+    const realOpen = fs.open;
+    fs.open = async (...args) => {
+      openNow += 1;
+      openAtMost = Math.max(openAtMost, openNow);
+      try {
+        const handle = await realOpen(...args);
+        const realClose = handle.close.bind(handle);
+        handle.close = async () => {
+          openNow -= 1;
+          return realClose();
+        };
+        return handle;
+      } catch (error) {
+        openNow -= 1;
+        throw error;
+      }
+    };
+
+    try {
+      // Announced the way the application announces them: all at once, awaited
+      // by nobody.
+      await Promise.all(
+        Array.from({ length: 30 }, (unused, index) =>
+          manager.onFileChanged(volumePath('Docs', `note-${index}.txt`))
+        )
+      );
+    } finally {
+      fs.open = realOpen;
+    }
+
+    expect(openAtMost).toBe(1);
+    expect((await manager.status()).documents).toBe(30);
+  });
+
+  // A backlog with no bottom is a memory leak wearing a queue's clothes.
+  it('drops what it cannot keep up with rather than remember all of it', async () => {
+    const announcements = [];
+    for (let index = 0; index < 1200; index += 1) {
+      announcements.push(manager.onFileChanged(volumePath('Docs', `ghost-${index}.txt`)));
+    }
+    await Promise.all(announcements);
+
+    const status = await manager.status();
+    expect(status.pending).toBe(0);
+    expect(status.dropped).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * A pass used to carry every path it had seen to the end, so it could work out
+ * what had gone. Fifty megabytes for two hundred thousand files, held from the
+ * first folder to the last, on a container whose whole working set is sixty.
+ * It asks the index what a folder held instead, and forgets the folder as soon
+ * as it leaves it.
+ */
+describe('forgetting what is gone', () => {
+  beforeEach(async () => {
+    await build();
+    await fs.mkdir(volumePath('Docs', 'Notes'), { recursive: true });
+    await fs.writeFile(volumePath('Docs', 'Notes', 'one.txt'), 'pangolin one\n');
+    await fs.writeFile(volumePath('Docs', 'Notes', 'two.txt'), 'pangolin two\n');
+    await fs.writeFile(volumePath('Docs', 'kept.txt'), 'pangolin kept\n');
+    await indexAll();
+  });
+
+  it('forgets a file that was removed from a folder', async () => {
+    await fs.rm(volumePath('Docs', 'Notes', 'one.txt'));
+
+    const result = await indexAll();
+
+    expect(result.removed).toBe(1);
+    expect(store.search(db, 'pangolin').sort()).toEqual(['Docs/Notes/two.txt', 'Docs/kept.txt']);
+  });
+
+  // Nothing walks a folder that is not there, so nothing asks what it held.
+  it('forgets a folder that was removed outright', async () => {
+    await fs.rm(volumePath('Docs', 'Notes'), { recursive: true });
+
+    const result = await indexAll();
+
+    expect(result.removed).toBe(2);
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/kept.txt']);
+  });
+
+  // A folder that was listed in full is a folder whose absences are known,
+  // whatever happens to the pass afterwards.
+  it('keeps the deletions it was sure of when it is cut short', async () => {
+    await fs.rm(volumePath('Docs', 'Notes', 'one.txt'));
+    for (let index = 0; index < 60; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', `filler-${index}.txt`), `pangolin ${index}\n`);
+    }
+
+    const controller = new AbortController();
+    const running = indexAll({ signal: controller.signal, cpuPercent: 1, workSliceMs: 1 });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    controller.abort();
+    const result = await running;
+
+    expect(result.interrupted).toBe(true);
+    expect(store.search(db, 'pangolin')).not.toContain('Docs/Notes/one.txt');
+  });
+});
+
+/**
+ * A pass that re-reads tens of thousands of files nobody touched is either
+ * looking at a volume that really does change that much, or asking a question
+ * its storage cannot answer the same way twice. From a count the two are
+ * identical, so the disagreement itself has to be reported.
+ */
+describe('saying why a file was read again', () => {
+  beforeEach(async () => {
+    await build();
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+    await fs.writeFile(volumePath('Docs', 'note.txt'), 'pangolin\n');
+    await indexAll();
+  });
+
+  // Half an hour is too long to wait to learn which folder is responsible.
+  it('carries the count and the folder leading it in every progress line', async () => {
+    await fs.mkdir(volumePath('Docs', 'Churn'), { recursive: true });
+    const settled = new Date(1_700_000_000_000);
+    for (let index = 0; index < 8; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', 'Churn', `c-${index}.txt`), `pangolin ${index}\n`);
+      // eslint-disable-next-line no-await-in-loop
+      await fs.utimes(volumePath('Docs', 'Churn', `c-${index}.txt`), settled, settled);
+    }
+    await indexAll();
+
+    const moved = new Date(1_700_000_060_000);
+    for (let index = 0; index < 8; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.utimes(volumePath('Docs', 'Churn', `c-${index}.txt`), moved, moved);
+    }
+
+    const lines = [];
+    await indexAll({ batchSize: 1, progressMs: 0, onProgress: (line) => lines.push(line) });
+
+    expect(lines.length).toBeGreaterThan(0);
+    const last = lines[lines.length - 1];
+    expect(last.reindexed).toBeGreaterThan(0);
+    expect(last.rereadTopFolder).toBe('Docs/Churn');
+    expect(last.rereadTopCount).toBeGreaterThan(0);
+  });
+
+  it('reports nothing when nothing was read again', async () => {
+    const result = await indexAll();
+
+    expect(result.reindexedKnown).toBe(0);
+    expect(result.rereadSamples).toEqual([]);
+  });
+
+  it('names the file and the field that disagreed', async () => {
+    // Same size, different date: the case that a count cannot tell apart from
+    // real activity.
+    const future = new Date(Date.now() + 60_000);
+    await fs.utimes(volumePath('Docs', 'note.txt'), future, future);
+
+    const result = await indexAll();
+
+    expect(result.reindexedKnown).toBe(1);
+    expect(result.rereadSamples).toHaveLength(1);
+
+    const [sample] = result.rereadSamples;
+    expect(sample.path).toBe('Docs/note.txt');
+    expect(sample.differs).toBe('mtime');
+    expect(sample.storedSize).toBe(sample.diskSize);
+    expect(sample.mtimeDeltaMs).toBeGreaterThan(0);
+  });
+
+  // The three shapes have to separate the three explanations, or the pass is
+  // just a total again.
+  it('separates a constant offset from one noisy folder', async () => {
+    await fs.mkdir(volumePath('Docs', 'Bruyant'), { recursive: true });
+    // Given the same starting date, so that a shared shift really is one
+    // delta. Left to their creation times they differ by a millisecond here
+    // and there, and six files produce six deltas — which is the noise this
+    // report exists to tell apart from a signal.
+    const before = new Date(1_700_000_000_000);
+    for (let index = 0; index < 6; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(volumePath('Docs', 'Bruyant', `n-${index}.txt`), `pangolin ${index}\n`);
+      // eslint-disable-next-line no-await-in-loop
+      await fs.utimes(volumePath('Docs', 'Bruyant', `n-${index}.txt`), before, before);
+    }
+    await indexAll();
+
+    // Every file in one folder, all moved by exactly the same amount: the
+    // signature of storage that rounds, and of nothing else.
+    const shifted = new Date(1_700_000_120_000);
+    for (let index = 0; index < 6; index += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.utimes(volumePath('Docs', 'Bruyant', `n-${index}.txt`), shifted, shifted);
+    }
+
+    const result = await indexAll();
+
+    expect(result.reindexedKnown).toBe(6);
+    expect(result.rereadByField.mtime).toBe(6);
+    expect(result.rereadByField.size).toBe(0);
+    // One folder accounts for all of it.
+    expect(result.topRereadDirs[0]).toEqual({ value: 'Docs/Bruyant', count: 6 });
+    // And one delta accounts for all of it.
+    expect(result.topMtimeDeltas).toEqual([{ value: 120_000, count: 6 }]);
+  });
+
+  it('says so when it is the size that moved', async () => {
+    await fs.writeFile(volumePath('Docs', 'note.txt'), 'pangolin and more\n');
+
+    const result = await indexAll();
+
+    const [sample] = result.rereadSamples;
+    expect(['size', 'both']).toContain(sample.differs);
+    expect(sample.diskSize).toBeGreaterThan(sample.storedSize);
+  });
+});
+
+/**
+ * An index holding nine thousand documents where the volume has six hundred
+ * thousand is either a working exclusion or a silent hole, and nothing in the
+ * log told the two apart — the question had to be asked and answered by hand.
+ */
+describe('saying what it does not read', () => {
+  beforeEach(async () => {
+    await build({ SEARCH_INDEX_EXCLUDE: 'Stacks/docker' });
+    await fs.mkdir(volumePath('Docs'), { recursive: true });
+  });
+
+  it('reports the environment list and the administrator list apart', async () => {
+    const exclusions = envContext.requireFresh('src/services/searchIndexExclusions');
+    exclusions.setAdminPaths(['Sauvegardes/2024']);
+
+    expect(exclusions.snapshot()).toEqual({
+      environmentExcludedPaths: ['Stacks/docker'],
+      excludedPaths: ['Sauvegardes/2024'],
+    });
+    // And the pass is given both, so what it skipped is what was asked.
+    expect(exclusions.effectivePaths()).toEqual(['Sauvegardes/2024', 'Stacks/docker']);
+  });
+
+  it('leaves out what the environment named, without being told twice', async () => {
+    await fs.mkdir(volumePath('Stacks', 'docker'), { recursive: true });
+    await fs.writeFile(volumePath('Stacks', 'docker', 'layer.txt'), 'pangolin\n');
+    await fs.writeFile(volumePath('Docs', 'kept.txt'), 'pangolin\n');
+
+    const exclusions = envContext.requireFresh('src/services/searchIndexExclusions');
+    const result = await indexAll({ exclude: exclusions.effectivePaths() });
+
+    expect(result.indexed).toBe(1);
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/kept.txt']);
+  });
+});

--- a/backend/tests/services/searchIndexManager.test.js
+++ b/backend/tests/services/searchIndexManager.test.js
@@ -1,0 +1,391 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * When the index is built, when it is not, and what it refuses to read.
+ *
+ * This is the service that decides what a search can see. Three of its rules
+ * are worth being sure of. A folder an administrator has just excluded is
+ * forgotten immediately rather than at the next pass, because until it is the
+ * index goes on answering searches from a folder somebody said not to read. A
+ * path outside the volume is not indexed at all, whatever asks for it. And the
+ * backlog of per-file updates has a bottom: copying a large folder announces
+ * one update per file, and a queue that grows without limit is the whole point
+ * of having a periodic pass to fall back on.
+ *
+ * Run against a real database, a real store and a real volume, the way the
+ * other index tests are: what is being tested is the coordination, and mocking
+ * the parts it coordinates would test the mock.
+ */
+
+let envContext;
+let manager;
+let store;
+let db;
+
+const volumePath = (...parts) => path.join(envContext.volumeDir, ...parts);
+
+const build = async (env = {}) => {
+  envContext = await setupTestEnv({
+    tag: 'search-index-manager-',
+    env: { SEARCH_INDEX: 'true', SEARCH_INDEX_CPU_PERCENT: '100', ...env },
+  });
+  const dbService = envContext.requireFresh('src/services/db');
+  db = await dbService.getDb();
+  store = envContext.requireFresh('src/services/searchIndexStore');
+  manager = envContext.requireFresh('src/services/searchIndexManager');
+};
+
+const seedDocs = async () => {
+  await fs.mkdir(volumePath('Docs'), { recursive: true });
+  await fs.writeFile(volumePath('Docs', 'notes.md'), 'le pangolin mange des fourmis\n');
+  await fs.writeFile(volumePath('Docs', 'autre.txt'), 'rien de particulier\n');
+};
+
+const indexed = () => store.stats(db).documents;
+
+afterEach(async () => {
+  manager?.stop();
+  manager = null;
+  if (envContext) await envContext.cleanup();
+  envContext = null;
+  vi.useRealTimers();
+});
+
+describe('a pass over the volume', () => {
+  it('reads what is there', async () => {
+    await build();
+    await seedDocs();
+
+    await manager.reconcile({ reason: 'test' });
+
+    expect(indexed()).toBe(2);
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/notes.md']);
+  });
+
+  /** Only a pass that reached the end can promise the index answers for everything. */
+  it('marks the index ready once it has been all the way through', async () => {
+    await build();
+    await seedDocs();
+    expect(store.isReady(db)).toBe(false);
+
+    await manager.reconcile({ reason: 'test' });
+
+    expect(store.isReady(db)).toBe(true);
+  });
+
+  it('leaves it unready when the pass was cut short', async () => {
+    await build();
+    await seedDocs();
+
+    const pass = manager.reconcile({ reason: 'test' });
+    manager.stop();
+    await pass;
+
+    expect(store.isReady(db)).toBe(false);
+  });
+
+  it('runs one at a time', async () => {
+    await build();
+    await seedDocs();
+
+    const [first, second] = await Promise.all([
+      manager.reconcile({ reason: 'a' }),
+      manager.reconcile({ reason: 'b' }),
+    ]);
+
+    expect(Boolean(first) !== Boolean(second)).toBe(true);
+  });
+
+  it('does nothing once the service has been stopped', async () => {
+    await build();
+    await seedDocs();
+    manager.stop();
+
+    expect(await manager.reconcile({ reason: 'test' })).toBeNull();
+    expect(indexed()).toBe(0);
+  });
+
+  it('does nothing at all where the index is switched off', async () => {
+    await build({ SEARCH_INDEX: 'false' });
+    await seedDocs();
+
+    expect(await manager.reconcile({ reason: 'test' })).toBeNull();
+  });
+
+  /** A failing pass is a pass that runs again later, not a crashed service. */
+  it('survives a pass that throws', async () => {
+    await build();
+    await seedDocs();
+    await fs.rm(envContext.volumeDir, { recursive: true, force: true });
+
+    await expect(manager.reconcile({ reason: 'test' })).resolves.toBeDefined();
+  });
+});
+
+describe('starting and stopping', () => {
+  it('runs a first pass and schedules the ones after it', async () => {
+    await build();
+    await seedDocs();
+
+    manager.start();
+    await vi.waitFor(() => expect(indexed()).toBe(2));
+
+    expect((await manager.status()).enabled).toBe(true);
+  });
+
+  it('starts nothing where the index is switched off', async () => {
+    await build({ SEARCH_INDEX: 'false' });
+    await seedDocs();
+
+    manager.start();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(indexed()).toBe(0);
+  });
+
+  it('stops the scheduled passes', async () => {
+    await build();
+    await seedDocs();
+    manager.start();
+    await vi.waitFor(() => expect(indexed()).toBe(2));
+
+    manager.stop();
+    await fs.writeFile(volumePath('Docs', 'nouveau.md'), 'encore un pangolin\n');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(indexed()).toBe(2);
+  });
+});
+
+describe('a folder an administrator excludes', () => {
+  it('is forgotten straight away, not at the next pass', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+    expect(store.search(db, 'pangolin')).toEqual(['Docs/notes.md']);
+
+    await manager.setAdminExclusions(['Docs']);
+    await vi.waitFor(() => expect(store.search(db, 'pangolin')).toEqual([]));
+  });
+
+  it('says what changed', async () => {
+    await build();
+
+    const changed = await manager.setAdminExclusions(['Docs']);
+
+    expect(changed.added).toEqual(['Docs']);
+  });
+
+  it('is not read by the next pass either', async () => {
+    await build();
+    await seedDocs();
+    await manager.setAdminExclusions(['Docs']);
+
+    await manager.reconcile({ reason: 'test' });
+
+    expect(indexed()).toBe(0);
+  });
+
+  /** Removing an exclusion is the next pass's job; nothing is read here. */
+  it('is picked up again by a later pass once the exclusion goes', async () => {
+    await build();
+    await seedDocs();
+    await manager.setAdminExclusions(['Docs']);
+    await manager.reconcile({ reason: 'excluded' });
+    expect(indexed()).toBe(0);
+
+    await manager.setAdminExclusions([]);
+    await manager.reconcile({ reason: 'again' });
+
+    expect(indexed()).toBe(2);
+  });
+
+  it('changes nothing where the index is switched off', async () => {
+    await build({ SEARCH_INDEX: 'false' });
+
+    const changed = await manager.setAdminExclusions(['Docs']);
+
+    expect(changed.added).toEqual(['Docs']);
+  });
+});
+
+describe('a file the application itself changed', () => {
+  it('is read into the index on its own', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+    await fs.writeFile(volumePath('Docs', 'nouveau.md'), 'un autre pangolin\n');
+
+    await manager.onFileChanged(volumePath('Docs', 'nouveau.md'));
+
+    expect(store.search(db, 'pangolin').sort()).toEqual(['Docs/notes.md', 'Docs/nouveau.md']);
+  });
+
+  it('is forgotten when it is removed', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+
+    await manager.onPathRemoved(volumePath('Docs', 'notes.md'));
+
+    expect(store.search(db, 'pangolin')).toEqual([]);
+  });
+
+  it('takes a whole folder with it', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+
+    await manager.onPathRemoved(volumePath('Docs'));
+
+    expect(indexed()).toBe(0);
+  });
+
+  it('follows a move', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+    await fs.mkdir(volumePath('Archive'), { recursive: true });
+    await fs.rename(volumePath('Docs', 'notes.md'), volumePath('Archive', 'notes.md'));
+
+    await manager.onPathMoved(volumePath('Docs', 'notes.md'), volumePath('Archive', 'notes.md'));
+
+    expect(store.search(db, 'pangolin')).toEqual(['Archive/notes.md']);
+  });
+
+  /**
+   * A rename is a rename: the words did not change, only where they live. The
+   * index entry is carried across rather than the file being opened again —
+   * which is what makes renaming a folder of ten thousand files cost ten
+   * thousand row updates instead of ten thousand reads.
+   */
+  it('does not read the file again to do it', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+    await fs.mkdir(volumePath('Archive'), { recursive: true });
+    await fs.rename(volumePath('Docs', 'notes.md'), volumePath('Archive', 'notes.md'));
+    // Different words at the destination, which only a re-read could pick up.
+    await fs.writeFile(volumePath('Archive', 'notes.md'), 'le tatou mange des fourmis\n');
+
+    await manager.onPathMoved(volumePath('Docs', 'notes.md'), volumePath('Archive', 'notes.md'));
+
+    expect(store.search(db, 'pangolin')).toEqual(['Archive/notes.md']);
+    expect(store.search(db, 'tatou')).toEqual([]);
+  });
+
+  it('forgets a file moved out of the volume', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+
+    await manager.onPathMoved(volumePath('Docs', 'notes.md'), '/ailleurs/notes.md');
+
+    expect(store.search(db, 'pangolin')).toEqual([]);
+  });
+
+  it('reads a file moved into the volume', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+    await fs.writeFile(volumePath('Docs', 'arrive.md'), 'encore un pangolin\n');
+
+    await manager.onPathMoved('/ailleurs/arrive.md', volumePath('Docs', 'arrive.md'));
+
+    expect(store.search(db, 'pangolin').sort()).toEqual(['Docs/arrive.md', 'Docs/notes.md']);
+  });
+
+  it('says nothing about a move that never touched the volume', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+
+    await manager.onPathMoved('/ailleurs/a.md', '/ailleurs/b.md');
+
+    expect(indexed()).toBe(2);
+  });
+});
+
+describe('what the index refuses to read', () => {
+  /**
+   * The path decides what is indexed, so a path that walks out of the volume
+   * with `..` would have the index reading, and later answering searches from,
+   * files nobody shared through this server at all.
+   */
+  it('a path that climbs out of the volume', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+
+    await manager.onFileChanged(path.join(envContext.volumeDir, '..', 'dehors.md'));
+
+    expect(indexed()).toBe(2);
+  });
+
+  it('an absolute path somewhere else entirely', async () => {
+    await build();
+    await seedDocs();
+
+    await manager.onFileChanged('/etc/passwd');
+    await manager.onPathRemoved('/etc/passwd');
+
+    expect(indexed()).toBe(0);
+  });
+
+  it('nothing at all', async () => {
+    await build();
+
+    await expect(manager.onFileChanged('')).resolves.toBeUndefined();
+    await expect(manager.onPathRemoved(null)).resolves.toBeUndefined();
+  });
+
+  /**
+   * Work announced after a stop is refused rather than queued: a shutdown that
+   * takes a moment must not spend it reading files.
+   */
+  it('anything, once the service is stopped', async () => {
+    await build();
+    await seedDocs();
+    manager.stop();
+
+    await manager.onFileChanged(volumePath('Docs', 'notes.md'));
+
+    expect(indexed()).toBe(0);
+    expect((await manager.status()).pending).toBe(0);
+  });
+
+  it('anything, where the index is switched off', async () => {
+    await build({ SEARCH_INDEX: 'false' });
+    await seedDocs();
+
+    await manager.onFileChanged(volumePath('Docs', 'notes.md'));
+    await manager.onPathRemoved(volumePath('Docs', 'notes.md'));
+    await manager.onPathMoved(volumePath('Docs', 'notes.md'), volumePath('a.md'));
+
+    expect(indexed()).toBe(0);
+  });
+});
+
+describe('what it reports about itself', () => {
+  it('says it is off when it is', async () => {
+    await build({ SEARCH_INDEX: 'false' });
+
+    expect(await manager.status()).toEqual({ enabled: false });
+  });
+
+  it('says what it holds when it is on', async () => {
+    await build();
+    await seedDocs();
+    await manager.reconcile({ reason: 'seed' });
+
+    const status = await manager.status();
+
+    expect(status).toMatchObject({ enabled: true, running: false, ready: true, documents: 2 });
+    expect(status.pending).toBe(0);
+    expect(status.dropped).toBe(0);
+  });
+});


### PR DESCRIPTION
Batch 5 of #373 — the half deliberately left out of [3/14]. Cut from `main` at `a50f6e1`.

**~1 400 lines of code, ~1 600 of tests. 107 tests, all passing.**

## Why

A content search reads every file it is allowed to, every time. That is correct, and it does not scale: past a certain volume the time budget runs out before the tree does, and the answer becomes whatever part happened to get read. A term found yesterday goes missing today, with nothing in the answer to say why.

## What it stores

**Terms, not text.** A search asks the index for paths, then reads the line to display from the file itself — one read per *result* rather than one per *document*, and only for the handful actually returned.

That is the whole bargain of a contentless index and I think it is a good one: the database stays small, no file contents live in it, and a stale entry is caught the moment the line is read back (the file no longer says that, so it is simply not offered).

## Off unless asked for

`SEARCH_INDEX=true`. An index is a promise to keep something up to date, and that is a decision rather than a default.

Until a first pass has finished, searches read the tree exactly as they do today — the route asks whether the index is *ready* and believes the answer rather than assuming. A half-built index answering a search is worse than no index at all.

## How it is built

A walk that can be interrupted and resumed where it stopped, paced against a share of one core (`SEARCH_INDEX_CPU_PERCENT`) and a memory ceiling, with the container's own limit read rather than the host's. Files whose size and mtime match what was indexed are skipped without being opened, so a second pass costs a stat per file.

Folders an administrator excludes are forgotten immediately rather than at the next pass — until they are, the index goes on answering from a folder somebody just said not to read.

## One adaptation

**Schema v9**, not the v16 it is on our side: this tree stops at v8, so the migration is renumbered. It creates the index tables and nothing else; no existing table is touched.

## Tests

107 pass, including the ones removed from [3/14] because they belonged here (the index tests in `search-content`, and the folder-exclusion tests in `search-glob`).

The 15 pre-existing failures on `main` are unchanged — same list, none new.