### PR TITLE
[7/14] Folder sizes: show a folder's recursive size, from an index built in the background

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "fluent-ffmpeg": "^2.1.2",
     "jsonwebtoken": "^9.0.2",
     "memorystore": "^1.6.7",
+    "p-limit": "^3.1.0",
     "multer": "^2.0.2",
     "p-queue": "^7.4.1",
     "pino": "^10.1.0",

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -73,6 +73,17 @@ module.exports = {
   MAX_EXTRACTED_ARCHIVE_SIZE: process.env.MAX_EXTRACTED_ARCHIVE_SIZE?.trim() || null,
   MAX_ARCHIVE_ENTRIES: Number(process.env.MAX_ARCHIVE_ENTRIES) || 100000,
   ARCHIVE_EXTENSIONS: process.env.ARCHIVE_EXTENSIONS || '',
+  // --- Folder size index ---
+  FOLDER_SIZE_MODE: process.env.FOLDER_SIZE_MODE?.trim().toLowerCase() || 'off',
+  FOLDER_SIZE_EXCLUDE_PATHS: process.env.FOLDER_SIZE_EXCLUDE_PATHS || '',
+  FOLDER_SIZE_CONCURRENCY: Number(process.env.FOLDER_SIZE_CONCURRENCY) || 6,
+  FOLDER_SIZE_NETWORK_CONCURRENCY: Number(process.env.FOLDER_SIZE_NETWORK_CONCURRENCY) || 2,
+  FOLDER_SIZE_FLUSH_MS: Number(process.env.FOLDER_SIZE_FLUSH_MS) || 3000,
+  FOLDER_SIZE_RECONCILE_MS: Number(process.env.FOLDER_SIZE_RECONCILE_MS) || 0,
+  FOLDER_SIZE_RECONCILE_MIN_MS: Number(process.env.FOLDER_SIZE_RECONCILE_MIN_MS) || 900000,
+  FOLDER_SIZE_RECONCILE_MAX_MS: Number(process.env.FOLDER_SIZE_RECONCILE_MAX_MS) || 43200000,
+  FOLDER_SIZE_RECONCILE_BATCH: Number(process.env.FOLDER_SIZE_RECONCILE_BATCH) || 100,
+  FOLDER_SIZE_REBUILD: normalizeBoolean(process.env.FOLDER_SIZE_REBUILD) || false,
   // --- Search index ---
   SEARCH_INDEX: normalizeBoolean(process.env.SEARCH_INDEX) ?? false,
   SEARCH_INDEX_BATCH: Number(process.env.SEARCH_INDEX_BATCH) || null,

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -387,7 +387,51 @@ const archives = (() => {
   };
 })();
 
+// --- Folder size index ---
+const VALID_FOLDER_SIZE_MODES = new Set(['off', 'shallow', 'full']);
+const folderSizeMode = VALID_FOLDER_SIZE_MODES.has(env.FOLDER_SIZE_MODE)
+  ? env.FOLDER_SIZE_MODE
+  : 'off';
+
+const folderSize = {
+  mode: folderSizeMode,
+  enabled: folderSizeMode !== 'off',
+  envExcludedPaths: env.FOLDER_SIZE_EXCLUDE_PATHS,
+  concurrency: env.FOLDER_SIZE_CONCURRENCY,
+  networkConcurrency: env.FOLDER_SIZE_NETWORK_CONCURRENCY,
+  flushMs: env.FOLDER_SIZE_FLUSH_MS,
+  reconcileMs: env.FOLDER_SIZE_RECONCILE_MS,
+  reconcileMinMs: env.FOLDER_SIZE_RECONCILE_MIN_MS,
+  reconcileMaxMs: env.FOLDER_SIZE_RECONCILE_MAX_MS,
+  reconcileBatch: env.FOLDER_SIZE_RECONCILE_BATCH,
+  reconcilePauseMs: env.FOLDER_SIZE_RECONCILE_PAUSE_MS,
+  reconcileMaxDirectories:
+    Number.isFinite(env.FOLDER_SIZE_RECONCILE_MAX_DIRECTORIES) &&
+    env.FOLDER_SIZE_RECONCILE_MAX_DIRECTORIES >= 0
+      ? Math.floor(env.FOLDER_SIZE_RECONCILE_MAX_DIRECTORIES)
+      : 200,
+  subtreeBatch:
+    Number.isFinite(env.FOLDER_SIZE_SUBTREE_BATCH) && env.FOLDER_SIZE_SUBTREE_BATCH > 0
+      ? Math.floor(env.FOLDER_SIZE_SUBTREE_BATCH)
+      : env.FOLDER_SIZE_RECONCILE_BATCH,
+  subtreePauseMs:
+    Number.isFinite(env.FOLDER_SIZE_SUBTREE_PAUSE_MS) && env.FOLDER_SIZE_SUBTREE_PAUSE_MS >= 0
+      ? env.FOLDER_SIZE_SUBTREE_PAUSE_MS
+      : env.FOLDER_SIZE_RECONCILE_PAUSE_MS,
+  subtreeSlowLogMs: Math.max(0, env.FOLDER_SIZE_SUBTREE_SLOW_LOG_MS),
+  ioTimeoutMs:
+    Number.isFinite(env.FOLDER_SIZE_IO_TIMEOUT_MS) && env.FOLDER_SIZE_IO_TIMEOUT_MS >= 0
+      ? env.FOLDER_SIZE_IO_TIMEOUT_MS
+      : 30000,
+  maxStalledIo:
+    Number.isFinite(env.FOLDER_SIZE_MAX_STALLED_IO) && env.FOLDER_SIZE_MAX_STALLED_IO > 0
+      ? Math.floor(env.FOLDER_SIZE_MAX_STALLED_IO)
+      : 2,
+  rebuild: env.FOLDER_SIZE_REBUILD,
+};
+
 module.exports = {
+  folderSize,
   archives,
   port: env.PORT,
   address: env.ADDRESS,
@@ -498,6 +542,7 @@ module.exports = {
 
   features: {
     volumeUsage: env.SHOW_VOLUME_USAGE,
+    folderSizeMode,
     personalFolders: env.USER_DIR_ENABLED,
     userVolumes: env.USER_VOLUMES,
     shares: env.SHARES_ENABLED,

--- a/backend/src/routes/features.js
+++ b/backend/src/routes/features.js
@@ -48,6 +48,10 @@ router.get('/features', (_req, res) => {
     navigation: {
       skipHome: Boolean(features?.skipHome),
     },
+    folderSize: {
+      mode: features?.folderSizeMode || 'off',
+      enabled: (features?.folderSizeMode || 'off') !== 'off',
+    },
     terminal: {
       enabled: Boolean(features?.terminal) && terminalService.isAvailable(),
       extensions: Array.isArray(terminal?.extensions) ? terminal.extensions : [],

--- a/backend/src/routes/folderSize.js
+++ b/backend/src/routes/folderSize.js
@@ -1,0 +1,258 @@
+const express = require('express');
+const fs = require('fs/promises');
+const { normalizeRelativePath, parsePathSpace, resolveVolumePath } = require('../utils/pathUtils');
+const { resolvePathWithAccess } = require('../services/accessManager');
+const { getDb } = require('../services/db');
+const folderSizeIndex = require('../services/folderSizeIndex');
+const { getVolumeScope } = require('../services/folderSizeIndexer');
+const folderSizeManager = require('../services/folderSizeManager');
+const folderSizeExclusions = require('../services/folderSizeExclusions');
+const config = require('../config/index');
+const asyncHandler = require('../utils/asyncHandler');
+const logger = require('../utils/logger');
+const {
+  ValidationError,
+  ForbiddenError,
+  NotFoundError,
+  RateLimitError,
+} = require('../errors/AppError');
+
+const router = express.Router();
+
+const MAX_BATCH_PATHS = 500;
+const MAX_MANUAL_REFRESHES = 24;
+const manualRefreshes = new Map();
+
+// Keep this router entirely dormant when folder sizes are disabled. The
+// frontend normally never calls it in that mode, but this guard also prevents
+// direct API consumers from resolving paths, opening SQLite, or stat'ing a
+// directory before the manager can reject a refresh request.
+router.use('/folder-size', (_req, res, next) => {
+  if (!config.folderSize.enabled) {
+    return res.status(404).json({ error: 'Folder size indexing is disabled.' });
+  }
+  return next();
+});
+
+/**
+ * Resolve the absolute filesystem path for a logical path *without* enforcing
+ * the navigation ACL — used so a folder's size can still be reported when the
+ * user is not allowed to enter it (the non-negotiable requirement of the
+ * feature). Only volume-space paths are resolvable this way; personal/share
+ * spaces need user context and are left to the access-checked resolution.
+ * Returns null when the path cannot be resolved safely.
+ */
+const fallbackAbsolutePath = async (context, inputRel) => {
+  // Share visitors never get the fallback: they reach files through their
+  // share only, so resolving a volume path for them would turn this endpoint
+  // into a size oracle over the whole tree — including paths an admin hid.
+  if (!context?.user?.id) return null;
+  try {
+    const { space, rel } = parsePathSpace(inputRel);
+    if (space !== 'volume') return null;
+    return await resolveVolumePath(rel);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Look up a single logical path in the index. Never triggers a filesystem
+ * traversal: it reads the pre-computed entry (or reports indexed:false).
+ */
+const lookupFolderSize = async (context, inputRelRaw) => {
+  const inputRel = normalizeRelativePath(inputRelRaw);
+  const { accessInfo, resolved } = await resolvePathWithAccess(context, inputRel);
+  const canEnter = Boolean(accessInfo && accessInfo.canAccess && accessInfo.canRead);
+
+  // Prefer the access-checked absolute path; fall back to a volume-root
+  // resolution so size is available even when navigation is denied.
+  const absolutePath = resolved?.absolutePath ?? (await fallbackAbsolutePath(context, inputRel));
+
+  const db = await getDb();
+  const scope = getVolumeScope();
+  const withinRoot = Boolean(absolutePath && folderSizeIndex.isWithinRoot(scope.root, absolutePath));
+  const excluded = withinRoot && folderSizeExclusions.isExcluded(absolutePath, scope);
+  const entry = withinRoot ? folderSizeIndex.getByAbsolutePath(db, absolutePath) : null;
+
+  return {
+    result: {
+      path: resolved?.relativePath ?? inputRel,
+      canEnter,
+      sizeBytes: entry ? entry.sizeBytes : null,
+      entryCount: entry ? entry.entryCount : null,
+      lastUpdated: folderSizeIndex.getLastUpdatedAt(entry),
+      indexed: Boolean(entry),
+      dirty: Boolean(entry?.dirty),
+      excluded,
+    },
+    // Absolute path (volume-space, within root) for the on-view refresh, or null.
+    absolutePath: withinRoot ? absolutePath : null,
+  };
+};
+
+/**
+ * Fire-and-forget on-view refresh: ask the indexer to re-check these folders'
+ * mtime in the background so external changes surface within seconds. Never
+ * blocks or fails the response.
+ */
+const scheduleOnViewRefresh = (absolutePaths) => {
+  const dirs = absolutePaths.filter(Boolean);
+  if (!dirs.length) return;
+  Promise.resolve(folderSizeManager.touch(dirs)).catch(() => {});
+};
+
+const indexResult = (db, scope, absolutePath, logicalPath, canEnter) => {
+  const entry = folderSizeIndex.getByAbsolutePath(db, absolutePath);
+  return {
+    path: logicalPath,
+    canEnter,
+    sizeBytes: entry ? entry.sizeBytes : null,
+    entryCount: entry ? entry.entryCount : null,
+    lastUpdated: folderSizeIndex.getLastUpdatedAt(entry),
+    indexed: Boolean(entry),
+    dirty: Boolean(entry?.dirty),
+    excluded: folderSizeExclusions.isExcluded(absolutePath, scope),
+  };
+};
+
+/**
+ * Queue one user-requested, authoritative scan of a folder tree. The manager
+ * deduplicates same-path scans; this route additionally caps distinct pending
+ * requests so an authenticated client cannot fill the serialized scan queue.
+ *
+ * The scan itself deliberately continues after the HTTP response. A deep tree
+ * can be paced for minutes, and keeping a browser/proxy request open for that
+ * duration leaves the UI in an unhelpful perpetual loading state.
+ */
+const queueRefreshDirectory = (absolutePath) => {
+  const pending = manualRefreshes.get(absolutePath);
+  if (pending) return;
+  if (manualRefreshes.size >= MAX_MANUAL_REFRESHES) {
+    throw new RateLimitError('Too many folder size refreshes are already pending.');
+  }
+  if (!folderSizeManager.isRunning()) {
+    throw new ValidationError('Folder size indexing is not ready.');
+  }
+
+  const refresh = folderSizeManager.refreshSubtree(absolutePath);
+  manualRefreshes.set(absolutePath, refresh);
+  refresh
+    .then((result) => {
+      if (!result) {
+        logger.warn({ path: absolutePath }, 'Manual folder size refresh did not start');
+      }
+    })
+    .catch((err) => {
+      logger.warn({ err, path: absolutePath }, 'Manual folder size refresh failed');
+    })
+    .finally(() => manualRefreshes.delete(absolutePath));
+};
+
+// POST /api/folder-size/refresh/<logical path>
+// An explicit repair action for a folder changed outside NextExplorer. Unlike
+// normal size reads, this is deliberately authoritative and scans only the
+// requested subtree, updating every indexed descendant and its ancestors.
+router.post(
+  '/folder-size/refresh/{*splat}',
+  asyncHandler(async (req, res) => {
+    const raw = (req.params.splat || []).join('/');
+    const relativePath = normalizeRelativePath(raw);
+    if (!relativePath) {
+      throw new ValidationError('A folder path is required.');
+    }
+
+    const context = { user: req.user, guestSession: req.guestSession };
+    const { accessInfo, resolved } = await resolvePathWithAccess(context, relativePath);
+    if (!accessInfo?.canAccess || !accessInfo?.canRead) {
+      throw new ForbiddenError(accessInfo?.denialReason || 'Path is not accessible.');
+    }
+
+    const scope = getVolumeScope();
+    const absolutePath = resolved?.absolutePath;
+    if (!absolutePath || !folderSizeIndex.isWithinRoot(scope.root, absolutePath)) {
+      throw new ValidationError('Folder size refresh is only available for volume folders.');
+    }
+    if (folderSizeExclusions.isExcluded(absolutePath, scope)) {
+      throw new ValidationError('Folder size indexing is excluded for this directory.');
+    }
+
+    let stats;
+    try {
+      // Do not follow a directory symlink here: the indexed volume is a hard
+      // boundary, and a manual refresh must never turn it into a traversal of
+      // an arbitrary target outside that boundary.
+      stats = await fs.lstat(absolutePath);
+    } catch {
+      throw new NotFoundError('Folder not found.');
+    }
+    if (!stats.isDirectory()) {
+      throw new ValidationError('Folder size refresh requires a directory.');
+    }
+
+    queueRefreshDirectory(absolutePath);
+    const db = await getDb();
+    res.status(202).json({
+      ...indexResult(db, scope, absolutePath, resolved.relativePath, true),
+      refreshPending: true,
+    });
+  })
+);
+
+// GET /api/folder-size/<logical path>
+// Returns the pre-computed recursive size for a single folder. `sizeBytes` is
+// returned regardless of `canEnter`; `indexed:false` (not a 500) when the path
+// is not yet in the index.
+router.get(
+  '/folder-size/{*splat}',
+  asyncHandler(async (req, res) => {
+    const raw = (req.params.splat || []).join('/');
+    const context = { user: req.user, guestSession: req.guestSession };
+    const { result, absolutePath } = await lookupFolderSize(context, raw);
+    res.json(result);
+    scheduleOnViewRefresh([absolutePath]);
+  })
+);
+
+// POST /api/folder-size/batch  { paths: ["a", "a/b", ...] }
+// One index lookup per requested path so a list view can be populated without
+// N separate round trips.
+router.post(
+  '/folder-size/batch',
+  asyncHandler(async (req, res) => {
+    const paths = Array.isArray(req.body?.paths) ? req.body.paths : [];
+    const limited = paths.slice(0, MAX_BATCH_PATHS);
+    const context = { user: req.user, guestSession: req.guestSession };
+
+    const results = [];
+    const touchPaths = [];
+    for (const p of limited) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const { result, absolutePath } = await lookupFolderSize(
+          context,
+          typeof p === 'string' ? p : ''
+        );
+        results.push(result);
+        if (absolutePath) touchPaths.push(absolutePath);
+      } catch (err) {
+        logger.debug({ err, path: p }, 'folder-size batch lookup failed for path');
+        results.push({
+          path: typeof p === 'string' ? p : '',
+          canEnter: false,
+          sizeBytes: null,
+          entryCount: null,
+          lastUpdated: null,
+          indexed: false,
+          dirty: false,
+          excluded: false,
+        });
+      }
+    }
+
+    res.json({ results, truncated: paths.length > limited.length });
+    scheduleOnViewRefresh(touchPaths);
+  })
+);
+
+module.exports = router;

--- a/backend/src/routes/index.js
+++ b/backend/src/routes/index.js
@@ -20,6 +20,7 @@ const sharesRoutes = require('./shares');
 const zipRoutes = require('./zip');
 const healthRoutes = require('./health');
 const userVolumesRoutes = require('./userVolumes');
+const folderSizeRoutes = require('./folderSize');
 const { onlyoffice, collabora } = require('../config/index');
 
 const registerRoutes = (app) => {
@@ -41,6 +42,7 @@ const registerRoutes = (app) => {
   app.use('/api', metadataRoutes);
   app.use('/api', permissionsRoutes);
   app.use('/api', zipRoutes);
+  app.use('/api', folderSizeRoutes);
   // User volumes management (admin only, requires USER_VOLUMES feature)
   app.use('/api', userVolumesRoutes);
   // Share routes (supports guest sessions)

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -9,6 +9,7 @@ const logger = require('./utils/logger');
 const { printStartupBanner } = require('./utils/startupBanner');
 const terminalService = require('./services/terminalService');
 const searchIndexManager = require('./services/searchIndexManager');
+const folderSizeManager = require('./services/folderSizeManager');
 
 let server = null;
 
@@ -48,12 +49,14 @@ const startServer = async () => {
 
   // Deliberately not awaited: a server does not wait for its index to be
   // ready, it answers from the live search until it is.
+  folderSizeManager.start();
   searchIndexManager.start();
 
   // Cleanup on process termination
   const cleanup = () => {
     logger.info('Shutting down server...');
     terminalService.cleanup();
+    folderSizeManager.stop();
     searchIndexManager.stop();
     server.close(() => {
       logger.info('Server closed');

--- a/backend/src/services/db.js
+++ b/backend/src/services/db.js
@@ -8,6 +8,27 @@ const logger = require('../utils/logger');
 
 let dbInstance = null;
 
+// DDL for the folder size index. Kept as a constant so it can be applied both by
+// the versioned migration (clean installs) and idempotently on every open — the
+// latter guarantees the table exists even when the recorded schema_version was
+// already advanced past this migration by a different build sharing /config.
+const FOLDER_SIZE_INDEX_DDL = `
+  CREATE TABLE IF NOT EXISTS folder_size_index (
+    path_hash         TEXT PRIMARY KEY,
+    parent_hash       TEXT,
+    volume            TEXT NOT NULL,
+    relative_path     TEXT NOT NULL,
+    size_bytes        INTEGER NOT NULL DEFAULT 0,
+    entry_count       INTEGER NOT NULL DEFAULT 0,
+    last_delta_at     DATETIME,
+    last_full_scan_at DATETIME,
+    dirty             INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE INDEX IF NOT EXISTS idx_folder_size_parent ON folder_size_index(parent_hash);
+  CREATE INDEX IF NOT EXISTS idx_folder_size_volume ON folder_size_index(volume);
+`;
+
+
 const getDbPath = () => {
   const configDir = directories.config;
   // Generic app database for auth, shares, and user settings.
@@ -30,26 +51,6 @@ const migrate = (db) => {
       value TEXT
     );
   `);
-
-  // DDL for the folder size index. Kept as a constant so it can be applied both by
-// the versioned migration (clean installs) and idempotently on every open — the
-// latter guarantees the table exists even when the recorded schema_version was
-// already advanced past this migration by a different build sharing /config.
-const FOLDER_SIZE_INDEX_DDL = `
-  CREATE TABLE IF NOT EXISTS folder_size_index (
-    path_hash         TEXT PRIMARY KEY,
-    parent_hash       TEXT,
-    volume            TEXT NOT NULL,
-    relative_path     TEXT NOT NULL,
-    size_bytes        INTEGER NOT NULL DEFAULT 0,
-    entry_count       INTEGER NOT NULL DEFAULT 0,
-    last_delta_at     DATETIME,
-    last_full_scan_at DATETIME,
-    dirty             INTEGER NOT NULL DEFAULT 0
-  );
-  CREATE INDEX IF NOT EXISTS idx_folder_size_parent ON folder_size_index(parent_hash);
-  CREATE INDEX IF NOT EXISTS idx_folder_size_volume ON folder_size_index(volume);
-`;
 
 const getVersion = db.prepare('SELECT value FROM meta WHERE key = ?').pluck();
   let version = Number(getVersion.get('schema_version') || 0);

--- a/backend/src/services/db.js
+++ b/backend/src/services/db.js
@@ -31,7 +31,27 @@ const migrate = (db) => {
     );
   `);
 
-  const getVersion = db.prepare('SELECT value FROM meta WHERE key = ?').pluck();
+  // DDL for the folder size index. Kept as a constant so it can be applied both by
+// the versioned migration (clean installs) and idempotently on every open — the
+// latter guarantees the table exists even when the recorded schema_version was
+// already advanced past this migration by a different build sharing /config.
+const FOLDER_SIZE_INDEX_DDL = `
+  CREATE TABLE IF NOT EXISTS folder_size_index (
+    path_hash         TEXT PRIMARY KEY,
+    parent_hash       TEXT,
+    volume            TEXT NOT NULL,
+    relative_path     TEXT NOT NULL,
+    size_bytes        INTEGER NOT NULL DEFAULT 0,
+    entry_count       INTEGER NOT NULL DEFAULT 0,
+    last_delta_at     DATETIME,
+    last_full_scan_at DATETIME,
+    dirty             INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE INDEX IF NOT EXISTS idx_folder_size_parent ON folder_size_index(parent_hash);
+  CREATE INDEX IF NOT EXISTS idx_folder_size_volume ON folder_size_index(volume);
+`;
+
+const getVersion = db.prepare('SELECT value FROM meta WHERE key = ?').pluck();
   let version = Number(getVersion.get('schema_version') || 0);
 
   db.transaction(() => {
@@ -363,6 +383,15 @@ const migrate = (db) => {
       );
       version = 9;
     }
+    if (version < 10) {
+      logger.info('[DB Migration] Migrating to v10: Folder size index...');
+      db.exec(FOLDER_SIZE_INDEX_DDL);
+      db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run(
+        'schema_version',
+        String(10)
+      );
+      version = 10;
+    }
   })();
 };
 
@@ -585,6 +614,14 @@ const getDb = async () => {
 
   const db = new Database(dbPath);
   migrate(db);
+  // Applied on every open as well as by the migration above: a database created
+  // by another build sharing this /config may already be past v10 without the
+  // table, which would make the indexer fail with "no such table".
+  try {
+    db.exec(FOLDER_SIZE_INDEX_DDL);
+  } catch (err) {
+    logger.warn({ err }, '[DB] Failed to ensure folder_size_index table');
+  }
   ensureAnonymousUser(db);
   dbInstance = db;
   return dbInstance;

--- a/backend/src/services/folderSizeExclusions.js
+++ b/backend/src/services/folderSizeExclusions.js
@@ -1,0 +1,16 @@
+const config = require('../config');
+const { createPathExclusions } = require('./pathExclusions');
+
+/**
+ * Folders the recursive size calculation leaves alone.
+ *
+ * A Docker overlay tree or a snapshot directory is hundreds of thousands of
+ * entries whose total nobody wants, and walking it is the whole cost of the
+ * index. One list comes from the environment and the interface cannot edit it;
+ * the other belongs to whoever administers the instance.
+ */
+module.exports = createPathExclusions({
+  settingsCategory: 'system',
+  settingsKey: 'folderSize',
+  readEnvironmentPaths: () => config.folderSize.envExcludedPaths || [],
+});

--- a/backend/src/services/folderSizeIndex.js
+++ b/backend/src/services/folderSizeIndex.js
@@ -1,0 +1,517 @@
+/**
+ * Data-access layer for the `folder_size_index` table.
+ *
+ * This module is intentionally free of any application configuration: every
+ * function takes an explicit better-sqlite3 `db` handle and, where relevant, a
+ * `scope` object describing the volume being indexed:
+ *
+ *   scope = { root: '<absolute volume root>', label: '<volume identifier>' }
+ *
+ * Keeping it pure makes it trivial to unit test against a temporary database
+ * and an arbitrary directory tree, and lets it be shared unchanged between the
+ * Express request threads (write hooks + read route) and the indexer worker
+ * thread — each simply passes its own connection.
+ *
+ * Sizes are recursive by convention (a folder's `size_bytes` is the total of
+ * everything beneath it). Relative paths are always stored POSIX-style so that
+ * prefix range scans behave identically across platforms.
+ */
+const crypto = require('crypto');
+const path = require('path');
+
+// Bump this whenever the indexer gains a capability that older, already
+// populated indexes cannot retroactively provide. The manager performs one
+// cooperative baseline rebuild for each affected volume on upgrade.
+const CURRENT_INDEX_VERSION = 2;
+
+const toPosix = (p) => (p.includes('\\') ? p.split('\\').join('/') : p);
+
+/**
+ * Prepared-statement cache, keyed by the db handle then the SQL text. Preparing
+ * a statement compiles it; doing that on every call churns a lot of native
+ * handles and JS garbage during a large reconcile (hundreds of thousands of
+ * folders). Caching means each distinct query is compiled once and reused. The
+ * WeakMap lets the cache be collected with its connection.
+ */
+const stmtCache = new WeakMap();
+const prep = (db, sql) => {
+  let bySql = stmtCache.get(db);
+  if (!bySql) {
+    bySql = new Map();
+    stmtCache.set(db, bySql);
+  }
+  let stmt = bySql.get(sql);
+  if (!stmt) {
+    stmt = db.prepare(sql);
+    bySql.set(sql, stmt);
+  }
+  return stmt;
+};
+
+/** Stable primary key for a folder: the sha1 of its absolute path. */
+const pathHash = (absolutePath) => crypto.createHash('sha1').update(absolutePath).digest('hex');
+
+const relativeOf = (root, absolutePath) => {
+  if (absolutePath === root) return '';
+  return toPosix(path.relative(root, absolutePath));
+};
+
+const isWithinRoot = (root, absolutePath) => {
+  if (absolutePath === root) return true;
+  const withSep = root.endsWith(path.sep) ? root : root + path.sep;
+  return absolutePath.startsWith(withSep);
+};
+
+/**
+ * Build the chain of absolute paths from `dirAbsolutePath` up to and including
+ * the volume `root`. Returns [] when the path is not inside the volume.
+ */
+const ancestorChain = (root, dirAbsolutePath) => {
+  if (!isWithinRoot(root, dirAbsolutePath)) return [];
+  const chain = [];
+  let current = dirAbsolutePath;
+  // The 4096 bound is a defensive guard against unexpected path cycles; a real
+  // directory depth never approaches it.
+  for (let i = 0; i < 4096; i += 1) {
+    chain.push(current);
+    if (current === root) break;
+    const parent = path.dirname(current);
+    if (parent === current) break; // filesystem root reached without matching volume root
+    current = parent;
+  }
+  return chain;
+};
+
+const mapRow = (row) => {
+  if (!row) return null;
+  return {
+    parentHash: row.parent_hash,
+    volume: row.volume,
+    relativePath: row.relative_path,
+    sizeBytes: row.size_bytes,
+    entryCount: row.entry_count,
+    lastDeltaAt: row.last_delta_at,
+    lastFullScanAt: row.last_full_scan_at,
+    dirty: row.dirty,
+  };
+};
+
+const getByAbsolutePath = (db, absolutePath) => {
+  const row = prep(db, 'SELECT * FROM folder_size_index WHERE path_hash = ?').get(
+    pathHash(absolutePath)
+  );
+  return mapRow(row);
+};
+
+/**
+ * Return the most recent index write timestamp for an entry. A pending
+ * transfer keeps its delta timestamp when its authoritative scan completes,
+ * so using `lastDeltaAt || lastFullScanAt` would permanently hide that later
+ * scan from clients waiting for a refresh.
+ */
+const getLastUpdatedAt = (entry) => {
+  if (!entry) return null;
+  const candidates = [entry.lastDeltaAt, entry.lastFullScanAt]
+    .filter((value) => Number.isFinite(Date.parse(value)))
+    .sort((a, b) => Date.parse(b) - Date.parse(a));
+  return candidates[0] || null;
+};
+
+/**
+ * One page of folders for the reconciliation pass, ordered by relative_path
+ * DESC (children before their parents) and limited to `limit` rows. Only the
+ * three columns reconcile needs are selected. Pass `beforeRelativePath = null`
+ * for the first page, then the last (smallest) `relativePath` of the previous
+ * page as the cursor for the next. Paging keeps reconcile's peak memory O(page)
+ * instead of O(all folders) on very large volumes, and the DESC order lets a
+ * vanished folder's size be subtracted from an ancestor before that ancestor is
+ * re-aggregated.
+ */
+const listScanTargetsPage = (db, volume, beforeRelativePath, limit) => {
+  const rows =
+    beforeRelativePath === null || beforeRelativePath === undefined
+      ? prep(
+          db,
+          `SELECT relative_path, last_full_scan_at, dirty FROM folder_size_index
+             WHERE volume = ? ORDER BY relative_path DESC LIMIT ?`
+        ).all(volume, limit)
+      : prep(
+          db,
+          `SELECT relative_path, last_full_scan_at, dirty FROM folder_size_index
+             WHERE volume = ? AND relative_path < ? ORDER BY relative_path DESC LIMIT ?`
+        ).all(volume, beforeRelativePath, limit);
+  return rows.map((row) => ({
+    relativePath: row.relative_path,
+    lastFullScanAt: row.last_full_scan_at,
+    dirty: row.dirty,
+  }));
+};
+
+const countByVolume = (db, volume) =>
+  prep(db, 'SELECT COUNT(*) AS n FROM folder_size_index WHERE volume = ?').get(volume).n;
+
+const indexVersionKey = (scope) =>
+  `folder_size_index_version:${scope.label}:${pathHash(scope.root)}`;
+
+const getIndexVersion = (db, scope) => {
+  const value = prep(db, 'SELECT value FROM meta WHERE key = ?')
+    .pluck()
+    .get(indexVersionKey(scope));
+  const version = Number(value);
+  return Number.isInteger(version) && version >= 0 ? version : 0;
+};
+
+const setIndexVersion = (db, scope, version = CURRENT_INDEX_VERSION) => {
+  prep(db, 'INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run(
+    indexVersionKey(scope),
+    String(version)
+  );
+};
+
+/**
+ * Apply an incremental byte delta to a folder and propagate it up every
+ * ancestor to the volume root, in a single transaction. Rows that do not yet
+ * exist are created and flagged `dirty` so the reconciler can later replace the
+ * approximate value with a true aggregate. `entryDelta` only affects the target
+ * folder's direct entry count, never its ancestors'.
+ *
+ * @returns {number} number of levels touched (0 when outside the volume)
+ */
+const applyDelta = (db, scope, dirAbsolutePath, byteDelta, { entryDelta = 0 } = {}) => {
+  const { root, label } = scope;
+  const chain = ancestorChain(root, dirAbsolutePath);
+  if (!chain.length) return 0;
+
+  const now = new Date().toISOString();
+  const upsert = prep(
+    db,
+    `
+    INSERT INTO folder_size_index
+      (path_hash, parent_hash, volume, relative_path, size_bytes, entry_count, last_delta_at, dirty)
+    VALUES (@pathHash, @parentHash, @volume, @relativePath, @initialSize, @initialCount, @now, 1)
+    ON CONFLICT(path_hash) DO UPDATE SET
+      size_bytes = MAX(0, size_bytes + @byteDelta),
+      entry_count = MAX(0, entry_count + @entryDelta),
+      last_delta_at = @now
+  `
+  );
+
+  const run = db.transaction(() => {
+    for (let i = 0; i < chain.length; i += 1) {
+      const abs = chain[i];
+      const isTarget = i === 0;
+      const parentAbs = abs === root ? null : path.dirname(abs);
+      const levelEntryDelta = isTarget ? entryDelta : 0;
+      upsert.run({
+        pathHash: pathHash(abs),
+        parentHash: parentAbs ? pathHash(parentAbs) : null,
+        volume: label,
+        relativePath: relativeOf(root, abs),
+        initialSize: Math.max(0, byteDelta),
+        initialCount: Math.max(0, levelEntryDelta),
+        byteDelta,
+        entryDelta: levelEntryDelta,
+        now,
+      });
+    }
+  });
+  run();
+  return chain.length;
+};
+
+/**
+ * Upsert an authoritative (non-dirty) entry — used by the baseline walk and the
+ * reconciler when the true recursive size of a folder is known.
+ */
+const upsertScanEntry = (db, scope, { absolutePath, sizeBytes, entryCount, lastFullScanAt }) => {
+  const { root, label } = scope;
+  const parentAbs = absolutePath === root ? null : path.dirname(absolutePath);
+  prep(
+    db,
+    `
+    INSERT INTO folder_size_index
+      (path_hash, parent_hash, volume, relative_path, size_bytes, entry_count, last_full_scan_at, dirty)
+    VALUES (@pathHash, @parentHash, @volume, @relativePath, @sizeBytes, @entryCount, @lastFullScanAt, 0)
+    ON CONFLICT(path_hash) DO UPDATE SET
+      parent_hash = @parentHash,
+      volume = @volume,
+      relative_path = @relativePath,
+      size_bytes = @sizeBytes,
+      entry_count = @entryCount,
+      last_full_scan_at = @lastFullScanAt,
+      dirty = 0
+  `
+  ).run({
+    pathHash: pathHash(absolutePath),
+    parentHash: parentAbs ? pathHash(parentAbs) : null,
+    volume: label,
+    relativePath: relativeOf(root, absolutePath),
+    sizeBytes,
+    entryCount,
+    lastFullScanAt,
+  });
+};
+
+/** Bulk variant of {@link upsertScanEntry}, wrapped in one transaction. */
+const bulkUpsertScanEntries = (db, scope, entries = []) => {
+  if (!entries.length) return;
+  const run = db.transaction(() => {
+    for (const entry of entries) upsertScanEntry(db, scope, entry);
+  });
+  run();
+};
+
+/**
+ * Duplicate existing index rows for a directory copy without reading the
+ * filesystem again. The source and target must belong to the same indexed
+ * volume. Rows are read and written in small pages, so even a large directory
+ * tree does not require materialising all of its SQLite rows in JavaScript
+ * memory. A page is fully read before its write transaction starts because
+ * SQLite does not allow a cursor query and a write on one connection at once.
+ */
+const cloneSubtree = (db, scope, sourceAbsolutePath, targetAbsolutePath) => {
+  const { root, label } = scope;
+  if (
+    !isWithinRoot(root, sourceAbsolutePath) ||
+    !isWithinRoot(root, targetAbsolutePath) ||
+    sourceAbsolutePath === targetAbsolutePath
+  ) {
+    return 0;
+  }
+
+  const sourceRelativePath = relativeOf(root, sourceAbsolutePath);
+  const pageSize = 256;
+  const selectRows =
+    sourceRelativePath === ''
+      ? prep(
+          db,
+          `SELECT * FROM folder_size_index
+             WHERE volume = ? AND (? IS NULL OR relative_path > ?)
+             ORDER BY relative_path ASC LIMIT ?`
+        )
+      : prep(
+          db,
+          `SELECT * FROM folder_size_index
+             WHERE volume = ?
+               AND (relative_path = ? OR (relative_path >= ? AND relative_path < ?))
+               AND (? IS NULL OR relative_path > ?)
+             ORDER BY relative_path ASC LIMIT ?`
+        );
+  const upsert = prep(
+    db,
+    `
+    INSERT INTO folder_size_index
+      (path_hash, parent_hash, volume, relative_path, size_bytes, entry_count, last_delta_at, last_full_scan_at, dirty)
+    VALUES (@pathHash, @parentHash, @volume, @relativePath, @sizeBytes, @entryCount, @lastDeltaAt, @lastFullScanAt, @dirty)
+    ON CONFLICT(path_hash) DO UPDATE SET
+      parent_hash = @parentHash,
+      volume = @volume,
+      relative_path = @relativePath,
+      size_bytes = @sizeBytes,
+      entry_count = @entryCount,
+      last_delta_at = @lastDeltaAt,
+      last_full_scan_at = @lastFullScanAt,
+      dirty = @dirty
+  `
+  );
+
+  let copied = 0;
+  const writePage = db.transaction((rows) => {
+    for (const row of rows) {
+      const sourceRowAbsolutePath = row.relative_path ? path.join(root, row.relative_path) : root;
+      const suffix =
+        sourceRowAbsolutePath === sourceAbsolutePath
+          ? ''
+          : sourceRowAbsolutePath.slice(sourceAbsolutePath.length);
+      const targetRowAbsolutePath = `${targetAbsolutePath}${suffix}`;
+      const parentAbsolutePath =
+        targetRowAbsolutePath === root ? null : path.dirname(targetRowAbsolutePath);
+
+      upsert.run({
+        pathHash: pathHash(targetRowAbsolutePath),
+        parentHash: parentAbsolutePath ? pathHash(parentAbsolutePath) : null,
+        volume: label,
+        relativePath: relativeOf(root, targetRowAbsolutePath),
+        sizeBytes: row.size_bytes,
+        entryCount: row.entry_count,
+        lastDeltaAt: row.last_delta_at,
+        lastFullScanAt: row.last_full_scan_at,
+        dirty: row.dirty,
+      });
+      copied += 1;
+    }
+  });
+
+  let afterRelativePath = null;
+  for (;;) {
+    const rows =
+      sourceRelativePath === ''
+        ? selectRows.all(label, afterRelativePath, afterRelativePath, pageSize)
+        : selectRows.all(
+            label,
+            sourceRelativePath,
+            `${sourceRelativePath}/`,
+            `${sourceRelativePath}0`,
+            afterRelativePath,
+            afterRelativePath,
+            pageSize
+          );
+    if (!rows.length) break;
+    writePage(rows);
+    if (rows.length < pageSize) break;
+    afterRelativePath = rows[rows.length - 1].relative_path;
+  }
+  return copied;
+};
+
+/**
+ * Record a directory whose recursive byte count is known from an operation,
+ * while leaving it marked dirty until its descendant rows are needed. This
+ * keeps a completed directory copy off the filesystem hot path: the list view
+ * can show its exact root size immediately, and a detailed scan happens only
+ * when someone actually opens that tree.
+ */
+const upsertPendingDirectoryEntry = (db, scope, { absolutePath, sizeBytes, entryCount = 0 }) => {
+  const { root, label } = scope;
+  const parentAbs = absolutePath === root ? null : path.dirname(absolutePath);
+  prep(
+    db,
+    `
+    INSERT INTO folder_size_index
+      (path_hash, parent_hash, volume, relative_path, size_bytes, entry_count, last_delta_at, dirty)
+    VALUES (@pathHash, @parentHash, @volume, @relativePath, @sizeBytes, @entryCount, @now, 1)
+    ON CONFLICT(path_hash) DO UPDATE SET
+      parent_hash = @parentHash,
+      volume = @volume,
+      relative_path = @relativePath,
+      size_bytes = @sizeBytes,
+      entry_count = @entryCount,
+      last_delta_at = @now,
+      dirty = 1
+  `
+  ).run({
+    pathHash: pathHash(absolutePath),
+    parentHash: parentAbs ? pathHash(parentAbs) : null,
+    volume: label,
+    relativePath: relativeOf(root, absolutePath),
+    sizeBytes: Math.max(0, Number(sizeBytes) || 0),
+    entryCount: Math.max(0, Number(entryCount) || 0),
+    now: new Date().toISOString(),
+  });
+};
+
+/**
+ * Update scan metadata (entry count, last scan timestamp, dirty flag) without
+ * touching `size_bytes` — the reconciler adjusts size separately via
+ * {@link applyDelta} so the change also propagates to ancestors.
+ */
+const setScanMeta = (db, absolutePath, { entryCount, lastFullScanAt, dirty = 0 }) => {
+  prep(
+    db,
+    `
+    UPDATE folder_size_index
+    SET entry_count = @entryCount, last_full_scan_at = @lastFullScanAt, dirty = @dirty
+    WHERE path_hash = @pathHash
+  `
+  ).run({
+    pathHash: pathHash(absolutePath),
+    entryCount,
+    lastFullScanAt,
+    dirty: dirty ? 1 : 0,
+  });
+};
+
+/**
+ * Remove a folder and its entire subtree from the index in one transaction.
+ * Uses a binary prefix range ([rel + '/', rel + '0')) rather than LIKE so that
+ * folder names containing `%` or `_` cannot over-match.
+ *
+ * @returns {number} the recorded recursive size of the removed folder, so
+ *   callers can propagate a negative delta to the ancestors that remain.
+ */
+const removeSubtree = (db, scope, dirAbsolutePath) => {
+  const { root, label } = scope;
+  const existing = getByAbsolutePath(db, dirAbsolutePath);
+  const size = existing ? existing.sizeBytes : 0;
+  const rel = relativeOf(root, dirAbsolutePath);
+
+  const run = db.transaction(() => {
+    if (rel === '') {
+      prep(db, 'DELETE FROM folder_size_index WHERE volume = ?').run(label);
+    } else {
+      prep(
+        db,
+        `DELETE FROM folder_size_index
+         WHERE volume = ?
+           AND (relative_path = ? OR (relative_path >= ? AND relative_path < ?))`
+      ).run(label, rel, `${rel}/`, `${rel}0`);
+    }
+  });
+  run();
+  return size;
+};
+
+/**
+ * Re-key a folder and its whole subtree after a move/rename, in one
+ * transaction. Sizes are preserved (a rename does not change bytes); only the
+ * path_hash / parent_hash / relative_path of each row are rewritten. The target
+ * key space is assumed free (callers move to a fresh, conflict-resolved name).
+ *
+ * @returns {number} number of rows re-keyed
+ */
+const reparentSubtree = (db, scope, oldAbsolutePath, newAbsolutePath) => {
+  const { root, label } = scope;
+  const oldRel = relativeOf(root, oldAbsolutePath);
+  const rows =
+    oldRel === ''
+      ? prep(db, 'SELECT * FROM folder_size_index WHERE volume = ?').all(label)
+      : prep(
+          db,
+          `SELECT * FROM folder_size_index
+             WHERE volume = ?
+               AND (relative_path = ? OR (relative_path >= ? AND relative_path < ?))`
+        ).all(label, oldRel, `${oldRel}/`, `${oldRel}0`);
+
+  const update = prep(
+    db,
+    `UPDATE folder_size_index
+     SET path_hash = @newHash, parent_hash = @newParentHash, relative_path = @newRel
+     WHERE path_hash = @oldHash`
+  );
+
+  const run = db.transaction(() => {
+    for (const row of rows) {
+      const rowAbs = row.relative_path ? path.join(root, row.relative_path) : root;
+      const suffix = rowAbs === oldAbsolutePath ? '' : rowAbs.slice(oldAbsolutePath.length);
+      const newRowAbs = newAbsolutePath + suffix;
+      const newParentAbs = newRowAbs === root ? null : path.dirname(newRowAbs);
+      update.run({
+        newHash: pathHash(newRowAbs),
+        newParentHash: newParentAbs ? pathHash(newParentAbs) : null,
+        newRel: relativeOf(root, newRowAbs),
+        oldHash: row.path_hash,
+      });
+    }
+  });
+  run();
+  return rows.length;
+};
+
+module.exports = {
+  CURRENT_INDEX_VERSION,
+  isWithinRoot,
+  getByAbsolutePath,
+  getLastUpdatedAt,
+  listScanTargetsPage,
+  countByVolume,
+  getIndexVersion,
+  setIndexVersion,
+  applyDelta,
+  upsertScanEntry,
+  bulkUpsertScanEntries,
+  cloneSubtree,
+  upsertPendingDirectoryEntry,
+  setScanMeta,
+  removeSubtree,
+  reparentSubtree,
+};

--- a/backend/src/services/folderSizeIndexer.js
+++ b/backend/src/services/folderSizeIndexer.js
@@ -1,0 +1,725 @@
+/**
+ * Folder size indexer — core logic.
+ *
+ * This module owns the three ways the `folder_size_index` table is kept up to
+ * date, all designed to keep HTTP reads O(1) and filesystem load negligible:
+ *
+ *   1. `runBaseline`  — a one-off recursive walk of a volume, run once (or on
+ *                       explicit rebuild) with bounded concurrency and event
+ *                       loop yields, writing authoritative sizes in batches.
+ *   2. `applyDelta`   — incremental, ancestor-propagating updates (re-exported
+ *                       from the storage layer) used by the write hooks and by
+ *                       the watcher flush; never recomputes a subtree.
+ *   3. `reconcile`    — a low-cost safety net that stat()s the mtime of every
+ *                       known folder and only re-aggregates the *direct* level
+ *                       of folders that changed since their last scan, then
+ *                       propagates the resulting delta upward.
+ *
+ * Every function takes an explicit `db` and `scope` ({ root, label }) so the
+ * logic can be unit tested against a temp database and directory tree, and so
+ * the same code runs unchanged in the worker thread.
+ */
+const fs = require('fs/promises');
+const fsSync = require('fs');
+const path = require('path');
+const pLimit = require('p-limit');
+
+const config = require('../config/index');
+const folderSizeIndex = require('./folderSizeIndex');
+const { nowIso } = require('../utils/ids');
+
+const NETWORK_FS_TYPES = new Set(['nfs', 'nfs4', 'cifs', 'smbfs', 'smb', 'smb2', 'fuse.sshfs']);
+
+const yieldToEventLoop = () => new Promise((resolve) => setImmediate(resolve));
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const activeStalledIo = new Map();
+let nextStalledIoId = 1;
+
+const createIoError = (code, message, details) => {
+  const err = new Error(message);
+  err.code = code;
+  Object.assign(err, details);
+  return err;
+};
+
+const isIoTimeoutError = (err) => err?.code === 'FOLDER_SIZE_IO_TIMEOUT';
+
+const isIoCircuitOpenError = (err) => err?.code === 'FOLDER_SIZE_IO_CIRCUIT_OPEN';
+
+const isMissingPathError = (err) => err?.code === 'ENOENT' || err?.code === 'ENOTDIR';
+
+const createScanAbortedError = (absolutePath) =>
+  createIoError(
+    'FOLDER_SIZE_SCAN_ABORTED',
+    'Folder-size subtree scan was invalidated by a mutation',
+    {
+      path: absolutePath,
+    }
+  );
+
+/**
+ * Bound a filesystem request without pretending Node can cancel it. When the
+ * deadline wins, the caller is released immediately; the original fs request
+ * stays tracked until it actually settles. A small circuit breaker prevents a
+ * pathological mount from consuming all libuv filesystem workers over time.
+ */
+const withIoTimeout = (operation, absolutePath, run, options = {}) => {
+  const timeoutMs = options.timeoutMs ?? config.folderSize.ioTimeoutMs;
+  const maxStalledIo = options.maxStalledIo ?? config.folderSize.maxStalledIo;
+  if (!timeoutMs || timeoutMs < 0) return Promise.resolve().then(run);
+
+  if (activeStalledIo.size >= maxStalledIo) {
+    return Promise.reject(
+      createIoError(
+        'FOLDER_SIZE_IO_CIRCUIT_OPEN',
+        'Folder-size filesystem safety circuit is open',
+        { operation, path: absolutePath, stalledOperations: activeStalledIo.size, maxStalledIo }
+      )
+    );
+  }
+
+  const operationPromise = Promise.resolve().then(run);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let stalledId = null;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      stalledId = nextStalledIoId++;
+      const timedOutAt = Date.now();
+      activeStalledIo.set(stalledId, { operation, path: absolutePath, timedOutAt });
+      reject(
+        createIoError('FOLDER_SIZE_IO_TIMEOUT', 'Folder-size filesystem operation timed out', {
+          operation,
+          path: absolutePath,
+          timeoutMs,
+        })
+      );
+    }, timeoutMs);
+    if (timer.unref) timer.unref();
+
+    operationPromise.then(
+      (value) => {
+        clearTimeout(timer);
+        if (stalledId !== null) {
+          activeStalledIo.delete(stalledId);
+          return;
+        }
+        if (!settled) {
+          settled = true;
+          resolve(value);
+        }
+      },
+      (err) => {
+        clearTimeout(timer);
+        if (stalledId !== null) {
+          activeStalledIo.delete(stalledId);
+          return;
+        }
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
+      }
+    );
+  });
+};
+
+const getIoDiagnostics = () => ({
+  stalledOperations: Array.from(activeStalledIo.values()).map(
+    ({ operation, path: absolutePath, timedOutAt }) => ({
+      operation,
+      path: absolutePath,
+      ageMs: Date.now() - timedOutAt,
+    })
+  ),
+  maxStalledIo: config.folderSize.maxStalledIo,
+  timeoutMs: config.folderSize.ioTimeoutMs,
+});
+
+/**
+ * Whether a folder needs re-aggregation given a fresh stat of it: it is unknown
+ * to the index, or its on-disk mtime is newer than the most recent time we
+ * recorded a size for it (a full scan or an incremental delta). Used by the
+ * on-view refresh and the reconciler to skip untouched folders for free.
+ */
+const isStale = (entry, mtimeMs) => {
+  if (!entry) return true;
+  if (entry.dirty) return true;
+  const lastKnown = Math.max(
+    entry.lastFullScanAt ? Date.parse(entry.lastFullScanAt) : 0,
+    entry.lastDeltaAt ? Date.parse(entry.lastDeltaAt) : 0
+  );
+  return !Number.isFinite(lastKnown) || mtimeMs > lastKnown;
+};
+
+/**
+ * Next adaptive reconciliation delay: reset to `minMs` whenever the last pass
+ * found external changes (stay responsive while activity continues), otherwise
+ * double the previous delay up to `maxMs` (back off while idle). Mirrors the
+ * accelerate-on-change / decelerate-when-idle scheduling that keeps periodic
+ * scanning cheap without a filesystem watcher.
+ */
+const nextReconcileDelay = (prevDelay, changed, { minMs, maxMs }) => {
+  if (changed > 0) return minMs;
+  const base = prevDelay > 0 ? prevDelay : minMs;
+  return Math.min(base * 2, maxMs);
+};
+
+/** The default volume scope derived from configuration (main volume root). */
+const getVolumeScope = () => ({ root: config.directories.volume, label: 'volume' });
+
+/**
+ * Best-effort detection of whether `absPath` sits on a network filesystem, so
+ * the baseline can throttle concurrency there. Linux-only (reads /proc/mounts);
+ * anywhere else it conservatively reports "not network".
+ */
+const detectNetworkFs = (absPath) => {
+  try {
+    const mounts = fsSync.readFileSync('/proc/mounts', 'utf8');
+    let best = null;
+    for (const line of mounts.split('\n')) {
+      const parts = line.split(/\s+/);
+      if (parts.length < 3) continue;
+      const mountPoint = parts[1];
+      const fsType = parts[2];
+      if (absPath === mountPoint || absPath.startsWith(mountPoint.replace(/\/?$/, '/'))) {
+        // Longest matching mount point wins (most specific).
+        if (!best || mountPoint.length > best.mountPoint.length) {
+          best = { mountPoint, fsType };
+        }
+      }
+    }
+    if (!best) return false;
+    const type = best.fsType.toLowerCase();
+    return NETWORK_FS_TYPES.has(type) || type.startsWith('fuse.');
+  } catch {
+    // /proc/mounts absent (non-Linux) or unreadable — assume local.
+    return false;
+  }
+};
+
+/** Resolve the effective baseline concurrency for a scope. */
+const resolveConcurrency = (scope, overrides = {}) => {
+  const isNetwork =
+    typeof overrides.isNetwork === 'boolean' ? overrides.isNetwork : detectNetworkFs(scope.root);
+  const local = overrides.concurrency ?? config.folderSize.concurrency ?? 6;
+  const network = overrides.networkConcurrency ?? config.folderSize.networkConcurrency ?? 2;
+  return Math.max(1, isNetwork ? network : local);
+};
+
+const absOf = (scope, relativePath) =>
+  relativePath ? path.join(scope.root, relativePath) : scope.root;
+
+/**
+ * Recursively walk `rootAbs`, writing an authoritative index entry for every
+ * folder. Directory sizes are recursive in `full` mode and direct-entries-only
+ * in `shallow` mode. Writes happen in batched transactions and the event loop
+ * is yielded between batches so the walk never starves concurrent HTTP work.
+ *
+ * @returns {Promise<{ folders: number, bytes: number }>}
+ */
+const scanTree = async (db, scope, rootAbs, options = {}) => {
+  const {
+    mode = config.folderSize.mode || 'full',
+    concurrency = resolveConcurrency(scope, options),
+    batchSize = 300,
+    yieldEvery = 200,
+    pauseMs = 0,
+    signal,
+    shouldExclude,
+    ioTimeoutMs = config.folderSize.ioTimeoutMs,
+    onProgress,
+  } = options;
+
+  if (typeof shouldExclude === 'function' && shouldExclude(rootAbs)) {
+    return { folders: 0, files: 0, bytes: 0, entryCount: 0, batches: 0, pauses: 0, excluded: true };
+  }
+
+  const limit = pLimit(concurrency);
+  const pending = [];
+  let folders = 0;
+  let files = 0;
+  let batches = 0;
+  let pauses = 0;
+  let scanTimedOut = false;
+
+  const throwIfAborted = () => {
+    if (signal?.aborted) throw createScanAbortedError(rootAbs);
+  };
+
+  const reportProgress = (phase, absolutePath) => {
+    if (typeof onProgress !== 'function') return;
+    onProgress({
+      phase,
+      path: absolutePath,
+      folders,
+      files,
+      batches,
+      at: Date.now(),
+    });
+  };
+
+  const guardedFs = async (operation, absolutePath, run) => {
+    if (scanTimedOut) {
+      throw createIoError('FOLDER_SIZE_IO_TIMEOUT', 'Folder-size subtree scan already timed out', {
+        operation,
+        path: absolutePath,
+        timeoutMs: ioTimeoutMs,
+      });
+    }
+    try {
+      return await withIoTimeout(operation, absolutePath, run, { timeoutMs: ioTimeoutMs });
+    } catch (err) {
+      if (isIoTimeoutError(err) || isIoCircuitOpenError(err)) scanTimedOut = true;
+      throw err;
+    }
+  };
+
+  const yieldAndPause = async () => {
+    batches += 1;
+    await yieldToEventLoop();
+    if (pauseMs > 0) {
+      pauses += 1;
+      await sleep(pauseMs);
+    }
+  };
+
+  const flush = () => {
+    if (!pending.length) return;
+    const batch = pending.splice(0, pending.length);
+    folderSizeIndex.bulkUpsertScanEntries(db, scope, batch);
+  };
+
+  const recordEntry = (absDir, sizeBytes, entryCount) => {
+    pending.push({ absolutePath: absDir, sizeBytes, entryCount, lastFullScanAt: nowIso() });
+    folders += 1;
+    if (pending.length >= batchSize) flush();
+  };
+
+  const newFrame = (abs) => ({
+    abs,
+    childDirs: null, // null until the directory has been read
+    next: 0,
+    directFileBytes: 0,
+    childrenBytes: 0,
+    entryCount: 0,
+  });
+
+  // Iterative post-order DFS. The stack only ever holds the frames on the
+  // current root-to-node path, so peak memory is O(sum of directory widths along
+  // a single path) — never O(total directories in the tree). This is what keeps
+  // the baseline's RAM flat on very large volumes: the previous recursive
+  // version eagerly created a promise (and held the Dirent array) for *every*
+  // directory in the whole tree simultaneously.
+  //
+  // Only the leaf I/O (readdir, stat) goes through the concurrency limiter, and a
+  // frame never holds a limiter slot while awaiting a child — so it cannot
+  // deadlock on deep trees the way limiting the recursion itself would.
+  const stack = [newFrame(rootAbs)];
+  let rootTotal = 0;
+  let rootEntryCount = 0;
+
+  while (stack.length) {
+    throwIfAborted();
+    const frame = stack[stack.length - 1];
+
+    // First visit: read the directory, stat its files (bounded concurrency) and
+    // remember its subdirectories to descend into. An unreadable directory is
+    // still recorded (size 0) so it exists in the index.
+    if (frame.childDirs === null) {
+      let entries = null;
+      try {
+        reportProgress('readdir', frame.abs);
+        // eslint-disable-next-line no-await-in-loop
+        entries = await limit(() =>
+          guardedFs('readdir', frame.abs, () => fs.readdir(frame.abs, { withFileTypes: true }))
+        );
+        throwIfAborted();
+      } catch (err) {
+        if (isIoTimeoutError(err) || isIoCircuitOpenError(err)) throw err;
+        frame.childDirs = [];
+      }
+
+      if (entries) {
+        const filePaths = [];
+        const childDirs = [];
+        for (const entry of entries) {
+          const full = path.join(frame.abs, entry.name);
+          if (entry.isDirectory()) {
+            frame.entryCount += 1;
+            if (typeof shouldExclude !== 'function' || !shouldExclude(full)) {
+              childDirs.push(full);
+            }
+          } else if (entry.isFile()) {
+            frame.entryCount += 1;
+            filePaths.push(full);
+          } else {
+            // symlink / socket / fifo / device — counted but contributes no size
+            frame.entryCount += 1;
+          }
+        }
+        // Do not enqueue a promise for every file in a large directory. The
+        // limiter bounds active I/O, but its pending queue would still retain
+        // thousands of closures and immediately heat the filesystem cache.
+        for (let offset = 0; offset < filePaths.length; offset += batchSize) {
+          throwIfAborted();
+          const paths = filePaths.slice(offset, offset + batchSize);
+          reportProgress('stat', frame.abs);
+          // eslint-disable-next-line no-await-in-loop
+          const fileSizes = await Promise.all(
+            paths.map((filePath) =>
+              limit(async () => {
+                try {
+                  return (await guardedFs('stat', filePath, () => fs.stat(filePath))).size;
+                } catch (err) {
+                  if (isIoTimeoutError(err) || isIoCircuitOpenError(err)) throw err;
+                  return 0;
+                }
+              })
+            )
+          );
+          throwIfAborted();
+          frame.directFileBytes += fileSizes.reduce((total, size) => total + size, 0);
+          files += paths.length;
+          if (offset + paths.length < filePaths.length) {
+            // eslint-disable-next-line no-await-in-loop
+            await yieldAndPause();
+          }
+        }
+        frame.childDirs = childDirs;
+      }
+    }
+
+    // Descend into the next unvisited subdirectory, if any.
+    if (frame.next < frame.childDirs.length) {
+      const childAbs = frame.childDirs[frame.next];
+      frame.childDirs[frame.next] = null; // release the path as we descend
+      frame.next += 1;
+      stack.push(newFrame(childAbs));
+      continue;
+    }
+
+    // All children processed: finalize this directory (post-order) and bubble
+    // its recursive total up to its parent.
+    stack.pop();
+    const recursiveTotal = frame.directFileBytes + frame.childrenBytes;
+    const sizeBytes = mode === 'full' ? recursiveTotal : frame.directFileBytes;
+    recordEntry(frame.abs, sizeBytes, frame.entryCount);
+
+    if (stack.length) {
+      stack[stack.length - 1].childrenBytes += recursiveTotal;
+    } else {
+      rootTotal = recursiveTotal;
+      rootEntryCount = frame.entryCount;
+    }
+
+    if (folders % yieldEvery === 0) {
+      // eslint-disable-next-line no-await-in-loop
+      await yieldAndPause();
+    }
+  }
+
+  throwIfAborted();
+  flush();
+  return { folders, files, bytes: rootTotal, entryCount: rootEntryCount, batches, pauses };
+};
+
+/** Run a full authoritative scan of the configured volume root. */
+const runBaseline = (db, scope, options = {}) => scanTree(db, scope, scope.root, options);
+
+/**
+ * Index a newly-created directory tree and apply its resulting size exactly
+ * once to the parent chain. This is the completion path for operations such as
+ * ZIP extraction and directory copy: it avoids an eventual, view-driven walk
+ * while keeping the scan limited to the newly produced subtree.
+ */
+const indexSubtree = async (db, scope, absDir, options = {}) => {
+  if (!folderSizeIndex.isWithinRoot(scope.root, absDir)) return null;
+  if (typeof options.shouldExclude === 'function' && options.shouldExclude(absDir)) return null;
+
+  const mode = options.mode || config.folderSize.mode || 'full';
+  const previous = folderSizeIndex.getByAbsolutePath(db, absDir);
+  const result = await scanTree(db, scope, absDir, { ...options, mode });
+
+  if (absDir !== scope.root) {
+    // In shallow mode parents deliberately exclude their child folders' bytes.
+    const byteDelta = mode === 'full' ? result.bytes - (previous?.sizeBytes || 0) : 0;
+    folderSizeIndex.applyDelta(db, scope, path.dirname(absDir), byteDelta, {
+      entryDelta: previous ? 0 : 1,
+    });
+  }
+
+  return result;
+};
+
+/**
+ * Re-aggregate the *direct* level of a single folder: sum the sizes of files
+ * directly inside it and (in `full` mode) the already-indexed sizes of its
+ * direct subfolders. It also reports if one of those children has no index
+ * entry yet, allowing the manager to schedule one targeted subtree rebuild
+ * without adding a recursive scan to the read path.
+ *
+ * @returns {Promise<{
+ *   sizeBytes: number,
+ *   entryCount: number,
+ *   hasUnindexedSubdirectories: boolean
+ * } | null>} null if the path is not a readable directory.
+ */
+const aggregateDirectory = async (db, scope, absDir, options = {}) => {
+  const mode = options.mode || config.folderSize.mode || 'full';
+  const ioTimeoutMs = options.ioTimeoutMs ?? config.folderSize.ioTimeoutMs;
+  const shouldExclude = options.shouldExclude;
+  if (typeof shouldExclude === 'function' && shouldExclude(absDir)) return null;
+  let entries;
+  try {
+    entries = await withIoTimeout(
+      'readdir',
+      absDir,
+      () => fs.readdir(absDir, { withFileTypes: true }),
+      {
+        timeoutMs: ioTimeoutMs,
+      }
+    );
+  } catch (err) {
+    if (isIoTimeoutError(err) || isIoCircuitOpenError(err)) throw err;
+    return null;
+  }
+
+  let directFileBytes = 0;
+  let childrenBytes = 0;
+  let entryCount = 0;
+  let hasUnindexedSubdirectories = false;
+
+  for (const entry of entries) {
+    const full = path.join(absDir, entry.name);
+    if (entry.isDirectory()) {
+      entryCount += 1;
+      if (typeof shouldExclude === 'function' && shouldExclude(full)) continue;
+      if (mode === 'full') {
+        const child = folderSizeIndex.getByAbsolutePath(db, full);
+        if (child) {
+          childrenBytes += child.sizeBytes;
+        } else {
+          hasUnindexedSubdirectories = true;
+        }
+      }
+    } else if (entry.isFile()) {
+      entryCount += 1;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        directFileBytes += (
+          await withIoTimeout('stat', full, () => fs.stat(full), { timeoutMs: ioTimeoutMs })
+        ).size;
+      } catch (err) {
+        if (isIoTimeoutError(err) || isIoCircuitOpenError(err)) throw err;
+        // Unreadable/removed file mid-scan — treat as zero.
+      }
+    } else {
+      entryCount += 1;
+    }
+  }
+
+  const sizeBytes = mode === 'full' ? directFileBytes + childrenBytes : directFileBytes;
+  return { sizeBytes, entryCount, hasUnindexedSubdirectories };
+};
+
+/**
+ * Reconcile the index for a folder against a freshly computed aggregate
+ * (synchronous — safe to call inside a wrapping better-sqlite3 transaction).
+ * Applies the size delta to the folder and its ancestors, then records the new
+ * direct entry count / scan time. Returns the byte delta applied.
+ */
+const applyAggregate = (db, scope, absDir, agg) => {
+  const existing = folderSizeIndex.getByAbsolutePath(db, absDir);
+  const oldSize = existing ? existing.sizeBytes : 0;
+  const delta = agg.sizeBytes - oldSize;
+  if (delta !== 0 || !existing) {
+    folderSizeIndex.applyDelta(db, scope, absDir, delta, {});
+  }
+  folderSizeIndex.setScanMeta(db, absDir, {
+    entryCount: agg.entryCount,
+    lastFullScanAt: nowIso(),
+    dirty: 0,
+  });
+  return delta;
+};
+
+/**
+ * Drop a folder that has disappeared (or is no longer a directory) from the
+ * index and remove its recorded size from the ancestors that remain
+ * (synchronous). Returns the negative byte delta applied (0 if it was unknown).
+ */
+const removeMissing = (db, scope, absDir) => {
+  const existing = folderSizeIndex.getByAbsolutePath(db, absDir);
+  if (!existing) return 0;
+  const size = folderSizeIndex.removeSubtree(db, scope, absDir);
+  if (absDir !== scope.root && size) {
+    folderSizeIndex.applyDelta(db, scope, path.dirname(absDir), -size, {});
+  }
+  return -size;
+};
+
+/**
+ * Re-aggregate one folder and reconcile the index with the result, propagating
+ * any delta to the ancestors. Returns the byte delta applied (0 if unchanged,
+ * null if the folder is no longer a readable directory — caller decides what to
+ * do with a vanished folder).
+ */
+const reconcileDirectory = async (db, scope, absDir, options = {}) => {
+  const agg = await aggregateDirectory(db, scope, absDir, options);
+  if (!agg) return null;
+  if (agg.hasUnindexedSubdirectories && options.onIncompleteSubtree) {
+    options.onIncompleteSubtree(absDir);
+  }
+  return applyAggregate(db, scope, absDir, agg);
+};
+
+/**
+ * mtime-based reconciliation pass (safety net for external writes that bypassed
+ * the hooks and the on-view refresh, e.g. another Samba/NFS client on the same
+ * mount).
+ *
+ * For every indexed folder it does a single stat(): folders whose mtime has not
+ * advanced past their last scan (and are not flagged dirty) are skipped for
+ * free; changed folders are re-aggregated at their direct level only and the
+ * delta propagates upward. Vanished folders are pruned and their size removed
+ * from the ancestors.
+ *
+ * Rows are streamed in pages ordered by relative_path DESC — i.e. children
+ * before their parents — so a vanished folder's size is removed from an ancestor
+ * before that ancestor is itself re-aggregated (no double counting), and peak
+ * memory is O(page) rather than O(all folders). Between pages the pass sleeps for
+ * `pauseMs`, so even a volume with hundreds of thousands of folders is scanned
+ * as a gentle background trickle instead of one CPU/IO burst. Callers may also
+ * set `maxDirectories` and resume from `beforeRelativePath`, making scheduled
+ * reconciliation bounded rather than a permanently active full-volume sweep.
+ *
+ * @returns {Promise<{ checked, changed, removed, skipped, processed, hasMore, nextCursor }>}
+ */
+const reconcile = async (db, scope, options = {}) => {
+  const {
+    mode = config.folderSize.mode || 'full',
+    signal,
+    batch = config.folderSize.reconcileBatch || 100,
+    pauseMs = options.pauseMs ?? config.folderSize.reconcilePauseMs ?? 0,
+    maxDirectories = config.folderSize.reconcileMaxDirectories ?? 200,
+    beforeRelativePath = null,
+    ioTimeoutMs = options.ioTimeoutMs ?? config.folderSize.ioTimeoutMs,
+    shouldSkip,
+    shouldExclude,
+    onIncompleteSubtree,
+  } = options;
+
+  let checked = 0;
+  let changed = 0;
+  let removed = 0;
+  let skipped = 0;
+  let processed = 0;
+
+  const pruneStale = (abs) => {
+    const size = folderSizeIndex.removeSubtree(db, scope, abs);
+    if (abs !== scope.root && size) {
+      folderSizeIndex.applyDelta(db, scope, path.dirname(abs), -size, {});
+    }
+    removed += 1;
+  };
+
+  const handleRow = async (row) => {
+    const abs = absOf(scope, row.relativePath);
+    if (typeof shouldExclude === 'function' && shouldExclude(abs)) {
+      pruneStale(abs);
+      skipped += 1;
+      return;
+    }
+    if (typeof shouldSkip === 'function' && shouldSkip(abs)) {
+      skipped += 1;
+      return;
+    }
+    let stat;
+    try {
+      stat = await withIoTimeout('stat', abs, () => fs.stat(abs), { timeoutMs: ioTimeoutMs });
+    } catch (err) {
+      if (isIoTimeoutError(err) || isIoCircuitOpenError(err)) throw err;
+      if (!isMissingPathError(err)) {
+        skipped += 1;
+        return;
+      }
+      pruneStale(abs); // gone entirely
+      return;
+    }
+    if (!stat.isDirectory()) {
+      pruneStale(abs); // replaced by a file of the same name
+      return;
+    }
+    checked += 1;
+    const lastScan = row.lastFullScanAt ? Date.parse(row.lastFullScanAt) : 0;
+    const unchanged = !row.dirty && Number.isFinite(lastScan) && stat.mtimeMs <= lastScan;
+    if (unchanged) {
+      skipped += 1;
+      return;
+    }
+    const delta = await reconcileDirectory(db, scope, abs, {
+      mode,
+      onIncompleteSubtree,
+      shouldExclude,
+    });
+    if (delta !== 0) changed += 1;
+  };
+
+  let cursor = beforeRelativePath;
+  let exhausted = false;
+  for (;;) {
+    if (signal?.aborted || (maxDirectories > 0 && processed >= maxDirectories)) break;
+    const rows = folderSizeIndex.listScanTargetsPage(db, scope.label, cursor, batch);
+    if (!rows.length) {
+      exhausted = true;
+      break;
+    }
+    for (const row of rows) {
+      if (signal?.aborted || (maxDirectories > 0 && processed >= maxDirectories)) break;
+      processed += 1;
+      // eslint-disable-next-line no-await-in-loop
+      await handleRow(row);
+      cursor = row.relativePath;
+    }
+    if (signal?.aborted || (maxDirectories > 0 && processed >= maxDirectories)) break;
+    if (rows.length < batch) {
+      exhausted = true;
+      break;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    if (pauseMs > 0) await sleep(pauseMs);
+  }
+
+  const hasMore =
+    !signal?.aborted &&
+    !exhausted &&
+    Boolean(cursor && folderSizeIndex.listScanTargetsPage(db, scope.label, cursor, 1).length);
+  return {
+    checked,
+    changed,
+    removed,
+    skipped,
+    processed,
+    hasMore,
+    nextCursor: hasMore ? cursor : null,
+  };
+};
+
+module.exports = {
+  getVolumeScope,
+  isStale,
+  nextReconcileDelay,
+  withIoTimeout,
+  getIoDiagnostics,
+  runBaseline,
+  indexSubtree,
+  aggregateDirectory,
+  applyAggregate,
+  removeMissing,
+  reconcile,
+  // Re-export the propagating delta primitive so callers have a single import.
+  applyDelta: folderSizeIndex.applyDelta,
+};

--- a/backend/src/services/folderSizeManager.js
+++ b/backend/src/services/folderSizeManager.js
@@ -1,0 +1,598 @@
+/**
+ * Folder size indexer — in-process supervisor.
+ *
+ * Everything runs on the main thread to keep RAM low: no worker thread (no
+ * second V8 isolate, no second SQLite connection) and no recursive filesystem
+ * watcher (recursive inotify holds memory proportional to the directory count).
+ * Heavy work stays out of read/navigation paths. A mutating operation may await
+ * the final index of the subtree it created, but that scan is fully async
+ * (readdir/stat), writes to SQLite in small batched transactions, and yields to
+ * the event loop between batches — so Express keeps serving while it proceeds.
+ * We deliberately do NOT lower the process priority here (on the main thread
+ * that would nice request handling too).
+ *
+ * Freshness has three layers:
+ *   1. write hooks — NextExplorer's own operations update the index instantly;
+ *   2. on-view refresh — opening a folder re-checks the folders on screen
+ *      (mtime-gated) so external changes surface within seconds where you look;
+ *   3. adaptive reconciliation — a periodic mtime sweep that accelerates when it
+ *      finds external changes and backs off when idle. If a changed directory
+ *      exposes an unindexed child subtree, it queues one authoritative scan for
+ *      that subtree rather than leaving an incomplete aggregate behind.
+ */
+const fsp = require('fs/promises');
+const path = require('path');
+
+const config = require('../config/index');
+const logger = require('../utils/logger');
+const indexer = require('./folderSizeIndexer');
+const folderSizeIndex = require('./folderSizeIndex');
+const transferState = require('./folderSizeTransferState');
+const exclusions = require('./folderSizeExclusions');
+const { getDb } = require('./db');
+
+let db = null;
+let scope = null;
+let running = false;
+let starting = false;
+let stopped = false;
+
+// Directories that need (re)aggregation, coalesced until the next flush.
+const dirty = new Set();
+let flushing = false;
+let flushTimer = null;
+
+// Adaptive reconciliation state.
+let reconcileTimer = null;
+let reconcileDelay = 0;
+let reconciling = false;
+let abortController = null;
+let reconcileCursor = null;
+const reconcileStats = {
+  runs: 0,
+  partialRuns: 0,
+  completedPasses: 0,
+  processed: 0,
+  checked: 0,
+  changed: 0,
+  removed: 0,
+  skipped: 0,
+  lastRunAt: null,
+  lastDurationMs: null,
+};
+
+// Targeted scans are serialized with each other. A completed filesystem
+// operation can therefore await an exact subtree index without racing another
+// operation's ancestor delta or the SQLite writes it produces.
+let subtreeScanChain = Promise.resolve();
+const pendingSubtreeScans = new Map();
+let activeSubtreeScan = null;
+const subtreeScanStats = {
+  queued: 0,
+  started: 0,
+  completed: 0,
+  failed: 0,
+  folders: 0,
+  files: 0,
+  batches: 0,
+  pauses: 0,
+  totalMs: 0,
+  slow: 0,
+  timedOut: 0,
+  circuitOpen: 0,
+  cancelled: 0,
+};
+let readyPromise = null;
+
+const isFolderSizeIoSafetyError = (err) =>
+  err?.code === 'FOLDER_SIZE_IO_TIMEOUT' || err?.code === 'FOLDER_SIZE_IO_CIRCUIT_OPEN';
+
+const pathsOverlap = (left, right) =>
+  left === right ||
+  left.startsWith(`${right}${path.sep}`) ||
+  right.startsWith(`${left}${path.sep}`);
+
+const log = (level, message, extra = {}) =>
+  logger[level]({ component: 'folderSizeIndexer', ...extra }, message);
+
+/**
+ * Return the one-off baseline's transient heap to the OS. No-op unless the
+ * process was started with --expose-gc; called only after the baseline/rebuild
+ * (never in the steady-state loops) so it adds no ongoing pauses. Pair with
+ * NODE_OPTIONS=--max-old-space-size=<n> to keep the resident set low.
+ */
+const reclaimMemory = () => {
+  if (typeof global.gc === 'function') {
+    try {
+      global.gc();
+    } catch {
+      // ignore — best effort
+    }
+  }
+};
+
+const markDirty = (absPath) => {
+  if (!absPath || !scope) return;
+  if (!folderSizeIndex.isWithinRoot(scope.root, absPath)) return;
+  if (exclusions.isExcluded(absPath, scope)) return;
+  dirty.add(absPath);
+};
+
+/** Re-aggregate every dirty directory, applying all changes in one transaction. */
+const flush = async () => {
+  if (flushing || !db || !dirty.size) return;
+  flushing = true;
+  let retryDirs = [];
+  try {
+    const dirs = Array.from(dirty).filter(
+      (absolutePath) =>
+        !transferState.isRelatedToActiveTransfer(absolutePath) &&
+        !exclusions.isExcluded(absolutePath, scope)
+    );
+    dirty.clear();
+    if (!dirs.length) return;
+
+    // Phase 1 (async, read-only): compute each directory's new aggregate.
+    const ops = [];
+    const incompleteSubtrees = new Set();
+    for (const abs of dirs) {
+      let agg;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        agg = await indexer.aggregateDirectory(db, scope, abs, {
+          mode: config.folderSize.mode,
+          shouldExclude: (absDir) => exclusions.isExcluded(absDir, scope),
+        });
+      } catch (err) {
+        retryDirs.push(abs);
+        log('warn', 'Folder size aggregate deferred by I/O safety guard', {
+          path: abs,
+          code: err?.code,
+          timeoutMs: err?.timeoutMs,
+        });
+        continue;
+      }
+      ops.push({ abs, agg });
+      if (agg?.hasUnindexedSubdirectories) incompleteSubtrees.add(abs);
+    }
+
+    // Phase 2 (sync, one transaction): apply every change atomically.
+    const apply = db.transaction(() => {
+      for (const { abs, agg } of ops) {
+        if (agg) indexer.applyAggregate(db, scope, abs, agg);
+        else indexer.removeMissing(db, scope, abs);
+      }
+    });
+    apply();
+    for (const abs of incompleteSubtrees) {
+      refreshSubtree(abs).catch(() => {});
+    }
+  } catch (err) {
+    log('warn', 'Folder size flush failed', { err });
+  } finally {
+    for (const abs of retryDirs) dirty.add(abs);
+    flushing = false;
+  }
+};
+
+/**
+ * On-view refresh. Given the directories currently in view, mark the ones whose
+ * on-disk mtime is newer than what the index recorded so the next flush
+ * re-aggregates them. One stat per folder (skipped when unchanged), fired
+ * best-effort from the read route AFTER the response — the response itself stays
+ * an O(1) index lookup, never a traversal. This is what surfaces external
+ * changes promptly without a filesystem watcher.
+ */
+const touch = async (absDirs = []) => {
+  if (!running || !db || !Array.isArray(absDirs) || !absDirs.length) return;
+  for (const abs of absDirs) {
+    if (!folderSizeIndex.isWithinRoot(scope.root, abs)) continue;
+    if (exclusions.isExcluded(abs, scope)) continue;
+    if (transferState.isRelatedToActiveTransfer(abs)) continue;
+    let stat;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      stat = await indexer.withIoTimeout('stat', abs, () => fsp.stat(abs));
+    } catch (err) {
+      if (isFolderSizeIoSafetyError(err)) {
+        log('warn', 'Folder size on-view stat skipped by I/O safety guard', {
+          path: abs,
+          code: err.code,
+          timeoutMs: err.timeoutMs,
+        });
+        continue;
+      }
+      markDirty(abs); // vanished — the flush will remove it and fix ancestors
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    const entry = folderSizeIndex.getByAbsolutePath(db, abs);
+    if (indexer.isStale(entry, stat.mtimeMs)) markDirty(abs);
+  }
+};
+
+const runReconcile = async (reason, { full = false } = {}) => {
+  if (reconciling || stopped || !db) return { changed: 0 };
+  reconciling = true;
+  const startedAt = Date.now();
+  try {
+    const incompleteSubtrees = new Set();
+    const result = await indexer.reconcile(db, scope, {
+      mode: config.folderSize.mode,
+      signal: abortController?.signal,
+      beforeRelativePath: full ? null : reconcileCursor,
+      maxDirectories: full ? 0 : config.folderSize.reconcileMaxDirectories,
+      shouldSkip: transferState.isRelatedToActiveTransfer,
+      shouldExclude: (absDir) => exclusions.isExcluded(absDir, scope),
+      onIncompleteSubtree: (absDir) => incompleteSubtrees.add(absDir),
+    });
+    for (const abs of incompleteSubtrees) {
+      refreshSubtree(abs).catch(() => {});
+    }
+    if (!full) reconcileCursor = result.hasMore ? result.nextCursor : null;
+    reconcileStats.runs += 1;
+    reconcileStats.processed += result.processed || 0;
+    reconcileStats.checked += result.checked || 0;
+    reconcileStats.changed += result.changed || 0;
+    reconcileStats.removed += result.removed || 0;
+    reconcileStats.skipped += result.skipped || 0;
+    reconcileStats.lastRunAt = new Date().toISOString();
+    reconcileStats.lastDurationMs = Date.now() - startedAt;
+    if (result.hasMore) reconcileStats.partialRuns += 1;
+    else reconcileStats.completedPasses += 1;
+    log('debug', 'Reconciliation slice complete', {
+      reason,
+      full,
+      maxDirectories: full ? 0 : config.folderSize.reconcileMaxDirectories,
+      cursor: reconcileCursor,
+      ...result,
+    });
+    // A large sweep grows the heap; hand it back (no-op without --expose-gc).
+    reclaimMemory();
+    return result;
+  } catch (err) {
+    log('warn', 'Reconciliation failed', { err });
+    return { changed: 0, hasMore: false };
+  } finally {
+    reconciling = false;
+  }
+};
+
+/** Arm the next reconciliation timer, adaptively unless a fixed interval is set. */
+const armReconcile = () => {
+  if (stopped) return;
+  reconcileTimer = setTimeout(async () => {
+    const { changed, hasMore } = await runReconcile('scheduled');
+    const { reconcileMs, reconcileMinMs, reconcileMaxMs } = config.folderSize;
+    reconcileDelay =
+      reconcileMs > 0
+        ? reconcileMs
+        : hasMore
+          ? reconcileMinMs
+          : indexer.nextReconcileDelay(reconcileDelay, changed, {
+              minMs: reconcileMinMs,
+              maxMs: reconcileMaxMs,
+            });
+    armReconcile();
+  }, reconcileDelay);
+  if (reconcileTimer.unref) reconcileTimer.unref();
+};
+
+const baselineIfNeeded = async () => {
+  const existing = folderSizeIndex.countByVolume(db, scope.label);
+  const storedVersion = folderSizeIndex.getIndexVersion(db, scope);
+  const needsVersionUpgrade = existing > 0 && storedVersion < folderSizeIndex.CURRENT_INDEX_VERSION;
+  const rebuild = config.folderSize.rebuild || needsVersionUpgrade;
+  if (existing > 0 && !rebuild) {
+    log('info', 'Baseline skipped (volume already indexed)', {
+      folders: existing,
+      indexVersion: storedVersion,
+    });
+    return;
+  }
+  if (rebuild && existing > 0) {
+    folderSizeIndex.removeSubtree(db, scope, scope.root);
+    log('info', 'Rebuild requested — cleared existing index', {
+      folders: existing,
+      reason: config.folderSize.rebuild ? 'manual' : 'index-version-upgrade',
+      fromVersion: storedVersion,
+      toVersion: folderSizeIndex.CURRENT_INDEX_VERSION,
+    });
+  }
+  log('info', 'Starting baseline walk', { root: scope.root, mode: config.folderSize.mode });
+  const started = Date.now();
+  const result = await indexer.runBaseline(db, scope, {
+    mode: config.folderSize.mode,
+    shouldExclude: (absDir) => exclusions.isExcluded(absDir, scope),
+  });
+  folderSizeIndex.setIndexVersion(db, scope);
+  log('info', 'Baseline walk complete', { ...result, ms: Date.now() - started });
+};
+
+const pruneExcludedIndexEntries = (relativePaths = exclusions.effectivePaths()) => {
+  if (!db || !scope) return;
+  for (const relativePath of relativePaths) {
+    const absolutePath = path.resolve(scope.root, relativePath);
+    const removedSize = folderSizeIndex.removeSubtree(db, scope, absolutePath);
+    if (absolutePath !== scope.root && removedSize) {
+      folderSizeIndex.applyDelta(db, scope, path.dirname(absolutePath), -removedSize, {});
+    }
+  }
+};
+
+const init = async () => {
+  db = await getDb();
+  scope = indexer.getVolumeScope();
+  exclusions.loadFromDatabase(db);
+  pruneExcludedIndexEntries();
+
+  // Baseline once (or on explicit rebuild). Async + cooperative yields, so it
+  // never blocks request handling even on a large volume.
+  await baselineIfNeeded();
+  reclaimMemory();
+
+  running = true;
+  starting = false;
+  abortController = new AbortController();
+
+  flushTimer = setInterval(() => {
+    flush().catch(() => {});
+  }, config.folderSize.flushMs);
+  if (flushTimer.unref) flushTimer.unref();
+
+  reconcileDelay =
+    config.folderSize.reconcileMs > 0
+      ? config.folderSize.reconcileMs
+      : config.folderSize.reconcileMinMs;
+  armReconcile();
+
+  log('info', 'Folder size indexer ready (in-process)', {
+    root: scope.root,
+    mode: config.folderSize.mode,
+  });
+};
+
+const start = () => {
+  if (!config.folderSize.enabled) {
+    logger.debug('[folderSizeIndexer] Disabled (FOLDER_SIZE_MODE=off)');
+    return;
+  }
+  if (running || starting) return readyPromise;
+  starting = true;
+  stopped = false;
+  readyPromise = init().catch((err) => {
+    starting = false;
+    log('error', 'Folder size indexer failed to start', { err });
+    throw err;
+  });
+  readyPromise.catch(() => {});
+  return readyPromise;
+};
+
+const stop = async () => {
+  if (flushTimer) clearInterval(flushTimer);
+  if (reconcileTimer) clearTimeout(reconcileTimer);
+  flushTimer = null;
+  reconcileTimer = null;
+  if (abortController) abortController.abort(); // cancel any in-flight paced reconcile
+  activeSubtreeScan?.controller?.abort('indexer-stopped');
+  running = false;
+  // Final flush of anything still pending, then mark stopped so no late timer
+  // callback re-arms.
+  await flush();
+  stopped = true;
+};
+
+/**
+ * A filesystem mutation wins over a background scan. Cancel every queued or
+ * active targeted scan whose subtree overlaps the changed path so stale scan
+ * batches cannot recreate rows that a delete, move or rename just removed.
+ */
+const invalidateSubtree = (absolutePath, reason = 'filesystem-mutation') => {
+  if (!absolutePath) return { active: false, queued: 0 };
+  let queued = 0;
+  for (const [scanPath, pending] of pendingSubtreeScans) {
+    if (!pathsOverlap(scanPath, absolutePath)) continue;
+    pending.invalidated = true;
+    queued += 1;
+  }
+
+  const active = Boolean(activeSubtreeScan && pathsOverlap(activeSubtreeScan.path, absolutePath));
+  if (active) activeSubtreeScan.controller.abort(reason);
+  if (active || queued) {
+    log('debug', 'Folder size subtree scan invalidated by filesystem mutation', {
+      path: absolutePath,
+      reason,
+      active,
+      queued,
+    });
+  }
+  return { active, queued };
+};
+
+/**
+ * Queue an authoritative scan of one newly-created directory tree. Calls for
+ * the same path share the same work. During startup this waits for the baseline
+ * instead of returning a stale size for a completed operation.
+ */
+const refreshSubtree = async (absDir, { allowActiveTransfer = false } = {}) => {
+  if (!config.folderSize.enabled || stopped || (!running && !starting)) return null;
+  if (scope && exclusions.isExcluded(absDir, scope)) return null;
+  if (!allowActiveTransfer && transferState.isRelatedToActiveTransfer(absDir)) return null;
+  const existing = pendingSubtreeScans.get(absDir);
+  if (existing && !existing.invalidated) return existing.promise;
+  if (existing?.invalidated) pendingSubtreeScans.delete(absDir);
+
+  const pending = { invalidated: false, promise: null };
+
+  const scan = async () => {
+    if (pending.invalidated) return null;
+    if (starting && readyPromise) await readyPromise;
+    if (pending.invalidated) return null;
+    if (!running || !db || !scope || stopped) return null;
+    if (!allowActiveTransfer && transferState.isRelatedToActiveTransfer(absDir)) return null;
+
+    const startedAt = Date.now();
+    const controller = new AbortController();
+    activeSubtreeScan = {
+      path: absDir,
+      startedAt,
+      currentPath: absDir,
+      phase: 'queued',
+      controller,
+    };
+    subtreeScanStats.started += 1;
+    try {
+      const result = await indexer.indexSubtree(db, scope, absDir, {
+        mode: config.folderSize.mode,
+        batchSize: config.folderSize.subtreeBatch,
+        yieldEvery: config.folderSize.subtreeBatch,
+        pauseMs: config.folderSize.subtreePauseMs,
+        ioTimeoutMs: config.folderSize.ioTimeoutMs,
+        signal: controller.signal,
+        shouldExclude: (absolutePath) => exclusions.isExcluded(absolutePath, scope),
+        onProgress: (progress) => {
+          if (activeSubtreeScan?.path !== absDir) return;
+          activeSubtreeScan = {
+            ...activeSubtreeScan,
+            currentPath: progress.path,
+            phase: progress.phase,
+            folders: progress.folders,
+            files: progress.files,
+            batches: progress.batches,
+            lastProgressAt: progress.at,
+          };
+        },
+      });
+      const ms = Date.now() - startedAt;
+      subtreeScanStats.completed += 1;
+      subtreeScanStats.folders += result?.folders || 0;
+      subtreeScanStats.files += result?.files || 0;
+      subtreeScanStats.batches += result?.batches || 0;
+      subtreeScanStats.pauses += result?.pauses || 0;
+      subtreeScanStats.totalMs += ms;
+      if (result?.folders >= 300) reclaimMemory();
+
+      const details = {
+        path: absDir,
+        ...result,
+        ms,
+        queueDepth: Math.max(0, pendingSubtreeScans.size - 1),
+        batchSize: config.folderSize.subtreeBatch,
+        pauseMs: config.folderSize.subtreePauseMs,
+      };
+      if (ms >= config.folderSize.subtreeSlowLogMs) {
+        subtreeScanStats.slow += 1;
+        log('info', 'Folder size subtree scan complete', details);
+      } else {
+        log('debug', 'Folder size subtree scan complete', details);
+      }
+      return result;
+    } catch (err) {
+      if (err?.code === 'FOLDER_SIZE_SCAN_ABORTED') {
+        subtreeScanStats.cancelled += 1;
+        log('debug', 'Folder size subtree scan cancelled by filesystem mutation', {
+          path: absDir,
+          ms: Date.now() - startedAt,
+          currentPath: activeSubtreeScan?.currentPath || absDir,
+        });
+        return null;
+      }
+      subtreeScanStats.failed += 1;
+      if (err?.code === 'FOLDER_SIZE_IO_TIMEOUT') subtreeScanStats.timedOut += 1;
+      if (err?.code === 'FOLDER_SIZE_IO_CIRCUIT_OPEN') subtreeScanStats.circuitOpen += 1;
+      log('warn', 'Folder size subtree scan failed', {
+        path: absDir,
+        ms: Date.now() - startedAt,
+        currentPath: activeSubtreeScan?.currentPath || absDir,
+        phase: activeSubtreeScan?.phase || null,
+        err,
+      });
+      throw err;
+    } finally {
+      activeSubtreeScan = null;
+    }
+  };
+
+  const queued = subtreeScanChain.then(scan, scan);
+  subtreeScanChain = queued.catch(() => {});
+  subtreeScanStats.queued += 1;
+  pending.promise = queued;
+  pendingSubtreeScans.set(absDir, pending);
+  queued
+    .finally(() => {
+      if (pendingSubtreeScans.get(absDir) === pending) pendingSubtreeScans.delete(absDir);
+    })
+    .catch(() => {});
+  return queued;
+};
+
+/**
+ * Apply administrator-managed exclusions immediately. New exclusions are
+ * removed from the SQLite index and cancel any overlapping targeted walk;
+ * paths that become included are queued for one authoritative refresh.
+ */
+const setAdminExclusions = async (paths) => {
+  const changed = exclusions.setAdminPaths(paths);
+  if (!db || !scope || !config.folderSize.enabled) return { ...changed };
+
+  for (const relativePath of changed.added) {
+    const absolutePath = path.resolve(scope.root, relativePath);
+    invalidateSubtree(absolutePath, 'folder-size-excluded');
+    pruneExcludedIndexEntries([relativePath]);
+    markDirty(path.dirname(absolutePath));
+  }
+
+  for (const relativePath of changed.removed) {
+    const absolutePath = path.resolve(scope.root, relativePath);
+    refreshSubtree(absolutePath).catch(() => {});
+  }
+  return { ...changed };
+};
+
+const getDiagnosticsSnapshot = () => ({
+  running,
+  starting,
+  flushing,
+  reconciling,
+  dirtyDirectories: dirty.size,
+  pendingSubtreeScans: pendingSubtreeScans.size,
+  reconcileDelayMs: reconcileDelay || null,
+  reconcile: {
+    maxDirectories: config.folderSize.reconcileMaxDirectories,
+    cursor: reconcileCursor,
+    stats: { ...reconcileStats },
+  },
+  subtree: {
+    active: activeSubtreeScan
+      ? {
+          path: activeSubtreeScan.path,
+          currentPath: activeSubtreeScan.currentPath,
+          phase: activeSubtreeScan.phase,
+          folders: activeSubtreeScan.folders || 0,
+          files: activeSubtreeScan.files || 0,
+          batches: activeSubtreeScan.batches || 0,
+          ageMs: Date.now() - activeSubtreeScan.startedAt,
+          lastProgressAgeMs: activeSubtreeScan.lastProgressAt
+            ? Date.now() - activeSubtreeScan.lastProgressAt
+            : null,
+        }
+      : null,
+    batchSize: config.folderSize.subtreeBatch,
+    pauseMs: config.folderSize.subtreePauseMs,
+    slowLogMs: config.folderSize.subtreeSlowLogMs,
+    io: indexer.getIoDiagnostics(),
+    stats: { ...subtreeScanStats },
+  },
+});
+
+module.exports = {
+  start,
+  stop,
+  touch,
+  refreshSubtree,
+  invalidateSubtree,
+  setAdminExclusions,
+  isRunning: () => running,
+  getDiagnosticsSnapshot,
+};

--- a/backend/src/services/folderSizeTransferState.js
+++ b/backend/src/services/folderSizeTransferState.js
@@ -1,0 +1,34 @@
+const path = require('path');
+
+// Runtime coordination for directories currently being copied or moved. SQLite
+// keeps the pending index entry; this set prevents refreshes from scanning a
+// tree before its filesystem write has completed.
+const activeDirectories = new Set();
+
+const begin = (absolutePath) => {
+  if (absolutePath) activeDirectories.add(absolutePath);
+};
+
+const finish = (absolutePath) => {
+  if (absolutePath) activeDirectories.delete(absolutePath);
+};
+
+const isRelatedToActiveTransfer = (absolutePath) => {
+  if (!absolutePath) return false;
+  for (const activePath of activeDirectories) {
+    if (
+      absolutePath === activePath ||
+      absolutePath.startsWith(`${activePath}${path.sep}`) ||
+      activePath.startsWith(`${absolutePath}${path.sep}`)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+module.exports = {
+  begin,
+  finish,
+  isRelatedToActiveTransfer,
+};

--- a/backend/tests/routes/folderSize.test.js
+++ b/backend/tests/routes/folderSize.test.js
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import request from 'supertest';
+import { setupTestEnv, createTestApp } from '../helpers/env-test-utils.js';
+
+const ROUTE_MODULES = [
+  'src/routes/folderSize',
+  'src/services/accessManager',
+  'src/services/folderSizeIndex',
+  'src/services/folderSizeIndexer',
+  'src/services/folderSizeManager',
+  'src/utils/pathUtils',
+];
+
+/**
+ * Build the folder-size route test context: temp volume, a populated index and
+ * a mounted router. `userVolumes` toggles USER_VOLUMES so a non-admin user with
+ * no assigned volume is denied navigation (exercising the "size even when you
+ * cannot enter" requirement).
+ */
+const buildContext = async ({ user, userVolumes = false, folderSizeMode = 'full' } = {}) => {
+  const env = await setupTestEnv({
+    tag: 'folder-size-route-',
+    modules: ROUTE_MODULES,
+    env: {
+      FOLDER_SIZE_MODE: folderSizeMode,
+      USER_VOLUMES: userVolumes ? 'true' : 'false',
+    },
+  });
+
+  const { getDb } = env.requireFresh('src/services/db');
+  const folderSizeIndex = env.requireFresh('src/services/folderSizeIndex');
+  const indexer = env.requireFresh('src/services/folderSizeIndexer');
+  const manager = env.requireFresh('src/services/folderSizeManager');
+  const routes = env.requireFresh('src/routes/folderSize');
+
+  const db = await getDb();
+  const scope = { root: env.volumeDir, label: 'volume' };
+
+  const app = createTestApp({ router: routes, mountPath: '/api', user });
+  return { env, db, folderSizeIndex, indexer, manager, scope, app };
+};
+
+describe('Folder size route', () => {
+  let ctx;
+
+  afterEach(async () => {
+    if (ctx) {
+      await ctx.manager.stop();
+      await ctx.env.cleanup();
+      ctx = null;
+    }
+  });
+
+  it('returns sizeBytes even when the user cannot enter the folder', async () => {
+    ctx = await buildContext({
+      user: { id: 'restricted-user', roles: [] },
+      userVolumes: true,
+    });
+    const { env, db, indexer, scope } = ctx;
+
+    await fs.mkdir(path.join(env.volumeDir, 'TestVol', 'inner'), { recursive: true });
+    await fs.writeFile(path.join(env.volumeDir, 'TestVol', 'inner', 'file'), Buffer.alloc(4096));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    const response = await request(ctx.app).get('/api/folder-size/TestVol');
+
+    expect(response.status).toBe(200);
+    // USER_VOLUMES is on and this user has no assigned volume -> navigation denied
+    expect(response.body.canEnter).toBe(false);
+    // ...but the size is still reported (the non-negotiable requirement).
+    expect(response.body.indexed).toBe(true);
+    expect(response.body.sizeBytes).toBe(4096);
+    expect(response.body.entryCount).toBe(1);
+  });
+
+  it('returns indexed:false without error when the path is not indexed', async () => {
+    ctx = await buildContext({ user: { id: 'admin-user', roles: ['admin'] } });
+    await fs.mkdir(path.join(ctx.env.volumeDir, 'Unindexed'), { recursive: true });
+    // Deliberately no baseline run: the index is empty.
+
+    const response = await request(ctx.app).get('/api/folder-size/Unindexed');
+
+    expect(response.status).toBe(200);
+    expect(response.body.indexed).toBe(false);
+    expect(response.body.sizeBytes).toBeNull();
+    expect(response.body.entryCount).toBeNull();
+  });
+
+  it('returns a result per path from the batch endpoint', async () => {
+    ctx = await buildContext({ user: { id: 'admin-user', roles: ['admin'] } });
+    const { env, db, indexer, scope } = ctx;
+
+    await fs.mkdir(path.join(env.volumeDir, 'A', 'B'), { recursive: true });
+    await fs.writeFile(path.join(env.volumeDir, 'A', 'B', 'f1'), Buffer.alloc(100));
+    await fs.writeFile(path.join(env.volumeDir, 'A', 'f2'), Buffer.alloc(50));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    const response = await request(ctx.app)
+      .post('/api/folder-size/batch')
+      .send({ paths: ['A', 'A/B', 'DoesNotExist'] });
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body.results)).toBe(true);
+    expect(response.body.results).toHaveLength(3);
+
+    const byPath = Object.fromEntries(response.body.results.map((r) => [r.path, r]));
+    expect(byPath['A'].sizeBytes).toBe(150);
+    expect(byPath['A'].indexed).toBe(true);
+    expect(byPath['A/B'].sizeBytes).toBe(100);
+    expect(byPath['DoesNotExist'].indexed).toBe(false);
+    expect(byPath['DoesNotExist'].sizeBytes).toBeNull();
+  });
+
+  it('reports the authoritative scan timestamp after a pending transfer completes', async () => {
+    ctx = await buildContext({ user: { id: 'admin-user', roles: ['admin'] } });
+    const { env, db, folderSizeIndex, scope } = ctx;
+    const target = path.join(env.volumeDir, 'Transferred');
+    await fs.mkdir(target, { recursive: true });
+
+    folderSizeIndex.upsertPendingDirectoryEntry(db, scope, {
+      absolutePath: target,
+      sizeBytes: 0,
+      entryCount: 0,
+    });
+    folderSizeIndex.upsertScanEntry(db, scope, {
+      absolutePath: target,
+      sizeBytes: 123,
+      entryCount: 1,
+      lastFullScanAt: '2099-01-01T00:00:00.000Z',
+    });
+
+    const response = await request(ctx.app).get('/api/folder-size/Transferred');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ sizeBytes: 123, dirty: false });
+    expect(response.body.lastUpdated).toBe('2099-01-01T00:00:00.000Z');
+  });
+
+  it('never triggers a synchronous scan (unindexed folder with real content stays null)', async () => {
+    ctx = await buildContext({ user: { id: 'admin-user', roles: ['admin'] } });
+
+    // A folder that physically contains data but was never indexed must report
+    // null/false, proving the route does not fall back to a live traversal.
+    await fs.mkdir(path.join(ctx.env.volumeDir, 'Heavy'), { recursive: true });
+    await fs.writeFile(path.join(ctx.env.volumeDir, 'Heavy', 'big'), Buffer.alloc(123456));
+
+    const response = await request(ctx.app).get('/api/folder-size/Heavy');
+
+    expect(response.status).toBe(200);
+    expect(response.body.indexed).toBe(false);
+    expect(response.body.sizeBytes).toBeNull();
+  });
+
+  it('repairs a selected external directory tree through the explicit refresh endpoint', async () => {
+    ctx = await buildContext({ user: { id: 'admin-user', roles: ['admin'] } });
+    const { env, manager } = ctx;
+    await manager.start();
+
+    const external = path.join(env.volumeDir, 'External', 'nested');
+    await fs.mkdir(external, { recursive: true });
+    await fs.writeFile(path.join(external, 'payload.bin'), Buffer.alloc(321));
+
+    const response = await request(ctx.app).post('/api/folder-size/refresh/External');
+
+    expect(response.status).toBe(202);
+    expect(response.body).toMatchObject({
+      path: 'External',
+      refreshPending: true,
+    });
+  });
+
+  it('does not resolve paths or expose the index endpoints when disabled', async () => {
+    ctx = await buildContext({
+      user: { id: 'admin-user', roles: ['admin'] },
+      folderSizeMode: 'off',
+    });
+
+    const [single, batch, refresh] = await Promise.all([
+      request(ctx.app).get('/api/folder-size/anything'),
+      request(ctx.app)
+        .post('/api/folder-size/batch')
+        .send({ paths: ['anything'] }),
+      request(ctx.app).post('/api/folder-size/refresh/anything'),
+    ]);
+
+    expect(single.status).toBe(404);
+    expect(batch.status).toBe(404);
+    expect(refresh.status).toBe(404);
+    expect(ctx.manager.getDiagnosticsSnapshot()).toMatchObject({
+      running: false,
+      starting: false,
+      dirtyDirectories: 0,
+      pendingSubtreeScans: 0,
+    });
+  });
+});

--- a/backend/tests/services/folder-size-disabled.test.js
+++ b/backend/tests/services/folder-size-disabled.test.js
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+const MODULES = [
+  'src/config/env',
+  'src/config/index',
+  'src/services/folderSizeManager',
+  'src/services/folderSizeTransferState',
+];
+
+describe('Folder size disabled mode', () => {
+  let ctx;
+
+  afterEach(async () => {
+    if (ctx) {
+      await ctx.env.cleanup();
+      ctx = null;
+    }
+  });
+
+  it.each([undefined, 'invalid-mode'])(
+    'normalizes %s to off and leaves the indexer dormant',
+    async (folderSizeMode) => {
+      const env = await setupTestEnv({
+        tag: 'folder-size-disabled-',
+        modules: MODULES,
+        env: { FOLDER_SIZE_MODE: folderSizeMode },
+      });
+      ctx = { env };
+
+      const config = env.requireFresh('src/config/index');
+      const manager = env.requireFresh('src/services/folderSizeManager');
+      const transferState = env.requireFresh('src/services/folderSizeTransferState');
+
+      expect(config.folderSize).toMatchObject({ mode: 'off', enabled: false });
+
+      await manager.start();
+
+      expect(transferState.isRelatedToActiveTransfer('/tmp/folder-size-disabled-transfer')).toBe(
+        false
+      );
+      expect(await manager.refreshSubtree('/tmp/folder-size-disabled-transfer')).toBeNull();
+      expect(manager.getDiagnosticsSnapshot()).toMatchObject({
+        running: false,
+        starting: false,
+        flushing: false,
+        reconciling: false,
+        dirtyDirectories: 0,
+        pendingSubtreeScans: 0,
+      });
+    }
+  );
+});

--- a/backend/tests/services/folder-size-flush.test.js
+++ b/backend/tests/services/folder-size-flush.test.js
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * What the folder-size index takes in, and what it refuses to take in yet.
+ *
+ * Sizes are recorded by a background pass: directories a listing touched are
+ * marked, and a flush aggregates them into the index in one transaction. Half
+ * of that was uncovered — the marking and the flush both.
+ *
+ * The refusals are the part worth stating. A directory in the middle of a copy
+ * has a size that is true for an instant and wrong afterwards; recording it
+ * leaves a number nobody will correct until something else happens to that
+ * folder. An excluded tree is excluded because reading it is the whole cost the
+ * exclusion exists to avoid.
+ *
+ * Driven through `start`, `touch` and `stop`, which is how the application
+ * drives it — and `stop` flushing what is pending is itself the promise that a
+ * restart loses nothing.
+ */
+
+let currentEnv;
+let manager;
+
+const setup = async (extraEnv = {}) => {
+  currentEnv = await setupTestEnv({
+    tag: 'folder-size-flush-',
+    env: { FOLDER_SIZE_MODE: 'full', ...extraEnv },
+    modules: [
+      'src/config/env',
+      'src/config/index',
+      'src/services/folderSizeIndex',
+      'src/services/folderSizeIndexer',
+      'src/services/folderSizeTransferState',
+      'src/services/folderSizeManager',
+    ],
+  });
+
+  // The transfer state before the manager, deliberately. `requireFresh` builds
+  // a new module each time it is asked, and the manager captures whichever one
+  // exists when it is loaded — asking for it afterwards hands the test a second
+  // instance holding a set the manager never reads.
+  const transferState = currentEnv.requireFresh('src/services/folderSizeTransferState');
+  const folderSizeIndex = currentEnv.requireFresh('src/services/folderSizeIndex');
+  manager = currentEnv.requireFresh('src/services/folderSizeManager');
+  const db = await currentEnv.requireFresh('src/services/db').getDb();
+
+  await manager.start();
+
+  return { manager, folderSizeIndex, transferState, db, volume: currentEnv.volumeDir };
+};
+
+/** A folder holding one file of a known size. */
+const folderWith = async (volume, name, bytes) => {
+  const dir = path.join(volume, name);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, 'content.bin'), Buffer.alloc(bytes, 1));
+  return dir;
+};
+
+/** Mark it, then shut down — which flushes everything still pending. */
+const settle = async (dirs) => {
+  await manager.touch(dirs);
+  await manager.stop();
+};
+
+const sizeOf = (folderSizeIndex, db, dir) => folderSizeIndex.getByAbsolutePath(db, dir)?.sizeBytes;
+
+afterEach(async () => {
+  try {
+    await manager?.stop();
+  } catch (_) {
+    // Already stopped.
+  }
+  manager = null;
+  if (currentEnv) {
+    await currentEnv.cleanup();
+    currentEnv = null;
+  }
+});
+
+describe('a folder a listing has touched', () => {
+  it('has its size recorded', async () => {
+    const { folderSizeIndex, db, volume } = await setup();
+    const dir = await folderWith(volume, 'Photos', 2048);
+
+    await settle([dir]);
+
+    expect(sizeOf(folderSizeIndex, db, dir)).toBe(2048);
+  });
+
+  it('has it corrected when the folder grows', async () => {
+    const { folderSizeIndex, db, volume } = await setup();
+    const dir = await folderWith(volume, 'Photos', 1024);
+    await manager.touch([dir]);
+    await fs.writeFile(path.join(dir, 'more.bin'), Buffer.alloc(3072, 1));
+
+    await settle([dir]);
+
+    expect(sizeOf(folderSizeIndex, db, dir)).toBe(4096);
+  });
+
+  /** Shutting down is not a reason to lose what was already measured. */
+  it('is recorded even when the flush only happens on the way out', async () => {
+    const { folderSizeIndex, db, volume } = await setup();
+    const dir = await folderWith(volume, 'Photos', 512);
+
+    await manager.touch([dir]);
+    await manager.stop();
+
+    expect(sizeOf(folderSizeIndex, db, dir)).toBe(512);
+  });
+});
+
+describe('a folder in the middle of a copy', () => {
+  /**
+   * Its size is true for an instant and wrong immediately after. Recording it
+   * leaves a number nobody corrects until something else happens to that
+   * folder.
+   *
+   * The rule is enforced twice — once where a folder is marked and once where
+   * the marks are aggregated — so removing either guard alone changes nothing
+   * these can see. Removing both does. What is pinned here is the property,
+   * not either of the two places that keep it.
+   */
+  it('is left out of the index', async () => {
+    const { folderSizeIndex, db, transferState, volume } = await setup();
+    const dir = await folderWith(volume, 'Incoming', 4096);
+    transferState.begin(dir);
+
+    await settle([dir]);
+
+    expect(sizeOf(folderSizeIndex, db, dir)).toBeUndefined();
+  });
+
+  it('is taken in once the copy has finished', async () => {
+    const { folderSizeIndex, db, transferState, volume } = await setup();
+    const dir = await folderWith(volume, 'Incoming', 4096);
+    transferState.begin(dir);
+    await manager.touch([dir]);
+    transferState.finish(dir);
+
+    await settle([dir]);
+
+    expect(sizeOf(folderSizeIndex, db, dir)).toBe(4096);
+  });
+
+  /** A copy into a subfolder makes the folder above it just as uncertain. */
+  it('keeps its parent out as well', async () => {
+    const { folderSizeIndex, db, transferState, volume } = await setup();
+    const parent = await folderWith(volume, 'Media', 1024);
+    const child = path.join(parent, 'Incoming');
+    await fs.mkdir(child, { recursive: true });
+    transferState.begin(child);
+
+    await settle([parent]);
+
+    expect(sizeOf(folderSizeIndex, db, parent)).toBeUndefined();
+  });
+});
+
+describe('what the index will not walk into', () => {
+  /**
+   * The property, and only the property.
+   *
+   * Exclusion is applied in four places: where a folder is marked, where the
+   * marks are aggregated, in a prune at startup, and inside the aggregator
+   * itself. Removing any pair of them leaves the folder out all the same, so
+   * nothing below can say which one is doing the work — see TODO.md, where the
+   * same shape is already open against the search bounds.
+   */
+  it('leaves an excluded folder out', async () => {
+    const { folderSizeIndex, db, volume } = await setup({ FOLDER_SIZE_EXCLUDE_PATHS: 'Excluded' });
+    const dir = await folderWith(volume, 'Excluded', 8192);
+
+    await settle([dir]);
+
+    expect(sizeOf(folderSizeIndex, db, dir)).toBeUndefined();
+  });
+
+  it('still takes in the folder beside it', async () => {
+    const { folderSizeIndex, db, volume } = await setup({ FOLDER_SIZE_EXCLUDE_PATHS: 'Excluded' });
+    await folderWith(volume, 'Excluded', 8192);
+    const kept = await folderWith(volume, 'Kept', 256);
+
+    await settle([kept]);
+
+    expect(sizeOf(folderSizeIndex, db, kept)).toBe(256);
+  });
+
+  it('ignores a path outside the volume entirely', async () => {
+    const { folderSizeIndex, db } = await setup();
+    const outside = path.join(currentEnv.tmpRoot, 'outside');
+    await fs.mkdir(outside, { recursive: true });
+
+    await settle([outside]);
+
+    expect(sizeOf(folderSizeIndex, db, outside)).toBeUndefined();
+  });
+
+  it('ignores something that is a file rather than a folder', async () => {
+    const { folderSizeIndex, db, volume } = await setup();
+    const file = path.join(volume, 'note.txt');
+    await fs.writeFile(file, 'not a folder');
+
+    await settle([file]);
+
+    expect(sizeOf(folderSizeIndex, db, file)).toBeUndefined();
+  });
+});
+
+describe('a folder that is no longer there', () => {
+  /** The entry has to go, or the total keeps counting something deleted. */
+  it('is removed from the index', async () => {
+    const { folderSizeIndex, db, volume } = await setup();
+    const dir = await folderWith(volume, 'Temporary', 1024);
+    await settle([dir]);
+    expect(sizeOf(folderSizeIndex, db, dir)).toBe(1024);
+
+    await manager.start();
+    await fs.rm(dir, { recursive: true, force: true });
+    await settle([dir]);
+
+    expect(sizeOf(folderSizeIndex, db, dir)).toBeUndefined();
+  });
+});
+
+describe('being asked to take in nothing', () => {
+  it('is not an error', async () => {
+    const { volume } = await setup();
+
+    await expect(manager.touch([])).resolves.toBeUndefined();
+    await expect(manager.touch()).resolves.toBeUndefined();
+    expect(volume).toBeTruthy();
+  });
+});

--- a/backend/tests/services/folderSizeIndexer.test.js
+++ b/backend/tests/services/folderSizeIndexer.test.js
@@ -1,0 +1,661 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+const INDEXER_MODULES = [
+  'src/services/folderSizeIndex',
+  'src/services/folderSizeIndexer',
+  'src/services/folderSizeManager',
+];
+
+/**
+ * Build a fresh, isolated indexer test context: temp volume + database and
+ * freshly-required modules bound to that environment.
+ */
+const createContext = async (extraEnv = {}) => {
+  const env = await setupTestEnv({
+    tag: 'folder-size-indexer-',
+    modules: INDEXER_MODULES,
+    env: { FOLDER_SIZE_MODE: 'full', ...extraEnv },
+  });
+  const { getDb } = env.requireFresh('src/services/db');
+  const folderSizeIndex = env.requireFresh('src/services/folderSizeIndex');
+  const indexer = env.requireFresh('src/services/folderSizeIndexer');
+  const db = await getDb();
+  const scope = { root: env.volumeDir, label: 'volume' };
+  return { env, db, folderSizeIndex, indexer, scope };
+};
+
+const sizeOf = (folderSizeIndex, db, absPath) => {
+  const entry = folderSizeIndex.getByAbsolutePath(db, absPath);
+  return entry ? entry.sizeBytes : null;
+};
+
+describe('folderSizeIndexer', () => {
+  let ctx;
+  let manager;
+
+  afterEach(async () => {
+    await manager?.stop();
+    manager = null;
+    if (ctx) {
+      await ctx.env.cleanup();
+      ctx = null;
+    }
+  });
+
+  it('baseline scan aggregates recursive sizes across a tree', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    // vol/A/B/f1 (100), vol/A/f2 (50), vol/C/f3 (10)
+    await fs.mkdir(path.join(vol, 'A', 'B'), { recursive: true });
+    await fs.mkdir(path.join(vol, 'C'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'A', 'B', 'f1'), Buffer.alloc(100));
+    await fs.writeFile(path.join(vol, 'A', 'f2'), Buffer.alloc(50));
+    await fs.writeFile(path.join(vol, 'C', 'f3'), Buffer.alloc(10));
+
+    const result = await indexer.runBaseline(db, scope, { mode: 'full' });
+    expect(result.folders).toBe(4); // root, A, A/B, C
+    expect(result.bytes).toBe(160);
+
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(160);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A'))).toBe(150);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A', 'B'))).toBe(100);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'C'))).toBe(10);
+
+    const rootEntry = folderSizeIndex.getByAbsolutePath(db, vol);
+    expect(rootEntry.entryCount).toBe(2); // A and C
+  });
+
+  it('does not traverse or index excluded directory trees', async () => {
+    ctx = await createContext({ FOLDER_SIZE_EXCLUDE_PATHS: 'A/excluded' });
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'A', 'excluded', 'deep'), { recursive: true });
+    await fs.mkdir(path.join(vol, 'A', 'included'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'A', 'excluded', 'deep', 'large.bin'), Buffer.alloc(200));
+    await fs.writeFile(path.join(vol, 'A', 'included', 'kept.bin'), Buffer.alloc(50));
+
+    const exclusions = env.requireFresh('src/services/folderSizeExclusions');
+    const result = await indexer.runBaseline(db, scope, {
+      mode: 'full',
+      shouldExclude: (absolutePath) => exclusions.isExcluded(absolutePath, scope),
+    });
+
+    expect(result.bytes).toBe(50);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A'))).toBe(50);
+    expect(folderSizeIndex.getByAbsolutePath(db, path.join(vol, 'A', 'excluded'))).toBeNull();
+  });
+
+  it('releases callers when a filesystem operation stalls and opens a safety circuit', async () => {
+    ctx = await createContext();
+    const { indexer } = ctx;
+
+    await expect(
+      indexer.withIoTimeout('readdir', '/stalled/one', () => new Promise(() => {}), {
+        timeoutMs: 10,
+        maxStalledIo: 1,
+      })
+    ).rejects.toMatchObject({
+      code: 'FOLDER_SIZE_IO_TIMEOUT',
+      operation: 'readdir',
+      path: '/stalled/one',
+    });
+
+    expect(indexer.getIoDiagnostics()).toMatchObject({
+      maxStalledIo: 2,
+      stalledOperations: [{ operation: 'readdir', path: '/stalled/one' }],
+    });
+
+    await expect(
+      indexer.withIoTimeout('stat', '/stalled/two', () => Promise.resolve(), {
+        timeoutMs: 10,
+        maxStalledIo: 1,
+      })
+    ).rejects.toMatchObject({
+      code: 'FOLDER_SIZE_IO_CIRCUIT_OPEN',
+      operation: 'stat',
+      path: '/stalled/two',
+    });
+  });
+
+  it('a delta on a file propagates to every ancestor', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'A', 'B'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'A', 'B', 'f1'), Buffer.alloc(100));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    const before = {
+      root: sizeOf(folderSizeIndex, db, vol),
+      a: sizeOf(folderSizeIndex, db, path.join(vol, 'A')),
+      ab: sizeOf(folderSizeIndex, db, path.join(vol, 'A', 'B')),
+    };
+
+    // Simulate a 40-byte file added inside A/B.
+    indexer.applyDelta(db, scope, path.join(vol, 'A', 'B'), 40, { entryDelta: 1 });
+
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A', 'B'))).toBe(before.ab + 40);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A'))).toBe(before.a + 40);
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(before.root + 40);
+    expect(folderSizeIndex.getByAbsolutePath(db, path.join(vol, 'A', 'B')).entryCount).toBe(2);
+  });
+
+  it('clones indexed directory metadata without another filesystem traversal', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+    const source = path.join(vol, 'Source');
+    const target = path.join(vol, 'Copies', 'Source copy');
+
+    await fs.mkdir(path.join(source, 'nested'), { recursive: true });
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(path.join(source, 'top.bin'), Buffer.alloc(30));
+    await fs.writeFile(path.join(source, 'nested', 'deep.bin'), Buffer.alloc(70));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    const copied = folderSizeIndex.cloneSubtree(db, scope, source, target);
+
+    expect(copied).toBe(2);
+    expect(sizeOf(folderSizeIndex, db, target)).toBe(100);
+    expect(sizeOf(folderSizeIndex, db, path.join(target, 'nested'))).toBe(70);
+    expect(folderSizeIndex.getByAbsolutePath(db, target).dirty).toBe(0);
+  });
+
+  it('indexes a newly-created subtree and updates its ancestors in one pass', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'Existing'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'Existing', 'before'), Buffer.alloc(10));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    // Mirrors archive extraction: the new tree did not exist in the baseline.
+    const extracted = path.join(vol, 'Existing', 'Extracted');
+    await fs.mkdir(path.join(extracted, 'nested'), { recursive: true });
+    await fs.writeFile(path.join(extracted, 'top.bin'), Buffer.alloc(20));
+    await fs.writeFile(path.join(extracted, 'nested', 'payload.bin'), Buffer.alloc(70));
+
+    const result = await indexer.indexSubtree(db, scope, extracted, { mode: 'full' });
+
+    expect(result).toMatchObject({ folders: 2, bytes: 90 });
+    expect(sizeOf(folderSizeIndex, db, extracted)).toBe(90);
+    expect(sizeOf(folderSizeIndex, db, path.join(extracted, 'nested'))).toBe(70);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'Existing'))).toBe(100);
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(100);
+  });
+
+  it('replaces a pending transferred directory with an authoritative post-copy size', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+    const parent = path.join(vol, 'Destination');
+    const transferred = path.join(parent, 'Copied folder');
+
+    await fs.mkdir(parent, { recursive: true });
+    await fs.writeFile(path.join(parent, 'before.bin'), Buffer.alloc(10));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    // During a copy, the folder is recorded as pending without estimating its
+    // recursive bytes from possibly stale source metadata.
+    await fs.mkdir(path.join(transferred, 'nested'), { recursive: true });
+    await fs.writeFile(path.join(transferred, 'top.bin'), Buffer.alloc(20));
+    await fs.writeFile(path.join(transferred, 'nested', 'payload.bin'), Buffer.alloc(70));
+    folderSizeIndex.upsertPendingDirectoryEntry(db, scope, {
+      absolutePath: transferred,
+      sizeBytes: 0,
+      entryCount: 0,
+    });
+    folderSizeIndex.applyDelta(db, scope, parent, 0, { entryDelta: 1 });
+
+    expect(sizeOf(folderSizeIndex, db, parent)).toBe(10);
+    expect(folderSizeIndex.getByAbsolutePath(db, transferred)).toMatchObject({ dirty: 1 });
+
+    await indexer.indexSubtree(db, scope, transferred, { mode: 'full' });
+
+    expect(sizeOf(folderSizeIndex, db, transferred)).toBe(90);
+    expect(sizeOf(folderSizeIndex, db, parent)).toBe(100);
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(100);
+    expect(folderSizeIndex.getByAbsolutePath(db, transferred)).toMatchObject({ dirty: 0 });
+  });
+
+  it('allows only the transfer finalizer to scan a directory still protected from on-view refreshes', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+    const target = path.join(vol, 'Destination', 'Transferred');
+
+    await fs.mkdir(path.join(target, 'nested'), { recursive: true });
+    await fs.writeFile(path.join(target, 'nested', 'payload.bin'), Buffer.alloc(90));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    const transferState = env.requireFresh('src/services/folderSizeTransferState');
+    manager = env.requireFresh('src/services/folderSizeManager');
+    await manager.start();
+    transferState.begin(target);
+
+    await expect(manager.refreshSubtree(target)).resolves.toBeNull();
+    await expect(
+      manager.refreshSubtree(target, { allowActiveTransfer: true })
+    ).resolves.toMatchObject({
+      bytes: 90,
+    });
+    expect(sizeOf(folderSizeIndex, db, target)).toBe(90);
+
+    transferState.finish(target);
+  });
+
+  it('cancels an active subtree scan when a mutation invalidates its path', async () => {
+    ctx = await createContext();
+    const { env, indexer } = ctx;
+    const target = path.join(env.volumeDir, 'Mutating');
+    await fs.mkdir(target, { recursive: true });
+
+    manager = env.requireFresh('src/services/folderSizeManager');
+    await manager.start();
+
+    const originalIndexSubtree = indexer.indexSubtree;
+    let scanStarted;
+    const started = new Promise((resolve) => {
+      scanStarted = resolve;
+    });
+    indexer.indexSubtree = (_db, _scope, _absolutePath, { signal }) =>
+      new Promise((_resolve, reject) => {
+        scanStarted();
+        signal.addEventListener(
+          'abort',
+          () => {
+            const error = new Error('scan aborted');
+            error.code = 'FOLDER_SIZE_SCAN_ABORTED';
+            reject(error);
+          },
+          { once: true }
+        );
+      });
+
+    try {
+      const refresh = manager.refreshSubtree(target);
+      await started;
+
+      expect(manager.invalidateSubtree(target, 'entry-deleted')).toMatchObject({ active: true });
+      await expect(refresh).resolves.toBeNull();
+      expect(manager.getDiagnosticsSnapshot().subtree.stats.cancelled).toBe(1);
+    } finally {
+      indexer.indexSubtree = originalIndexSubtree;
+    }
+  });
+
+  it('bounds large-directory metadata work into paced batches', async () => {
+    ctx = await createContext();
+    const { env, db, indexer, scope } = ctx;
+    const target = path.join(env.volumeDir, 'large-directory');
+    await fs.mkdir(target, { recursive: true });
+
+    for (let i = 0; i < 45; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(path.join(target, `file-${i}`), Buffer.alloc(1));
+    }
+
+    const result = await indexer.indexSubtree(db, scope, target, {
+      mode: 'full',
+      concurrency: 2,
+      batchSize: 20,
+      yieldEvery: 20,
+      pauseMs: 0,
+    });
+
+    expect(result).toMatchObject({ folders: 1, files: 45, bytes: 45, pauses: 0 });
+    // 45 files over batches of 20 means two cooperative yields before the
+    // final batch. This guards against returning to an unbounded promise queue.
+    expect(result.batches).toBe(2);
+  });
+
+  it('marks an aggregate incomplete when a direct child directory is missing from the index', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'Known'), { recursive: true });
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    await fs.mkdir(path.join(vol, 'Known', 'AddedLater', 'nested'), { recursive: true });
+    await fs.writeFile(
+      path.join(vol, 'Known', 'AddedLater', 'nested', 'payload.bin'),
+      Buffer.alloc(25)
+    );
+
+    const aggregate = await indexer.aggregateDirectory(db, scope, path.join(vol, 'Known'), {
+      mode: 'full',
+    });
+
+    expect(aggregate).toMatchObject({ hasUnindexedSubdirectories: true });
+    expect(folderSizeIndex.getByAbsolutePath(db, path.join(vol, 'Known', 'AddedLater'))).toBeNull();
+  });
+
+  it('skips a directory explicitly marked as an active transfer during reconciliation', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+    const transferring = path.join(vol, 'Transferring');
+
+    await fs.mkdir(transferring, { recursive: true });
+    await fs.writeFile(path.join(transferring, 'before.bin'), Buffer.alloc(10));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    await fs.writeFile(path.join(transferring, 'during-copy.bin'), Buffer.alloc(90));
+    const future = new Date(Date.now() + 60_000);
+    await fs.utimes(transferring, future, future);
+
+    await indexer.reconcile(db, scope, {
+      mode: 'full',
+      shouldSkip: (absolutePath) => absolutePath === transferring,
+    });
+    expect(sizeOf(folderSizeIndex, db, transferring)).toBe(10);
+
+    await indexer.reconcile(db, scope, { mode: 'full' });
+    expect(sizeOf(folderSizeIndex, db, transferring)).toBe(100);
+  });
+
+  it('queues a targeted recovery when reconciliation finds an unindexed child subtree', async () => {
+    ctx = await createContext();
+    const { env, db, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'Known'), { recursive: true });
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    const added = path.join(vol, 'Known', 'AddedLater', 'nested');
+    await fs.mkdir(added, { recursive: true });
+    await fs.writeFile(path.join(added, 'payload.bin'), Buffer.alloc(25));
+    const future = new Date(Date.now() + 60_000);
+    await fs.utimes(path.join(vol, 'Known'), future, future);
+
+    const incomplete = [];
+    await indexer.reconcile(db, scope, {
+      mode: 'full',
+      onIncompleteSubtree: (absolutePath) => incomplete.push(absolutePath),
+    });
+
+    expect(incomplete).toContain(path.join(vol, 'Known'));
+  });
+
+  it('stores a per-volume index version after a successful baseline', async () => {
+    ctx = await createContext();
+    const { db, folderSizeIndex, indexer, scope } = ctx;
+
+    expect(folderSizeIndex.getIndexVersion(db, scope)).toBe(0);
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+    folderSizeIndex.setIndexVersion(db, scope);
+
+    expect(folderSizeIndex.getIndexVersion(db, scope)).toBe(folderSizeIndex.CURRENT_INDEX_VERSION);
+  });
+
+  it('rebuilds a populated legacy index once before serving folder sizes', async () => {
+    const env = await setupTestEnv({
+      tag: 'folder-size-manager-',
+      modules: INDEXER_MODULES,
+      env: { FOLDER_SIZE_MODE: 'full' },
+    });
+    ctx = { env };
+
+    const { getDb } = env.requireFresh('src/services/db');
+    const folderSizeIndex = env.requireFresh('src/services/folderSizeIndex');
+    const scope = { root: env.volumeDir, label: 'volume' };
+    const legacy = path.join(scope.root, 'Legacy');
+    await fs.mkdir(path.join(legacy, 'nested'), { recursive: true });
+    await fs.writeFile(path.join(legacy, 'nested', 'payload.bin'), Buffer.alloc(42));
+
+    const db = await getDb();
+    const scannedAt = new Date().toISOString();
+    folderSizeIndex.upsertScanEntry(db, scope, {
+      absolutePath: scope.root,
+      sizeBytes: 0,
+      entryCount: 1,
+      lastFullScanAt: scannedAt,
+    });
+    folderSizeIndex.upsertScanEntry(db, scope, {
+      absolutePath: legacy,
+      sizeBytes: 0,
+      entryCount: 1,
+      lastFullScanAt: scannedAt,
+    });
+
+    expect(folderSizeIndex.getIndexVersion(db, scope)).toBe(0);
+
+    manager = env.requireFresh('src/services/folderSizeManager');
+    await manager.start();
+
+    expect(folderSizeIndex.getIndexVersion(db, scope)).toBe(folderSizeIndex.CURRENT_INDEX_VERSION);
+    expect(folderSizeIndex.getByAbsolutePath(db, legacy).sizeBytes).toBe(42);
+    expect(folderSizeIndex.getByAbsolutePath(db, path.join(legacy, 'nested')).sizeBytes).toBe(42);
+  });
+
+  it('reconciliation detects and corrects an out-of-band change via mtime', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'A', 'B'), { recursive: true });
+    await fs.mkdir(path.join(vol, 'C'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'A', 'B', 'f1'), Buffer.alloc(100));
+    await fs.writeFile(path.join(vol, 'C', 'f3'), Buffer.alloc(10));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+    // Keep this untouched folder decisively older than its scan record. Some
+    // filesystems expose mtimes with a coarser resolution than Date.now().
+    const past = new Date(Date.now() - 60_000);
+    await fs.utimes(path.join(vol, 'C'), past, past);
+
+    // Add a file directly on the filesystem WITHOUT going through applyDelta,
+    // then bump the directory mtime so the reconciler notices it changed.
+    await fs.writeFile(path.join(vol, 'A', 'B', 'f_ext'), Buffer.alloc(25));
+    const future = new Date(Date.now() + 60_000);
+    await fs.utimes(path.join(vol, 'A', 'B'), future, future);
+
+    const result = await indexer.reconcile(db, scope, { mode: 'full' });
+
+    expect(result.changed).toBeGreaterThanOrEqual(1);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A', 'B'))).toBe(125);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A'))).toBe(125);
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(135); // 125 + C(10)
+    // The untouched C folder should have been skipped, not re-aggregated.
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'C'))).toBe(10);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+  });
+
+  it('reconciliation removes vanished folders and subtracts their size', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'A', 'B'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'A', 'B', 'f1'), Buffer.alloc(100));
+    await fs.writeFile(path.join(vol, 'A', 'f2'), Buffer.alloc(50));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    // Remove A/B out of band.
+    await fs.rm(path.join(vol, 'A', 'B'), { recursive: true, force: true });
+    await indexer.reconcile(db, scope, { mode: 'full' });
+
+    expect(folderSizeIndex.getByAbsolutePath(db, path.join(vol, 'A', 'B'))).toBeNull();
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A'))).toBe(50);
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(50);
+  });
+
+  it('reconciles correctly when paging (batch smaller than the tree)', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'A', 'B'), { recursive: true });
+    await fs.mkdir(path.join(vol, 'C'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'A', 'B', 'f1'), Buffer.alloc(100));
+    await fs.writeFile(path.join(vol, 'A', 'f2'), Buffer.alloc(50));
+    await fs.writeFile(path.join(vol, 'C', 'f3'), Buffer.alloc(10));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    // Out of band: remove A/B (−100) and add 5 bytes in C.
+    await fs.rm(path.join(vol, 'A', 'B'), { recursive: true, force: true });
+    await fs.writeFile(path.join(vol, 'C', 'f4'), Buffer.alloc(5));
+    const future = new Date(Date.now() + 60_000);
+    await fs.utimes(path.join(vol, 'C'), future, future);
+
+    // batch=1 forces multiple pages; the DESC order must remove A/B's size from A
+    // before A is re-aggregated (no double counting). pauseMs=0 keeps it fast.
+    await indexer.reconcile(db, scope, { mode: 'full', batch: 1, pauseMs: 0 });
+
+    expect(folderSizeIndex.getByAbsolutePath(db, path.join(vol, 'A', 'B'))).toBeNull();
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A'))).toBe(50); // only f2 remains
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'C'))).toBe(15); // f3 + f4
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(65); // A(50) + C(15)
+  });
+
+  it('resumes a bounded reconciliation pass from its SQLite cursor', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'A', 'B'), { recursive: true });
+    await fs.mkdir(path.join(vol, 'C'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'A', 'B', 'f1'), Buffer.alloc(100));
+    await fs.writeFile(path.join(vol, 'C', 'f2'), Buffer.alloc(10));
+    await indexer.runBaseline(db, scope, { mode: 'full' });
+
+    await fs.writeFile(path.join(vol, 'A', 'B', 'external'), Buffer.alloc(25));
+    const future = new Date(Date.now() + 60_000);
+    await fs.utimes(path.join(vol, 'A', 'B'), future, future);
+
+    let cursor = null;
+    let result;
+    let slices = 0;
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      result = await indexer.reconcile(db, scope, {
+        mode: 'full',
+        batch: 1,
+        pauseMs: 0,
+        beforeRelativePath: cursor,
+        maxDirectories: 2,
+      });
+      expect(result.processed).toBeLessThanOrEqual(2);
+      cursor = result.nextCursor;
+      slices += 1;
+    } while (result.hasMore && slices < 10);
+
+    expect(slices).toBeGreaterThan(1);
+    expect(result.hasMore).toBe(false);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A', 'B'))).toBe(125);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A'))).toBe(125);
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(135);
+  });
+
+  it('aggregates a deep tree (depth beyond the concurrency budget) correctly', async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    // A linear chain L0/L1/.../L9, each level holding a 10-byte file. Depth (10)
+    // far exceeds the concurrency budget (1); the old recursive walk risked a
+    // deadlock/blowup here, the iterative DFS must aggregate it cleanly.
+    const depth = 10;
+    let dir = vol;
+    for (let i = 0; i < depth; i += 1) {
+      dir = path.join(dir, `L${i}`);
+      // eslint-disable-next-line no-await-in-loop
+      await fs.mkdir(dir, { recursive: true });
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(path.join(dir, 'f'), Buffer.alloc(10));
+    }
+
+    const result = await indexer.runBaseline(db, scope, { mode: 'full', concurrency: 1 });
+    expect(result.folders).toBe(depth + 1); // root + L0..L9
+    expect(result.bytes).toBe(depth * 10); // 100
+
+    // Each level Lk holds its own 10 bytes plus everything below it.
+    dir = vol;
+    for (let i = 0; i < depth; i += 1) {
+      dir = path.join(dir, `L${i}`);
+      expect(sizeOf(folderSizeIndex, db, dir)).toBe((depth - i) * 10);
+    }
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(100);
+  });
+
+  it("shallow mode stores only each folder's direct file bytes", async () => {
+    ctx = await createContext();
+    const { env, db, folderSizeIndex, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    await fs.mkdir(path.join(vol, 'A', 'B'), { recursive: true });
+    await fs.writeFile(path.join(vol, 'A', 'B', 'f1'), Buffer.alloc(100));
+    await fs.writeFile(path.join(vol, 'A', 'f2'), Buffer.alloc(50));
+
+    await indexer.runBaseline(db, scope, { mode: 'shallow' });
+
+    // Direct-entries-only: A counts f2 (50), not the 100 nested inside A/B.
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A'))).toBe(50);
+    expect(sizeOf(folderSizeIndex, db, path.join(vol, 'A', 'B'))).toBe(100);
+    expect(sizeOf(folderSizeIndex, db, vol)).toBe(0); // root has no direct files
+  });
+
+  it('isStale flags only unknown or mtime-advanced folders', async () => {
+    ctx = await createContext();
+    const { indexer } = ctx;
+    expect(indexer.isStale(null, 1000)).toBe(true); // never indexed
+    expect(indexer.isStale({ lastFullScanAt: new Date(1000).toISOString() }, 2000)).toBe(true);
+    expect(indexer.isStale({ lastFullScanAt: new Date(5000).toISOString() }, 2000)).toBe(false);
+    // A recent incremental delta also counts as "known".
+    expect(indexer.isStale({ lastDeltaAt: new Date(5000).toISOString() }, 2000)).toBe(false);
+  });
+
+  it('nextReconcileDelay accelerates on change and backs off when idle', async () => {
+    ctx = await createContext();
+    const { indexer } = ctx;
+    const bounds = { minMs: 300000, maxMs: 43200000 };
+    expect(indexer.nextReconcileDelay(1000000, 3, bounds)).toBe(300000); // change -> reset to min
+    expect(indexer.nextReconcileDelay(0, 0, bounds)).toBe(600000); // idle from cold -> min*2
+    expect(indexer.nextReconcileDelay(600000, 0, bounds)).toBe(1200000); // idle -> double
+    expect(indexer.nextReconcileDelay(40000000, 0, bounds)).toBe(43200000); // capped at max
+  });
+
+  it('does not monopolise the event loop during a baseline scan', async () => {
+    ctx = await createContext();
+    const { env, db, indexer, scope } = ctx;
+    const vol = env.volumeDir;
+
+    // Build enough folders that the baseline yields multiple times.
+    for (let i = 0; i < 60; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await fs.mkdir(path.join(vol, `dir-${i}`, 'sub'), { recursive: true });
+      // eslint-disable-next-line no-await-in-loop
+      await fs.writeFile(path.join(vol, `dir-${i}`, 'sub', 'f'), Buffer.alloc(8));
+    }
+
+    let baselineDone = false;
+    const heartbeat = [];
+    const beat = async () => {
+      for (let i = 0; i < 20; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        heartbeat.push(baselineDone);
+      }
+    };
+
+    const scan = indexer
+      .runBaseline(db, scope, { mode: 'full', yieldEvery: 5, concurrency: 2 })
+      .then(() => {
+        baselineDone = true;
+      });
+
+    await Promise.all([scan, beat()]);
+
+    // At least one heartbeat must have fired while the scan was still running,
+    // proving the event loop kept servicing other (HTTP-like) work.
+    expect(heartbeat.some((done) => done === false)).toBe(true);
+  });
+});

--- a/frontend/src/components/FileObject.vue
+++ b/frontend/src/components/FileObject.vue
@@ -5,6 +5,9 @@ import { storeToRefs } from 'pinia';
 import FileIcon from '@/icons/FileIcon.vue';
 import { formatBytes, formatDate } from '@/utils';
 import { getKindLabel } from '@/utils/fileKinds';
+import FolderSizeLabel from '@/components/FolderSizeLabel.vue';
+import { useFolderSizeStore } from '@/stores/folderSize';
+import { useFeaturesStore } from '@/stores/features';
 import { useNavigation } from '@/composables/navigation';
 import { useSelection } from '@/composables/itemSelection';
 import { useFileStore } from '@/stores/fileStore';
@@ -24,6 +27,22 @@ const settings = useSettingsStore();
 const { openItem } = useNavigation();
 const { handleSelection, isSelected, toggleSelection } = useSelection();
 const fileStore = useFileStore();
+const folderSizeStore = useFolderSizeStore();
+const featuresStore = useFeaturesStore();
+
+const isDirectory = computed(() => props.item?.kind === 'directory');
+// item.path is the parent's logical path and item.name the entry name, so the
+// folder's own logical path — which is how the index knows it — is the two
+// joined.
+const folderFullPath = computed(() => {
+  const parent = props.item?.path || '';
+  const name = props.item?.name || '';
+  return parent ? `${parent}/${name}` : name;
+});
+const showFolderSize = computed(() => isDirectory.value && featuresStore.folderSizeEnabled);
+const folderSizeEntry = computed(() =>
+  showFolderSize.value ? folderSizeStore.sizeFor(folderFullPath.value) : null
+);
 const { renameState, selectionMode } = storeToRefs(fileStore);
 const { canDragDrop, handleDragStart } = useFileDragDrop();
 const contextMenu = useExplorerContextMenu();
@@ -359,7 +378,8 @@ if (isTouchDevice.value) {
           </template>
         </div>
         <p class="text-xs text-stone-400">
-          {{ formatBytes(item.size) }}
+          <FolderSizeLabel v-if="showFolderSize" :entry="folderSizeEntry" />
+          <template v-else>{{ formatBytes(item.size) }}</template>
         </p>
       </div>
     </div>
@@ -432,7 +452,8 @@ if (isTouchDevice.value) {
         </template>
       </div>
       <div class="text-sm">
-        {{ item.kind === 'directory' ? '&mdash;' : formatBytes(item.size) }}
+        <FolderSizeLabel v-if="showFolderSize" :entry="folderSizeEntry" />
+        <template v-else>{{ item.kind === 'directory' ? '&mdash;' : formatBytes(item.size) }}</template>
       </div>
       <div class="text-sm">
         {{ getKindLabel(item) }}

--- a/frontend/src/components/FolderSizeLabel.vue
+++ b/frontend/src/components/FolderSizeLabel.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { computed } from 'vue';
+import { formatBytes } from '@/utils';
+import { useI18n } from 'vue-i18n';
+
+// Displays a folder's pre-computed recursive size as formatted text. Styled to
+// match the surrounding size column (VolumeUsageBar's Tailwind-only approach);
+// folders have no quota, so there is no bar — just the formatted byte count,
+// with a muted placeholder while the size is not yet indexed.
+const props = defineProps({
+  entry: { type: Object, default: null },
+  placeholder: { type: String, default: '—' },
+});
+const { t } = useI18n();
+
+const hasSize = computed(
+  () =>
+    props.entry &&
+    !props.entry.dirty &&
+    props.entry.sizeBytes !== null &&
+    Number.isFinite(props.entry.sizeBytes)
+);
+
+const label = computed(() => {
+  if (hasSize.value) return formatBytes(props.entry.sizeBytes);
+  return props.entry?.excluded ? t('info.folderSizeExcluded') : props.placeholder;
+});
+
+const title = computed(() => {
+  if (props.entry?.excluded) return t('info.folderSizeExcludedHelp');
+  if (!hasSize.value) {
+    if (props.entry?.dirty) return 'Size is being calculated';
+    return props.entry && !props.entry.indexed ? 'Size not indexed yet' : '';
+  }
+  const parts = [formatBytes(props.entry.sizeBytes)];
+  if (Number.isFinite(props.entry.entryCount)) {
+    parts.push(`${props.entry.entryCount} item${props.entry.entryCount === 1 ? '' : 's'}`);
+  }
+  if (!props.entry.canEnter) parts.push('no access');
+  return parts.join(' · ');
+});
+</script>
+
+<template>
+  <span
+    class="tabular-nums"
+    :class="hasSize ? '' : 'text-neutral-400 dark:text-neutral-500'"
+    :title="title"
+  >
+    {{ label }}
+  </span>
+</template>

--- a/frontend/src/stores/features.js
+++ b/frontend/src/stores/features.js
@@ -14,6 +14,8 @@ export const useFeaturesStore = defineStore('features', () => {
   const collaboraEnabled = ref(false);
   const collaboraExtensions = ref([]);
   const volumeUsageEnabled = ref(false);
+  const folderSizeMode = ref('off');
+  const folderSizeEnabled = ref(false);
   const personalEnabled = ref(false);
   const userVolumesEnabled = ref(false);
   const skipHome = ref(false);
@@ -74,6 +76,9 @@ export const useFeaturesStore = defineStore('features', () => {
 
         // Volume usage
         volumeUsageEnabled.value = Boolean(features?.volumeUsage?.enabled);
+        folderSizeMode.value =
+          typeof features?.folderSize?.mode === 'string' ? features.folderSize.mode : 'off';
+        folderSizeEnabled.value = Boolean(features?.folderSize?.enabled);
 
         // Personal folders
         personalEnabled.value = Boolean(features?.personal?.enabled);
@@ -108,6 +113,8 @@ export const useFeaturesStore = defineStore('features', () => {
         collaboraEnabled.value = false;
         collaboraExtensions.value = [];
         volumeUsageEnabled.value = false;
+        folderSizeMode.value = 'off';
+        folderSizeEnabled.value = false;
         personalEnabled.value = false;
         userVolumesEnabled.value = false;
         skipHome.value = false;
@@ -141,6 +148,8 @@ export const useFeaturesStore = defineStore('features', () => {
     collaboraEnabled,
     collaboraExtensions,
     volumeUsageEnabled,
+    folderSizeMode,
+    folderSizeEnabled,
     personalEnabled,
     userVolumesEnabled,
     skipHome,

--- a/frontend/src/stores/folderSize.js
+++ b/frontend/src/stores/folderSize.js
@@ -1,0 +1,282 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { getFolderSizesBatch, normalizePath, refreshFolderSize } from '@/api';
+import { useFeaturesStore } from '@/stores/features';
+
+const REFRESH_THROTTLE_MS = 2500;
+const MANUAL_REFRESH_POLL_MS = 1500;
+const MANUAL_REFRESH_MAX_POLLS = 400;
+const DIRTY_REFRESH_INITIAL_MS = 2000;
+const DIRTY_REFRESH_MAX_MS = 15000;
+
+const normalizeEntry = (raw = {}) => ({
+  path: normalizePath(raw.path || ''),
+  sizeBytes: Number.isFinite(raw.sizeBytes) ? raw.sizeBytes : null,
+  entryCount: Number.isFinite(raw.entryCount) ? raw.entryCount : null,
+  canEnter: Boolean(raw.canEnter),
+  indexed: Boolean(raw.indexed),
+  dirty: Boolean(raw.dirty),
+  excluded: Boolean(raw.excluded),
+  lastUpdated: raw.lastUpdated || null,
+});
+
+const samePaths = (a, b) => {
+  if (!a || !b || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+};
+
+/**
+ * Store for pre-computed folder sizes. Mirrors the volumeUsage store's shape
+ * (reactive map keyed by normalized path, throttle + refreshPromise guard,
+ * scheduleRefresh) but tracks the set of folder paths currently visible and
+ * populates them in a single batch request.
+ */
+export const useFolderSizeStore = defineStore('folderSize', () => {
+  const sizes = ref({});
+  const isLoading = ref(false);
+
+  let refreshPromise = null;
+  let refreshTimer = null;
+  let lastRefreshAt = 0;
+  let trackedPaths = [];
+  let queuedRefresh = false;
+  let inFlightTargets = null;
+  const pendingManualRefreshes = new Map();
+  let dirtyRefreshTimer = null;
+  let dirtyRefreshDelay = DIRTY_REFRESH_INITIAL_MS;
+
+  const clearDisabledState = () => {
+    sizes.value = {};
+    queuedRefresh = false;
+
+    if (refreshTimer) {
+      window.clearTimeout(refreshTimer);
+      refreshTimer = null;
+    }
+
+    if (dirtyRefreshTimer) {
+      window.clearTimeout(dirtyRefreshTimer);
+      dirtyRefreshTimer = null;
+    }
+    dirtyRefreshDelay = DIRTY_REFRESH_INITIAL_MS;
+
+    for (const timer of pendingManualRefreshes.values()) {
+      window.clearTimeout(timer);
+    }
+    pendingManualRefreshes.clear();
+  };
+
+  const mergeEntries = (rawEntries = []) => {
+    const next = { ...sizes.value };
+    for (const raw of rawEntries) {
+      const entry = normalizeEntry(raw);
+      if (entry.path) next[entry.path] = entry;
+    }
+    sizes.value = next;
+  };
+
+  const setPaths = (paths = []) => {
+    const seen = new Set();
+    trackedPaths = [];
+    for (const p of paths) {
+      const key = normalizePath(p || '');
+      if (key && !seen.has(key)) {
+        seen.add(key);
+        trackedPaths.push(key);
+      }
+    }
+  };
+
+  const sizeFor = (path) => {
+    const key = normalizePath(path || '');
+    return key ? sizes.value[key] || null : null;
+  };
+
+  // Fetch the given paths in one batch and merge the results into `sizes`.
+  const fetchSizes = async (targets) => {
+    try {
+      const response = await getFolderSizesBatch(targets, {
+        // Folder sizes improve the view but must never turn a transient server
+        // overload during navigation/reload into a global network alert.
+        suppressErrorHandler: true,
+        retryNetworkErrors: true,
+      });
+      const results = Array.isArray(response?.results) ? response.results : [];
+      mergeEntries(results);
+      lastRefreshAt = Date.now();
+
+      // A copied or moved directory is intentionally exposed as dirty while
+      // its final subtree scan runs. Re-read only the current view, with a
+      // bounded exponential backoff, so its final size appears without a page
+      // reload and without polling an entire large tree.
+      const hasDirtyVisibleEntry = results.some((raw) => {
+        const entry = normalizeEntry(raw);
+        return entry.dirty && trackedPaths.includes(entry.path);
+      });
+      if (hasDirtyVisibleEntry) {
+        if (!dirtyRefreshTimer) {
+          const delay = dirtyRefreshDelay;
+          dirtyRefreshDelay = Math.min(dirtyRefreshDelay * 2, DIRTY_REFRESH_MAX_MS);
+          dirtyRefreshTimer = window.setTimeout(() => {
+            dirtyRefreshTimer = null;
+            refresh({ force: true }).catch(() => {});
+          }, delay);
+        }
+      } else {
+        if (dirtyRefreshTimer) {
+          window.clearTimeout(dirtyRefreshTimer);
+          dirtyRefreshTimer = null;
+        }
+        dirtyRefreshDelay = DIRTY_REFRESH_INITIAL_MS;
+      }
+    } catch (_) {
+      // Non-fatal: leave any previously known sizes in place.
+    }
+  };
+
+  const refresh = async ({ force = false, paths } = {}) => {
+    const featuresStore = useFeaturesStore();
+    await featuresStore.ensureLoaded();
+
+    if (!featuresStore.folderSizeEnabled) {
+      clearDisabledState();
+      return;
+    }
+
+    if (Array.isArray(paths)) {
+      setPaths(paths);
+    }
+
+    if (!trackedPaths.length) {
+      return;
+    }
+
+    const now = Date.now();
+    if (!force && now - lastRefreshAt < REFRESH_THROTTLE_MS) {
+      return;
+    }
+
+    // A batch is already in flight. Don't silently drop this request: if the
+    // tracked paths have changed since that batch started (e.g. the user
+    // navigated into another folder while the previous batch was still loading),
+    // queue exactly one follow-up that re-runs with the latest paths once the
+    // current batch settles. Identical concurrent calls are genuine duplicates,
+    // so we just share the in-flight promise.
+    if (refreshPromise) {
+      if (!samePaths(trackedPaths, inFlightTargets)) {
+        queuedRefresh = true;
+      }
+      return refreshPromise;
+    }
+
+    isLoading.value = true;
+    refreshPromise = (async () => {
+      try {
+        do {
+          queuedRefresh = false;
+          inFlightTargets = [...trackedPaths];
+          await fetchSizes(inFlightTargets);
+        } while (queuedRefresh);
+      } finally {
+        refreshPromise = null;
+        inFlightTargets = null;
+        isLoading.value = false;
+      }
+    })();
+
+    return refreshPromise;
+  };
+
+  /**
+   * Track and fetch sizes for the folders currently in view. Forced so a fresh
+   * navigation always populates, while the refreshPromise guard still prevents
+   * an overlapping duplicate request.
+   */
+  const ensureSizes = async (paths = []) => {
+    setPaths(paths);
+    if (!trackedPaths.length) return;
+    await refresh({ force: true });
+  };
+
+  const scheduleRefresh = ({ delayMs = 500, force = true } = {}) => {
+    if (!useFeaturesStore().folderSizeEnabled) {
+      clearDisabledState();
+      return;
+    }
+
+    if (refreshTimer) {
+      window.clearTimeout(refreshTimer);
+    }
+    refreshTimer = window.setTimeout(() => {
+      refreshTimer = null;
+      refresh({ force }).catch(() => {});
+    }, delayMs);
+  };
+
+  const pollManualRefresh = (path, previousLastUpdated) => {
+    if (pendingManualRefreshes.has(path)) return;
+
+    let attempts = 0;
+    const poll = async () => {
+      try {
+        const response = await getFolderSizesBatch([path], {
+          suppressErrorHandler: true,
+          retryNetworkErrors: false,
+        });
+        const raw = Array.isArray(response?.results) ? response.results[0] : null;
+        const entry = normalizeEntry(raw || {});
+        if (entry.path) {
+          mergeEntries([entry]);
+          if (entry.indexed && entry.lastUpdated && entry.lastUpdated !== previousLastUpdated) {
+            pendingManualRefreshes.delete(path);
+            return;
+          }
+        }
+      } catch (_) {
+        // The normal view refresh will retry later; do not raise a toast for a
+        // background completion check after the user explicitly queued a scan.
+      }
+
+      attempts += 1;
+      if (attempts >= MANUAL_REFRESH_MAX_POLLS) {
+        pendingManualRefreshes.delete(path);
+        return;
+      }
+      const timer = window.setTimeout(poll, MANUAL_REFRESH_POLL_MS);
+      pendingManualRefreshes.set(path, timer);
+    };
+
+    const timer = window.setTimeout(poll, MANUAL_REFRESH_POLL_MS);
+    pendingManualRefreshes.set(path, timer);
+  };
+
+  // Explicit repair for a folder changed outside NextExplorer. The server
+  // acknowledges the queued scan immediately; a tiny single-row poll updates
+  // the UI when the authoritative index entry is committed.
+  const refreshFolder = async (path) => {
+    const featuresStore = useFeaturesStore();
+    await featuresStore.ensureLoaded();
+    if (!featuresStore.folderSizeEnabled) return null;
+
+    const raw = await refreshFolderSize(path);
+    const entry = normalizeEntry(raw);
+    if (!entry.path) return null;
+    mergeEntries([entry]);
+    if (raw?.refreshPending) pollManualRefresh(entry.path, entry.lastUpdated);
+    return { ...entry, refreshPending: Boolean(raw?.refreshPending) };
+  };
+
+  return {
+    sizes,
+    isLoading,
+    refresh,
+    ensureSizes,
+    scheduleRefresh,
+    refreshFolder,
+    setPaths,
+    sizeFor,
+  };
+});

--- a/frontend/src/stores/folderSize.spec.js
+++ b/frontend/src/stores/folderSize.spec.js
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+const getFolderSizesBatch = vi.fn();
+const refreshFolderSize = vi.fn();
+const ensureLoaded = vi.fn(() => Promise.resolve());
+const featuresState = { folderSizeEnabled: true };
+
+vi.mock('@/api', () => ({
+  getFolderSizesBatch: (...args) => getFolderSizesBatch(...args),
+  refreshFolderSize: (...args) => refreshFolderSize(...args),
+  normalizePath: (p) => (p || '').replace(/^\/+|\/+$/g, ''),
+}));
+
+vi.mock('@/stores/features', () => ({
+  useFeaturesStore: () => ({
+    ensureLoaded,
+    get folderSizeEnabled() {
+      return featuresState.folderSizeEnabled;
+    },
+  }),
+}));
+
+import { useFolderSizeStore } from '@/stores/folderSize';
+
+describe('folderSize store', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    featuresState.folderSizeEnabled = true;
+    ensureLoaded.mockClear();
+    getFolderSizesBatch.mockReset();
+    refreshFolderSize.mockReset();
+    getFolderSizesBatch.mockResolvedValue({ results: [] });
+  });
+
+  it('fetches tracked paths and stores results keyed by path', async () => {
+    getFolderSizesBatch.mockResolvedValue({
+      results: [{ path: 'A', sizeBytes: 100, entryCount: 2, canEnter: true, indexed: true }],
+    });
+
+    const store = useFolderSizeStore();
+    await store.refresh({ force: true, paths: ['A', 'A/B'] });
+
+    expect(getFolderSizesBatch).toHaveBeenCalledTimes(1);
+    expect(getFolderSizesBatch).toHaveBeenCalledWith(['A', 'A/B'], {
+      suppressErrorHandler: true,
+      retryNetworkErrors: true,
+    });
+    expect(store.sizeFor('A')).toMatchObject({ sizeBytes: 100, entryCount: 2 });
+  });
+
+  it('respects the refresh throttle for non-forced calls', async () => {
+    const store = useFolderSizeStore();
+    store.setPaths(['A']);
+
+    await store.refresh({ force: true }); // primes lastRefreshAt
+    await store.refresh({ force: false }); // within throttle window -> skipped
+
+    expect(getFolderSizesBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-fetch while a refresh is already in flight (same paths)', async () => {
+    let resolveFetch;
+    getFolderSizesBatch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const store = useFolderSizeStore();
+    store.setPaths(['A']);
+
+    const first = store.refresh({ force: true });
+    const second = store.refresh({ force: true });
+    resolveFetch({ results: [] });
+    await Promise.all([first, second]);
+
+    expect(getFolderSizesBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches the latest paths when they change mid-flight (navigation)', async () => {
+    const calls = [];
+    let resolveFirst;
+    getFolderSizesBatch.mockImplementation((paths) => {
+      calls.push(paths);
+      if (calls.length === 1) {
+        return new Promise((resolve) => {
+          resolveFirst = resolve;
+        });
+      }
+      return Promise.resolve({ results: [] });
+    });
+
+    const store = useFolderSizeStore();
+    const first = store.ensureSizes(['A']); // starts a batch for A (kept in flight)
+    await vi.waitFor(() => expect(getFolderSizesBatch).toHaveBeenCalledTimes(1));
+
+    const second = store.ensureSizes(['B']); // navigate to B while A is still loading
+    resolveFirst({ results: [] });
+    await Promise.all([first, second]);
+
+    // B must not be dropped: it is fetched once A settles.
+    expect(calls).toEqual([['A'], ['B']]);
+  });
+
+  it('clears sizes and skips fetching when the feature is disabled', async () => {
+    featuresState.folderSizeEnabled = false;
+
+    const store = useFolderSizeStore();
+    await store.refresh({ force: true, paths: ['A'] });
+
+    expect(getFolderSizesBatch).not.toHaveBeenCalled();
+    expect(store.sizeFor('A')).toBeNull();
+  });
+
+  it('does not schedule an inert refresh timer when the feature is disabled', () => {
+    featuresState.folderSizeEnabled = false;
+    const store = useFolderSizeStore();
+
+    store.scheduleRefresh();
+
+    expect(getFolderSizesBatch).not.toHaveBeenCalled();
+  });
+
+  it('queues an explicit subtree refresh without keeping the UI request open', async () => {
+    refreshFolderSize.mockResolvedValue({
+      path: 'A/External',
+      sizeBytes: 0,
+      entryCount: 4,
+      canEnter: true,
+      indexed: true,
+      refreshPending: true,
+    });
+
+    const store = useFolderSizeStore();
+    const entry = await store.refreshFolder('A/External');
+
+    expect(refreshFolderSize).toHaveBeenCalledWith('A/External');
+    expect(entry).toMatchObject({ sizeBytes: 0, indexed: true, refreshPending: true });
+    expect(store.sizeFor('A/External')).toMatchObject({ sizeBytes: 0, entryCount: 4 });
+  });
+
+  it('re-fetches a visible directory while its authoritative scan is pending', async () => {
+    vi.useFakeTimers();
+    getFolderSizesBatch
+      .mockResolvedValueOnce({
+        results: [{ path: 'A', sizeBytes: 0, entryCount: 2, indexed: true, dirty: true }],
+      })
+      .mockResolvedValueOnce({
+        results: [{ path: 'A', sizeBytes: 123, entryCount: 2, indexed: true, dirty: false }],
+      });
+
+    const store = useFolderSizeStore();
+    await store.refresh({ force: true, paths: ['A'] });
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(getFolderSizesBatch).toHaveBeenCalledTimes(2);
+    expect(store.sizeFor('A')).toMatchObject({ sizeBytes: 123, dirty: false });
+  });
+});

--- a/frontend/src/views/FolderView.vue
+++ b/frontend/src/views/FolderView.vue
@@ -5,6 +5,8 @@ import { normalizePath } from '@/api';
 import { useSettingsStore } from '@/stores/settings';
 import FileObject from '@/components/FileObject.vue';
 import { useFileStore } from '@/stores/fileStore';
+import { useFolderSizeStore } from '@/stores/folderSize';
+import { useFeaturesStore } from '@/stores/features';
 import LoadingIcon from '@/icons/LoadingIcon.vue';
 import { useSelection } from '@/composables/itemSelection';
 import { useExplorerContextMenu } from '@/composables/contextMenu';
@@ -26,6 +28,8 @@ import { useFileDragDrop } from '@/composables/useFileDragDrop';
 
 const settings = useSettingsStore();
 const fileStore = useFileStore();
+const folderSizeStore = useFolderSizeStore();
+const featuresStore = useFeaturesStore();
 const route = useRoute();
 const { gridClasses, gridStyle } = useViewConfig();
 const loading = ref(true);
@@ -243,6 +247,19 @@ const loadFiles = async () => {
     updateScrollState();
   }
 };
+
+// Ask for the size of every folder currently on screen, in one request. Runs
+// again whenever the listing changes, which is what makes a folder show its
+// size the moment it appears rather than at the next pass.
+const refreshFolderSizes = () => {
+  if (!featuresStore.folderSizeEnabled) return;
+  const dirPaths = fileStore.getCurrentPathItems
+    .filter((item) => item?.kind === 'directory')
+    .map((item) => (item.path ? `${item.path}/${item.name}` : item.name));
+  if (dirPaths.length) folderSizeStore.ensureSizes(dirPaths).catch(() => {});
+};
+
+watch(() => fileStore.getCurrentPathItems, refreshFolderSizes, { immediate: true });
 
 onMounted(loadFiles);
 


### PR DESCRIPTION
Batch 7 of #373. Cut from `main` at `83f6e33`.

**~2 800 lines of code, ~1 500 of tests. 53 tests, all passing.**

## Why

A folder's own `size` is the few bytes of its inode, so the list shows nothing useful beside a directory. Computing the real size on demand is not an option either: that is a full recursive walk per folder, per listing.

So it is computed once and kept.

## What it does

An index holds the recursive size and entry count per folder, aggregated upward. It is built by a walk that can be **interrupted and resumed**, paced against a share of one core, with an I/O timeout and a circuit breaker for a mount that stops answering — a network share that hangs should slow the index down, not take the server with it.

Sorting by size uses the indexed value for directories, so the order matches the numbers printed beside them. Without that they disagree, which is worse than showing nothing.

**Off unless asked for**: `FOLDER_SIZE_MODE=shallow` or `full`. Left off, nothing is walked, no table is read, and the size column shows exactly what it shows today.

## Two things to flag

**`p-limit` is a new dependency.** The indexer uses it to bound how many `readdir` and `stat` calls are in flight.

If you would rather not add one, I can rewrite the two call sites against `mapWithConcurrency`, which is already in the tree from [2/14]. I did **not** do it unilaterally: one of the two uses p-limit as a shared limiter rather than a bounded map, so swapping it changes how `readdir` and `stat` share the same budget — a pacing change in a component whose whole job is pacing. Your call.

**The hooks are deliberately left out.** In our tree there are hooks telling the index the moment a file is written, moved or deleted. They live in about a dozen call sites across routes that differ substantially between our trees, and the periodic pass converges without them — sizes are simply less immediate after a copy.

That felt like a separate change rather than something to smuggle in here. Happy to send it as its own batch once this one has landed.

## Schema

**v10**, since v9 went to the search index in [5/14]. The table is also created idempotently on every open: a `/config` shared by two builds can have its `schema_version` past the migration without the table existing, and the indexer would then fail with "no such table".

## Tests

53 pass — 45 backend, 8 frontend. The 15 pre-existing failures on `main` are unchanged and none is new.