### PR TITLE
[8/14] Keep a personal folder personal

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -13,6 +13,7 @@ const { configureHttpLogging } = require('./middleware/logging');
 const { configureCors } = require('./middleware/cors');
 const { configureOidc } = require('./middleware/oidc');
 const { configureHttpsWarning } = require('./middleware/httpsWarning');
+const { requestContextMiddleware } = require('./utils/requestContext');
 const authMiddleware = require('./middleware/authMiddleware');
 const registerRoutes = require('./routes');
 const { configureStaticFiles } = require('./utils/staticServer');
@@ -49,6 +50,7 @@ const createApp = async (options = {}) => {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
   app.use(cookieParser());
+  app.use(requestContextMiddleware);
   logger.debug('Mounted cookie parser middleware');
 
   if (!skipBootstrap) {

--- a/backend/src/routes/userVolumes.js
+++ b/backend/src/routes/userVolumes.js
@@ -3,6 +3,7 @@ const path = require('path');
 const fs = require('fs/promises');
 
 const asyncHandler = require('../utils/asyncHandler');
+const { ensureAdmin } = require('../middleware/ensureAdmin');
 const { ForbiddenError, NotFoundError, ValidationError } = require('../errors/AppError');
 const { getById } = require('../services/users');
 const { directories, excludedFiles, features, hiddenFiles } = require('../config/index');
@@ -15,17 +16,6 @@ const {
 } = require('../services/userVolumesService');
 
 const router = express.Router();
-
-/**
- * Ensure user is an admin
- */
-const ensureAdmin = (req, res, next) => {
-  const roles = Array.isArray(req.user?.roles) ? req.user.roles : [];
-  if (!roles.includes('admin')) {
-    throw new ForbiddenError('Admin access required.');
-  }
-  next();
-};
 
 /**
  * Ensure USER_VOLUMES feature is enabled

--- a/backend/src/services/db.js
+++ b/backend/src/services/db.js
@@ -12,6 +12,14 @@ let dbInstance = null;
 // the versioned migration (clean installs) and idempotently on every open — the
 // latter guarantees the table exists even when the recorded schema_version was
 // already advanced past this migration by a different build sharing /config.
+/** Adds a column only when the table does not already have it. */
+const addColumnIfMissing = (db, tableName, columnName, definition) => {
+  const columns = db.prepare(`PRAGMA table_info(${tableName})`).all();
+  if (!columns.some((column) => column.name === columnName)) {
+    db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${definition}`);
+  }
+};
+
 const FOLDER_SIZE_INDEX_DDL = `
   CREATE TABLE IF NOT EXISTS folder_size_index (
     path_hash         TEXT PRIMARY KEY,
@@ -392,6 +400,24 @@ const getVersion = db.prepare('SELECT value FROM meta WHERE key = ?').pluck();
         String(10)
       );
       version = 10;
+    }
+    if (version < 11) {
+      logger.info('[DB Migration] Migrating to v11: One personal folder per account...');
+      addColumnIfMissing(db, 'users', 'personal_folder_name', 'personal_folder_name TEXT');
+      // SQLite lets a unique index hold any number of NULLs, so an account that
+      // has not claimed a name yet does not collide with the others.
+      db.exec(
+        'CREATE UNIQUE INDEX IF NOT EXISTS idx_users_personal_folder ON users(personal_folder_name);'
+      );
+      // eslint-disable-next-line global-require
+      const { claimAllPersonalFolderNames } = require('./personalFolders');
+      const claimed = claimAllPersonalFolderNames(db);
+      logger.info({ claimed }, '[DB Migration] Personal folder names assigned');
+      db.prepare('INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)').run(
+        'schema_version',
+        String(11)
+      );
+      version = 11;
     }
   })();
 };

--- a/backend/src/services/personalFolders.js
+++ b/backend/src/services/personalFolders.js
@@ -1,0 +1,106 @@
+const { getUserFolderNameCandidates } = require('../utils/pathUtils');
+const logger = require('../utils/logger');
+
+/**
+ * One personal folder per account, and never someone else's.
+ *
+ * The folder an account gets is derived from `USER_FOLDER_NAME_ORDER`, and
+ * nothing about that order guarantees a distinct answer per account. `username`
+ * carries no uniqueness constraint — the original schema had one, the migrated
+ * table does not, and an OIDC provider supplies the value as it pleases — while
+ * `email_local` cannot be unique by construction: `bob@a.com` and `bob@b.com`
+ * both yield `bob`. Two accounts that derive the same name are handed the same
+ * directory, and each sees the other's private files.
+ *
+ * A default install is safe, since the default order puts `id` first and ids
+ * are unique. But the environment reference recommends `username,id` outright,
+ * to reuse an existing /home/<username> layout, and that is where the collision
+ * lives.
+ *
+ * So the name is claimed rather than derived on the fly: the first account to
+ * ask for `bob` keeps it, a second one walks down its own preference order to
+ * the next free name, and `id` is always last in that order so the walk always
+ * ends. The claim is stored on the account and a unique index enforces it, so
+ * two requests racing cannot both win.
+ *
+ * What this deliberately does not do is refuse the login, or refuse the
+ * configuration. Someone whose username collides still gets a folder — their
+ * own — and the layout the documentation recommends keeps working for everyone
+ * it works for today.
+ */
+
+/** Rows that already hold a name, so a candidate can be tested against them. */
+const takenNames = (db, userId) => {
+  const rows = db
+    .prepare(
+      'SELECT personal_folder_name AS name FROM users WHERE personal_folder_name IS NOT NULL AND id != ?'
+    )
+    .all(userId);
+  return new Set(rows.map((row) => row.name));
+};
+
+/**
+ * Give this account a folder name of its own, and answer it. Idempotent: an
+ * account that already holds one keeps it.
+ */
+const claimPersonalFolderName = (db, user) => {
+  if (!user?.id) return null;
+
+  const held = user.personal_folder_name || user.personalFolderName;
+  if (typeof held === 'string' && held.trim()) return held.trim();
+
+  const taken = takenNames(db, user.id);
+  const candidates = getUserFolderNameCandidates(user);
+
+  for (const candidate of candidates) {
+    if (taken.has(candidate)) continue;
+
+    try {
+      db.prepare('UPDATE users SET personal_folder_name = ? WHERE id = ?').run(candidate, user.id);
+
+      if (candidate !== candidates[0]) {
+        logger.warn(
+          { userId: user.id, preferred: candidates[0], assigned: candidate },
+          'Personal folder name was already taken by another account; assigned the next one'
+        );
+      }
+      return candidate;
+    } catch (error) {
+      // The unique index refusing is another account winning the same name
+      // between the read above and this write. Try the next candidate.
+      if (!/UNIQUE constraint failed/i.test(error?.message || '')) throw error;
+    }
+  }
+
+  // Unreachable while `id` is in the order — it is appended to every
+  // configuration, and an id is unique — but a name is not worth an exception
+  // on a login path.
+  logger.error({ userId: user.id }, 'No personal folder name could be claimed');
+  return null;
+};
+
+/**
+ * Give every account a name, oldest first.
+ *
+ * Order matters on an instance that already has a collision: the account that
+ * has been using the folder is the one that keeps it, rather than whoever
+ * happens to sign in first after the upgrade.
+ */
+const claimAllPersonalFolderNames = (db) => {
+  const rows = db
+    .prepare(
+      `SELECT id, email, username, display_name, personal_folder_name
+       FROM users
+       WHERE personal_folder_name IS NULL
+       ORDER BY created_at ASC, id ASC`
+    )
+    .all();
+
+  let claimed = 0;
+  for (const row of rows) {
+    if (claimPersonalFolderName(db, row)) claimed += 1;
+  }
+  return claimed;
+};
+
+module.exports = { claimPersonalFolderName, claimAllPersonalFolderNames };

--- a/backend/src/services/userVolumesService.js
+++ b/backend/src/services/userVolumesService.js
@@ -1,15 +1,10 @@
-const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs/promises');
 
 const { getDb } = require('./db');
+const { generateId, nowIso } = require('../utils/ids');
 
-const generateId = () =>
-  typeof crypto.randomUUID === 'function'
-    ? crypto.randomUUID()
-    : `${Date.now().toString(36)}-${crypto.randomBytes(8).toString('hex')}`;
 
-const nowIso = () => new Date().toISOString();
 
 const RESERVED_VOLUME_LABELS = new Set(['personal', 'share', 'volumes']);
 
@@ -64,17 +59,6 @@ const getVolumesForUser = async (userId) => {
 const getVolumeById = async (volumeId) => {
   const db = await getDb();
   const row = db.prepare('SELECT * FROM user_volumes WHERE id = ?').get(volumeId);
-  return toClientVolume(row);
-};
-
-/**
- * Get user volume by user ID and path
- */
-const getVolumeByUserAndPath = async (userId, volumePath) => {
-  const db = await getDb();
-  const row = db
-    .prepare('SELECT * FROM user_volumes WHERE user_id = ? AND path = ?')
-    .get(userId, volumePath);
   return toClientVolume(row);
 };
 
@@ -264,67 +248,11 @@ const removeVolumeFromUser = async (volumeId) => {
   return true;
 };
 
-/**
- * Remove all volumes for a user (called when user is deleted, though CASCADE handles this)
- */
-const removeAllVolumesForUser = async (userId) => {
-  const db = await getDb();
-  db.prepare('DELETE FROM user_volumes WHERE user_id = ?').run(userId);
-  return true;
-};
-
-/**
- * Check if a user has access to a specific volume path
- */
-const userHasVolumeAccess = async (userId, volumePath) => {
-  const volume = await getUserVolumeForPath(userId, volumePath);
-  return volume !== null;
-};
-
-/**
- * Get the base path for a volume (the path segment that matches the volume)
- * Used for resolving logical paths to actual filesystem paths
- */
-const resolveUserVolumePath = async (userId, logicalPath) => {
-  const db = await getDb();
-  const volumes = db.prepare('SELECT * FROM user_volumes WHERE user_id = ?').all(userId);
-
-  // Normalize the logical path
-  const normalizedPath = logicalPath.replace(/^\/+/, '').replace(/\/+$/, '');
-  const pathParts = normalizedPath.split('/').filter(Boolean);
-
-  if (pathParts.length === 0) {
-    return null;
-  }
-
-  const firstSegment = pathParts[0];
-
-  for (const vol of volumes) {
-    if (vol.label === firstSegment) {
-      // Found matching volume - construct the absolute path
-      const remainingPath = pathParts.slice(1).join('/');
-      const absolutePath = remainingPath ? path.join(vol.path, remainingPath) : vol.path;
-
-      return {
-        volume: toClientVolume(vol),
-        absolutePath,
-        relativePath: logicalPath,
-      };
-    }
-  }
-
-  return null;
-};
-
 module.exports = {
   getVolumesForUser,
   getVolumeById,
-  getVolumeByUserAndPath,
   getUserVolumeForPath,
   addVolumeToUser,
   updateUserVolume,
   removeVolumeFromUser,
-  removeAllVolumesForUser,
-  userHasVolumeAccess,
-  resolveUserVolumePath,
 };

--- a/backend/src/utils/pathUtils.js
+++ b/backend/src/utils/pathUtils.js
@@ -1,7 +1,9 @@
 const path = require('path');
 const fs = require('fs');
+const fsp = require('fs/promises');
 const { directories, features, personal } = require('../config/index');
 const { pathExists } = require('./fsUtils');
+const { cachedForRequest, hasRequestContext } = require('./requestContext');
 const logger = require('./logger');
 
 const NAME_INVALID_PATTERN = /[\\/]/;
@@ -26,12 +28,226 @@ const normalizeRelativePath = (relativePath = '') => {
   return normalized;
 };
 
-const resolveVolumePath = (relativePath = '') => {
+/**
+ * Real (symlink-free) form of the configured roots, resolved once.
+ *
+ * Containment is a string comparison, which a symbolic link inside the volume
+ * defeats. Comparing real paths closes that, but the roots themselves are
+ * very often symlinks on a NAS (/mnt -> /volume1), so both sides have to be
+ * resolved or every request would be refused.
+ */
+const realRootCache = new Map();
+
+/**
+ * The one lookup here that is still synchronous, and deliberately.
+ *
+ * There are a handful of roots and each is resolved once for the life of the
+ * process, so this is a few calls at startup rather than one per path — the
+ * cost the rest of this file was made asynchronous to remove. Making it
+ * asynchronous would turn a memo into a promise several callers could race on,
+ * for nothing.
+ */
+const realRoot = (root) => {
+  if (!realRootCache.has(root)) {
+    try {
+      realRootCache.set(root, fs.realpathSync(root));
+    } catch {
+      // The root may not exist yet at startup; fall back to the literal path.
+      realRootCache.set(root, root);
+    }
+  }
+  return realRootCache.get(root);
+};
+
+// A dangling link may point at another dangling link. Bound the chase the way
+// the kernel does rather than trusting the filesystem to be acyclic.
+const MAX_SYMLINK_HOPS = 32;
+
+/**
+ * Asynchronous on purpose, and it is not a style preference.
+ *
+ * These run on every path a request touches, and a bulk operation resolves one
+ * per selected item — up to thirty-two hops each when links are chased. On a
+ * local disk that is microseconds. On the network mount most deployments point
+ * at, every one of them is a round trip, and the synchronous version made the
+ * only thread the server has wait for it: nothing else was served, not another
+ * request, not the liveness probe, not the response already half written.
+ */
+const lstatOrNull = async (target) => {
+  try {
+    return await fsp.lstat(target);
+  } catch {
+    return null;
+  }
+};
+
+const readLinkOrNull = async (target) => {
+  try {
+    return await fsp.readlink(target);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * A bulk operation resolves one path per selected item, and those paths share
+ * their parent directories. Only successful lookups are memoized: a path that
+ * did not exist a moment ago may have just been created by this very request,
+ * and answering "still missing" from a cache would be wrong.
+ */
+const realpathOrNull = (target) =>
+  cachedForRequest('realpath', target, async () => {
+    try {
+      return await fsp.realpath(target);
+    } catch {
+      return null;
+    }
+  });
+
+/**
+ * Confirm a resolved path really lives under its root once symlinks are
+ * followed. Paths that do not exist yet (a file about to be created) are
+ * checked through their closest existing ancestor.
+ *
+ * A broken link is neither: realpath fails on it, but it is not "not created
+ * yet" either — checking its parent instead would let `link -> /etc` through
+ * on the grounds that the directory holding the link is fine. Such a link is
+ * followed by hand and its target checked as a path in its own right.
+ */
+const assertRealPathWithinRoot = async (
+  absolutePath,
+  root,
+  label = 'the configured volume root',
+  hops = 0
+) => {
+  const expectedRoot = realRoot(root);
+  const rootWithSep = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  const realWithSep = expectedRoot.endsWith(path.sep) ? expectedRoot : `${expectedRoot}${path.sep}`;
+  const outside = () => new Error(`Resolved path is outside ${label}.`);
+  const contained = (candidate) => candidate === expectedRoot || candidate.startsWith(realWithSep);
+  const namedInside = (candidate) =>
+    candidate === root ||
+    candidate.startsWith(rootWithSep) ||
+    candidate === expectedRoot ||
+    candidate.startsWith(realWithSep);
+
+  // The walk below accepts a path it could not resolve once it has climbed
+  // above the root — the root itself may not exist yet at startup, and there is
+  // nothing above it for this function to judge. That is only safe for a path
+  // already known to be inside the root by name, which every caller does check
+  // just before calling. Checking it here as well is what makes the guarantee
+  // this function's own rather than a convention the next caller has to know:
+  // the name says within the root, so nothing outside it gets in, whether or
+  // not any of it exists.
+  if (hops === 0 && !namedInside(absolutePath)) throw outside();
+
+  // Resolving the whole path per entry is the expensive part: realpath walks
+  // every segment, where a bulk operation shares all but the last. If the
+  // parent directory really is inside the root and this entry is not itself a
+  // link, then neither can it leave — one lstat instead of a full walk, and
+  // the parent's own resolution is memoized for the rest of the request.
+  // Only inside a request, where the parent's resolution is memoized and paid
+  // once for the whole batch. On its own it would just add a lookup.
+  if (hops === 0 && hasRequestContext()) {
+    const parent = path.dirname(absolutePath);
+    if (parent !== absolutePath && (parent === root || parent.startsWith(rootWithSep))) {
+      const realParent = await realpathOrNull(parent);
+      if (realParent && contained(realParent)) {
+        const entry = await lstatOrNull(absolutePath);
+        if (entry && !entry.isSymbolicLink()) return;
+      }
+    }
+  }
+
+  let candidate = absolutePath;
+
+  for (;;) {
+    // eslint-disable-next-line no-await-in-loop
+    const realCandidate = await realpathOrNull(candidate);
+
+    if (realCandidate) {
+      if (!contained(realCandidate)) throw outside();
+      return;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const link = await readLinkOrNull(candidate);
+    if (link !== null) {
+      if (hops >= MAX_SYMLINK_HOPS) {
+        throw new Error('Too many levels of symbolic links.');
+      }
+      const target = path.resolve(path.dirname(candidate), link);
+      // The target of a broken link may not exist anywhere, so there is no real
+      // path to compare. Judge it on the name: a target outside both spellings
+      // of the root is an escape whether or not it exists yet.
+      if (!namedInside(target)) throw outside();
+      await assertRealPathWithinRoot(target, root, label, hops + 1);
+      return;
+    }
+
+    const parent = path.dirname(candidate);
+    // Nothing above the root is ours to judge: the root itself may not exist
+    // yet at startup, and the lexical check ran before we got here.
+    if (parent === candidate || (parent !== root && !parent.startsWith(rootWithSep))) return;
+    candidate = parent;
+  }
+};
+
+/**
+ * Whether this path is somebody's personal folder, reached the wrong way.
+ *
+ * Personal folders default to `<volume>/_users`, which puts every account's
+ * private files inside the tree everyone browses. The name was kept out of
+ * listings and nothing else: asking for `_users/alice` by name answered it, and
+ * the volume's access rules had no reason to refuse — whose folder it was never
+ * came up. An ordinary account could read another's files, and delete them.
+ *
+ * The personal space is how an account reaches its own folder, and it derives
+ * the directory from who is asking rather than from what was asked for. Reached
+ * through the volume there is no such derivation and no question of ownership
+ * is ever put, so the volume does not go there at all.
+ *
+ * Compared by name, against both the configured root and its real path, so a
+ * root that is itself reached through a link still matches. Both are resolved
+ * once for the life of the process, so this costs nothing per request.
+ *
+ * What it does not cover is a symbolic link planted inside the volume and
+ * aimed at the user root. Resolving every path to catch that added a round trip
+ * per item, which a bulk operation multiplies by every file in it — and the
+ * application offers no way to create such a link: extraction passes `-snl-`
+ * and then refuses an archive that produced one anyway (see archiveService).
+ * Planting one needs shell access to the host, which already grants the files
+ * this is protecting. If a way to create a link is ever added, this is the
+ * comment that has to change with it.
+ *
+ * A user root that *is* the volume is left alone: refusing there would lose the
+ * volume entirely, which is a worse answer than the question.
+ */
+const isInsidePersonalRoot = (absolutePath) => {
+  const userRoot = directories.userRoot;
+  if (!userRoot) return false;
+
+  for (const root of new Set([userRoot, realRoot(userRoot)])) {
+    if (root === directories.volume || root === realRoot(directories.volume)) continue;
+    const withSep = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+    if (absolutePath === root || absolutePath.startsWith(withSep)) return true;
+  }
+
+  return false;
+};
+
+const resolveVolumePath = async (relativePath = '') => {
   const safeRelativePath = normalizeRelativePath(relativePath);
   const absolutePath = path.resolve(directories.volume, safeRelativePath);
 
   if (absolutePath !== directories.volume && !absolutePath.startsWith(directories.volumeWithSep)) {
     throw new Error('Resolved path is outside the configured volume root.');
+  }
+
+  await assertRealPathWithinRoot(absolutePath, directories.volume);
+
+  if (isInsidePersonalRoot(absolutePath)) {
+    throw new Error('Personal folders are reached through the personal space, not the volume.');
   }
 
   return absolutePath;
@@ -142,7 +358,14 @@ const parsePathSpace = (relativePath = '') => {
   return { space: 'volume', rel: normalized };
 };
 
-const getUserFolderName = (user = {}) => {
+/**
+ * The folder names this account could be given, best first.
+ *
+ * `USER_FOLDER_NAME_ORDER` decides the preference — `username,id` to reuse an
+ * existing /home/<username> layout, for instance — and `id` is always in the
+ * list, so the walk always ends somewhere unique.
+ */
+const getUserFolderNameCandidates = (user = {}) => {
   const candidates = [];
 
   const configuredOrder = Array.isArray(personal?.userFolderNameOrder)
@@ -177,19 +400,56 @@ const getUserFolderName = (user = {}) => {
 
   candidates.push('user');
 
+  const valid = [];
   for (const candidate of candidates) {
     try {
       const safe = ensureValidName(String(candidate));
-      if (safe) return safe;
+      if (safe && !valid.includes(safe)) valid.push(safe);
     } catch (_) {
       // try next candidate
     }
   }
 
-  return 'user';
+  return valid.length > 0 ? valid : ['user'];
 };
 
-const getUserRootDir = (user) => {
+/**
+ * The folder this account owns.
+ *
+ * The name it was given when the account was first seen, if it has one. Two
+ * accounts can otherwise derive the same name — `username` carries no
+ * uniqueness constraint, and `bob@a.com` and `bob@b.com` both yield `bob` —
+ * and each would then be handed the other's private folder. The name is
+ * claimed once and stored (see services/personalFolders.js), so what is
+ * derived here is only the fallback for an account that has not been through
+ * that yet.
+ */
+const getUserFolderName = (user = {}) => {
+  const claimed = user?.personalFolderName || user?.personal_folder_name;
+  if (typeof claimed === 'string' && claimed.trim()) {
+    try {
+      const safe = ensureValidName(claimed.trim());
+      if (safe) return safe;
+    } catch (_) {
+      // A stored name that is no longer valid falls back to derivation.
+    }
+  }
+
+  return getUserFolderNameCandidates(user)[0];
+};
+
+/**
+ * The directory this account owns, created if it is not there yet.
+ *
+ * Asynchronous, and the creation happens after the check rather than before it.
+ * Both used to be the other way round: two `mkdirSync` calls ran on every
+ * personal path — blocking the event loop on a hot path — and they ran before
+ * anything had confirmed the directory belonged under the configured root, so a
+ * name that was about to be refused was created on disk first. The comment
+ * justifying the synchronous calls said they kept the resolver synchronous; the
+ * resolver had since become asynchronous, and the justification outlived it.
+ */
+const getUserRootDir = async (user) => {
   if (!PERSONAL_ENABLED) {
     throw new Error('Personal directories are disabled.');
   }
@@ -201,35 +461,28 @@ const getUserRootDir = (user) => {
   const folderName = getUserFolderName(user);
   const userRoot = path.resolve(base, folderName);
 
-  // Ensure base and user directory exist (sync to keep resolver synchronous)
-  try {
-    fs.mkdirSync(base, { recursive: true });
-  } catch (_) {
-    // ignore mkdir errors here; later operations will surface issues
-  }
-
-  try {
-    fs.mkdirSync(userRoot, { recursive: true });
-  } catch (_) {
-    // ignore mkdir errors here; later operations will surface issues
-  }
-
-  // Safety: ensure userRoot stays under configured userRootWithSep
   if (userRoot !== base && !userRoot.startsWith(directories.userRootWithSep)) {
     throw new Error('Resolved user directory is outside the configured user root.');
   }
 
+  // Failures are left to the operation that follows: it is the one that knows
+  // whether the directory was needed, and it reports in terms of what was asked
+  // for rather than in terms of a directory nobody mentioned.
+  await fsp.mkdir(userRoot, { recursive: true }).catch(() => {});
+
   return userRoot;
 };
 
-const resolvePersonalPath = (relativePath = '', user) => {
+const resolvePersonalPath = async (relativePath = '', user) => {
   const safeRelativePath = normalizeRelativePath(relativePath);
-  const userRoot = getUserRootDir(user);
+  const userRoot = await getUserRootDir(user);
   const absolutePath = path.resolve(userRoot, safeRelativePath);
 
   if (absolutePath !== userRoot && !absolutePath.startsWith(userRoot + path.sep)) {
     throw new Error('Resolved path is outside the configured user directory.');
   }
+
+  await assertRealPathWithinRoot(absolutePath, userRoot, 'the configured user directory');
 
   return absolutePath;
 };
@@ -263,7 +516,13 @@ const resolveLogicalPath = async (
       throw new Error('User context is required for personal paths.');
     }
 
-    const absolutePath = resolvePersonalPath(rel, user);
+    // Awaited, which is the whole point of it: `resolvePersonalPath` checks that
+    // the path is still inside the user's directory after every symbolic link
+    // has been followed, and that check lives in the promise. Left unawaited it
+    // handed back a promise as if it were a path — every personal path became a
+    // 404, and a path that should have been refused was refused by nobody: the
+    // rejection had no listener, which is how a request ends a Node process.
+    const absolutePath = await resolvePersonalPath(rel, user);
     const logical = rel ? `personal/${rel}` : 'personal';
 
     return {
@@ -299,6 +558,8 @@ const resolveLogicalPath = async (
       throw new Error('Resolved path is outside the assigned volume.');
     }
 
+    await assertRealPathWithinRoot(absolutePath, userVolume.path, 'the assigned volume');
+
     return {
       space: 'volume',
       relativePath: rel,
@@ -308,7 +569,7 @@ const resolveLogicalPath = async (
     };
   }
 
-  const absolutePath = resolveVolumePath(rel);
+  const absolutePath = await resolveVolumePath(rel);
 
   return {
     space: 'volume',
@@ -389,7 +650,7 @@ const resolveSharePath = async (
     const combinedPath =
       isDirShare && innerPath ? combineRelativePath(share.sourcePath, innerPath) : share.sourcePath;
 
-    absolutePath = resolvePersonalPath(combinedPath, owner);
+    absolutePath = await resolvePersonalPath(combinedPath, owner);
   } else if (share.sourceSpace === 'user_volume') {
     const [volumeId, ...rest] = String(share.sourcePath || '')
       .split('/')
@@ -420,11 +681,13 @@ const resolveSharePath = async (
     if (absolutePath !== userVolume.path && !absolutePath.startsWith(volumePathWithSep)) {
       throw new Error('Resolved path is outside the assigned volume.');
     }
+
+    await assertRealPathWithinRoot(absolutePath, userVolume.path, 'the assigned volume');
   } else {
     const combinedPath =
       isDirShare && innerPath ? combineRelativePath(share.sourcePath, innerPath) : share.sourcePath;
 
-    absolutePath = resolveVolumePath(combinedPath);
+    absolutePath = await resolveVolumePath(combinedPath);
   }
 
   return {
@@ -449,11 +712,13 @@ const resolveItemPaths = async (item = {}, options = {}) => {
 };
 
 module.exports = {
+  // Exported so the guarantee in its name can be tested directly, and so a
+  // caller outside this file gets the same one.
+  assertRealPathWithinRoot,
   normalizeRelativePath,
   resolveVolumePath,
   resolvePersonalPath,
   resolveLogicalPath,
-  resolveSharePath,
   combineRelativePath,
   splitName,
   findAvailableName,
@@ -461,6 +726,6 @@ module.exports = {
   ensureValidName,
   parsePathSpace,
   getUserFolderName,
-  getUserRootDir,
+  getUserFolderNameCandidates,
   resolveItemPaths,
 };

--- a/backend/src/utils/requestContext.js
+++ b/backend/src/utils/requestContext.js
@@ -1,0 +1,51 @@
+const { AsyncLocalStorage } = require('node:async_hooks');
+
+/**
+ * Per-request scratch space, used for caches that must not outlive a request.
+ *
+ * Path containment resolves real paths, and a bulk copy resolves one per
+ * selected item: on local storage that is ~18 µs each, but on network storage
+ * it is a round-trip, so a few thousand selected files turn into seconds spent
+ * asking the same questions.
+ *
+ * The lifetime is deliberately one request. A longer-lived cache would answer
+ * from a filesystem that has since changed — and this cache feeds a security
+ * check, so a stale answer there is not a stale answer anywhere.
+ */
+const storage = new AsyncLocalStorage();
+
+const runInRequestContext = (fn) => storage.run(new Map(), fn);
+
+/**
+ * Memoize `compute(key)` for the rest of the current request. Outside a
+ * request (scripts, background jobs) it simply computes every time.
+ */
+const cachedForRequest = (namespace, key, compute) => {
+  const store = storage.getStore();
+  if (!store) return compute();
+
+  let namespaceCache = store.get(namespace);
+  if (!namespaceCache) {
+    namespaceCache = new Map();
+    store.set(namespace, namespaceCache);
+  }
+
+  if (namespaceCache.has(key)) return namespaceCache.get(key);
+  const value = compute();
+  namespaceCache.set(key, value);
+  return value;
+};
+
+/** Whether a per-request cache is available to memoize into. */
+const hasRequestContext = () => storage.getStore() !== undefined;
+
+const requestContextMiddleware = (_req, _res, next) => {
+  runInRequestContext(() => next());
+};
+
+module.exports = {
+  runInRequestContext,
+  cachedForRequest,
+  hasRequestContext,
+  requestContextMiddleware,
+};

--- a/backend/tests/routes/personal-folder-isolation.test.js
+++ b/backend/tests/routes/personal-folder-isolation.test.js
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import request from 'supertest';
+import { createTestApp, setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * One account's personal folder, from another account.
+ *
+ * Personal folders default to `<volume>/_users`, which puts every account's
+ * private files inside the tree everybody browses. The directory name was kept
+ * out of listings, and that was the whole of it: asking for `_users/alice` by
+ * name answered, and the volume's access rules had no reason to refuse — the
+ * question of whose folder it was never came up.
+ *
+ * Measured before the fix, with an ordinary account holding no admin role: it
+ * listed the other account's folder, read a file in it, and deleted that file,
+ * answered 200 each time.
+ *
+ * The personal space itself was never the way in. It derives the directory from
+ * who is asking rather than from what was asked for, so there is nothing to
+ * aim. The volume was the way in, and the volume does not go there any more.
+ */
+
+let currentEnv;
+
+const setup = async ({ userRootEnv = {} } = {}) => {
+  const env = await setupTestEnv({
+    tag: 'personal-isolation-',
+    env: { USER_DIR_ENABLED: 'true', ...userRootEnv },
+    modules: [
+      'src/config/env',
+      'src/config/index',
+      'src/routes/browse',
+      'src/routes/files/index',
+      'src/middleware/errorHandler',
+      'src/services/accessManager',
+      'src/services/settingsService',
+      'src/utils/pathUtils',
+    ],
+  });
+  currentEnv = env;
+
+  const browseRoutes = env.requireFresh('src/routes/browse');
+  const fileRoutes = env.requireFresh('src/routes/files/index');
+  const { errorHandler } = env.requireFresh('src/middleware/errorHandler');
+  const { resolvePersonalPath } = env.requireFresh('src/utils/pathUtils');
+  const { getDb } = env.requireFresh('src/services/db');
+
+  const db = await getDb();
+  const now = new Date().toISOString();
+  for (const id of ['alice', 'bob']) {
+    db.prepare(
+      `INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(id, `${id}@example.com`, 1, id, id, '["user"]', now, now);
+  }
+
+  const aliceRoot = await resolvePersonalPath('', { id: 'alice', username: 'alice' });
+  await fs.mkdir(aliceRoot, { recursive: true });
+  await fs.writeFile(path.join(aliceRoot, 'salary.txt'), 'alice private');
+
+  const bob = { id: 'bob', username: 'bob', roles: ['user'] };
+  const asBob = (router) =>
+    createTestApp({ router, mountPath: '/api', user: bob, errorHandler });
+
+  return {
+    env,
+    aliceRoot,
+    aliceFolder: path.basename(aliceRoot),
+    browseApp: asBob(browseRoutes),
+    filesApp: asBob(fileRoutes),
+  };
+};
+
+afterEach(async () => {
+  if (currentEnv) {
+    await currentEnv.cleanup();
+    currentEnv = null;
+  }
+});
+
+describe("another account's personal folder, through the volume", () => {
+  it('cannot be listed', async () => {
+    const { browseApp } = await setup();
+
+    const response = await request(browseApp).get('/api/browse/_users');
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('cannot be opened by name', async () => {
+    const { browseApp, aliceFolder } = await setup();
+
+    const response = await request(browseApp).get(`/api/browse/_users/${aliceFolder}`);
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('does not leak a filename in the refusal', async () => {
+    const { browseApp, aliceFolder } = await setup();
+
+    const response = await request(browseApp).get(`/api/browse/_users/${aliceFolder}`);
+
+    expect(JSON.stringify(response.body)).not.toContain('salary.txt');
+  });
+
+  /** The one that had a 200 and a deleted file behind it. */
+  it('cannot have its files deleted', async () => {
+    const { filesApp, aliceRoot, aliceFolder } = await setup();
+
+    const response = await request(filesApp)
+      .delete('/api/files')
+      .send({ items: [{ path: `_users/${aliceFolder}`, name: 'salary.txt' }] });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    await expect(fs.access(path.join(aliceRoot, 'salary.txt'))).resolves.toBeUndefined();
+  });
+
+  it('is still absent from the volume listing', async () => {
+    const { browseApp } = await setup();
+
+    const response = await request(browseApp).get('/api/browse/');
+
+    expect((response.body.items || []).map((item) => item.name)).not.toContain('_users');
+  });
+});
+
+describe('an account reaching its own folder', () => {
+  /** The refusal above must not have closed the door it exists to keep open. */
+  it('still works through the personal space', async () => {
+    const { browseApp } = await setup();
+
+    const response = await request(browseApp).get('/api/browse/personal');
+
+    expect(response.status).toBe(200);
+  });
+
+  it('sees its own files and not the other one\u2019s', async () => {
+    const { browseApp } = await setup();
+    const { resolvePersonalPath } = currentEnv.requireFresh('src/utils/pathUtils');
+    const bobRoot = await resolvePersonalPath('', { id: 'bob', username: 'bob' });
+    await fs.mkdir(bobRoot, { recursive: true });
+    await fs.writeFile(path.join(bobRoot, 'mine.txt'), 'bob');
+
+    const response = await request(browseApp).get('/api/browse/personal');
+    const names = (response.body.items || []).map((item) => item.name);
+
+    expect(names).toContain('mine.txt');
+    expect(names).not.toContain('salary.txt');
+  });
+});
+
+describe('a volume that does not hold the personal folders', () => {
+  /**
+   * With the user root somewhere else, the volume has nothing to refuse and the
+   * check costs nothing. What matters is that ordinary browsing is untouched.
+   */
+  it('browses normally', async () => {
+    const env = await setupTestEnv({
+      tag: 'personal-isolation-elsewhere-',
+      env: { USER_DIR_ENABLED: 'true' },
+      modules: [
+        'src/config/env',
+        'src/config/index',
+        'src/routes/browse',
+        'src/middleware/errorHandler',
+        'src/services/accessManager',
+        'src/services/settingsService',
+        'src/utils/pathUtils',
+      ],
+    });
+    currentEnv = env;
+    await fs.mkdir(path.join(env.volumeDir, 'Shared'), { recursive: true });
+    await fs.writeFile(path.join(env.volumeDir, 'Shared', 'notes.txt'), 'everyone');
+
+    const browseRoutes = env.requireFresh('src/routes/browse');
+    const { errorHandler } = env.requireFresh('src/middleware/errorHandler');
+    const db = await (env.requireFresh('src/services/db').getDb());
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run('bob', 'bob@example.com', 1, 'bob', 'bob', '["user"]', now, now);
+
+    const app = createTestApp({
+      router: browseRoutes,
+      mountPath: '/api',
+      user: { id: 'bob', username: 'bob', roles: ['user'] },
+      errorHandler,
+    });
+
+    const response = await request(app).get('/api/browse/Shared');
+
+    expect(response.status).toBe(200);
+    expect((response.body.items || []).map((item) => item.name)).toContain('notes.txt');
+  });
+});

--- a/backend/tests/services/personal-folder-names.test.js
+++ b/backend/tests/services/personal-folder-names.test.js
@@ -1,0 +1,370 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * Two accounts could be handed the same personal folder, and each would see
+ * the other's private files.
+ *
+ * `USER_FOLDER_NAME_ORDER` decides which field names the folder, and nothing
+ * about that order guarantees a distinct answer: `username` carries no
+ * uniqueness constraint, and `bob@a.com` and `bob@b.com` both yield `bob`
+ * under `email_local`. A default install is safe — `id` comes first and ids
+ * are unique — but the environment reference recommends `username,id` to reuse
+ * an existing /home/<username> layout, which is exactly where it bites.
+ */
+
+let envContext;
+
+const build = async (env = {}) => {
+  envContext = await setupTestEnv({ tag: 'personal-folders-', env });
+  const dbService = envContext.requireFresh('src/services/db');
+  const db = await dbService.getDb();
+  const { claimPersonalFolderName } = envContext.requireFresh('src/services/personalFolders');
+  const { getUserFolderName } = envContext.requireFresh('src/utils/pathUtils');
+  return { db, claimPersonalFolderName, getUserFolderName };
+};
+
+/** An account, created at a given moment so the order between them is fixed. */
+const addUser = (db, { id, email, username, createdAt }) => {
+  db.prepare(
+    `INSERT INTO users (id, email, email_verified, username, display_name, roles, created_at, updated_at)
+     VALUES (?, ?, 1, ?, ?, '["user"]', ?, ?)`
+  ).run(id, email, username, username, createdAt, createdAt);
+  return db.prepare('SELECT * FROM users WHERE id = ?').get(id);
+};
+
+const nameOf = (db, id) =>
+  db.prepare('SELECT personal_folder_name AS name FROM users WHERE id = ?').get(id).name;
+
+afterEach(async () => {
+  if (envContext) await envContext.cleanup();
+  envContext = null;
+});
+
+describe('the folder an account owns', () => {
+  it('gives the preferred name to whoever asks first', async () => {
+    const { db, claimPersonalFolderName } = await build({ USER_FOLDER_NAME_ORDER: 'username,id' });
+    const first = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(claimPersonalFolderName(db, first)).toBe('bob');
+    expect(nameOf(db, 'u-1')).toBe('bob');
+  });
+
+  // The collision the review found, and what it costs: without this the second
+  // account resolves to the first account's directory.
+  it('does not give the same name twice', async () => {
+    const { db, claimPersonalFolderName } = await build({ USER_FOLDER_NAME_ORDER: 'username,id' });
+    const first = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const second = addUser(db, {
+      id: 'u-2',
+      email: 'bob@b.com',
+      username: 'bob',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    });
+
+    claimPersonalFolderName(db, first);
+    const assigned = claimPersonalFolderName(db, second);
+
+    expect(assigned).not.toBe('bob');
+    expect(assigned).toBe('u-2');
+    expect(nameOf(db, 'u-1')).toBe('bob');
+  });
+
+  // `email_local` cannot be made unique — two domains, one local part — so a
+  // constraint on `username` alone would not have covered this.
+  it('separates two accounts whose email local parts match', async () => {
+    const { db, claimPersonalFolderName } = await build({
+      USER_FOLDER_NAME_ORDER: 'email_local,id',
+    });
+    const first = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob-a',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const second = addUser(db, {
+      id: 'u-2',
+      email: 'bob@b.com',
+      username: 'bob-b',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    });
+
+    expect(claimPersonalFolderName(db, first)).toBe('bob');
+    expect(claimPersonalFolderName(db, second)).not.toBe('bob');
+  });
+
+  it('keeps the name an account already holds', async () => {
+    const { db, claimPersonalFolderName } = await build({ USER_FOLDER_NAME_ORDER: 'username,id' });
+    const user = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    claimPersonalFolderName(db, user);
+    const again = claimPersonalFolderName(
+      db,
+      db.prepare('SELECT * FROM users WHERE id = ?').get('u-1')
+    );
+
+    expect(again).toBe('bob');
+  });
+
+  // A renamed account does not move house: the folder it has been using is
+  // the one it keeps.
+  it('does not follow a username change', async () => {
+    const { db, claimPersonalFolderName, getUserFolderName } = await build({
+      USER_FOLDER_NAME_ORDER: 'username,id',
+    });
+    const user = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    claimPersonalFolderName(db, user);
+
+    db.prepare('UPDATE users SET username = ? WHERE id = ?').run('robert', 'u-1');
+    const renamed = db.prepare('SELECT * FROM users WHERE id = ?').get('u-1');
+
+    expect(
+      getUserFolderName({ ...renamed, personalFolderName: renamed.personal_folder_name })
+    ).toBe('bob');
+  });
+
+  it('leaves a default install exactly as it was', async () => {
+    const { db, claimPersonalFolderName } = await build();
+    const user = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    // The shipped order puts `id` first, and ids are unique.
+    expect(claimPersonalFolderName(db, user)).toBe('u-1');
+  });
+});
+
+// The check before the write is an optimisation; this is the guarantee. Two
+// requests racing past that check land here, and the loser walks on to its next
+// candidate rather than sharing a folder.
+describe('the constraint underneath', () => {
+  it('refuses two accounts the same folder name outright', async () => {
+    const { db } = await build({ USER_FOLDER_NAME_ORDER: 'username,id' });
+    addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    addUser(db, {
+      id: 'u-2',
+      email: 'bob@b.com',
+      username: 'bob',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    });
+
+    db.prepare('UPDATE users SET personal_folder_name = ? WHERE id = ?').run('bob', 'u-1');
+
+    expect(() =>
+      db.prepare('UPDATE users SET personal_folder_name = ? WHERE id = ?').run('bob', 'u-2')
+    ).toThrow(/UNIQUE/i);
+  });
+
+  // Unclaimed accounts must not collide with each other, or the index would
+  // stop the second one from being created at all.
+  it('lets any number of accounts hold no name yet', async () => {
+    const { db } = await build();
+    addUser(db, {
+      id: 'u-1',
+      email: 'a@example.com',
+      username: 'a',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    addUser(db, {
+      id: 'u-2',
+      email: 'b@example.com',
+      username: 'b',
+      createdAt: '2026-01-02T00:00:00.000Z',
+    });
+
+    db.prepare('UPDATE users SET personal_folder_name = NULL').run();
+    expect(
+      db.prepare('SELECT COUNT(*) AS n FROM users WHERE personal_folder_name IS NULL').get().n
+    ).toBe(2);
+  });
+});
+
+describe('accounts that existed before the names did', () => {
+  // Which of two colliding accounts keeps the folder cannot be left to whoever
+  // signs in first after an upgrade: the one that has been using it wins.
+  it('gives the name to the older account', async () => {
+    envContext = await setupTestEnv({
+      tag: 'personal-folders-backfill-',
+      env: { USER_FOLDER_NAME_ORDER: 'username,id' },
+    });
+    const dbService = envContext.requireFresh('src/services/db');
+    const db = await dbService.getDb();
+    const { claimAllPersonalFolderNames } = envContext.requireFresh('src/services/personalFolders');
+
+    addUser(db, {
+      id: 'u-new',
+      email: 'bob@b.com',
+      username: 'bob',
+      createdAt: '2026-06-01T00:00:00.000Z',
+    });
+    addUser(db, {
+      id: 'u-old',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
+    db.prepare('UPDATE users SET personal_folder_name = NULL').run();
+
+    expect(claimAllPersonalFolderNames(db)).toBe(2);
+    expect(nameOf(db, 'u-old')).toBe('bob');
+    expect(nameOf(db, 'u-new')).toBe('u-new');
+  });
+});
+
+/**
+ * The two paths that only open when something goes wrong between the read and
+ * the write.
+ *
+ * `claimPersonalFolderName` reads the names already taken, then writes the
+ * first free one. Two accounts signing in at the same moment both read the same
+ * answer, and the unique index is what stops them both keeping it — the loser
+ * gets an exception and has to walk on to its next candidate. Neither that
+ * recovery nor the give-up after it had ever run.
+ *
+ * The database is handed in, so a test can be the thing that goes wrong: a
+ * wrapper that refuses the writes it is told to refuse and passes everything
+ * else through untouched.
+ */
+describe('two accounts racing for the same name', () => {
+  /** A database that refuses the first `n` name writes the way the index does. */
+  const refusingWrites = (db, refusals) => ({
+    prepare: (sql) => {
+      const statement = db.prepare(sql);
+      if (!/UPDATE users SET personal_folder_name/i.test(sql)) return statement;
+      return {
+        ...statement,
+        run: (...args) => {
+          if (refusals.count > 0) {
+            refusals.count -= 1;
+            throw new Error('UNIQUE constraint failed: users.personal_folder_name');
+          }
+          return statement.run(...args);
+        },
+        all: (...args) => statement.all(...args),
+        get: (...args) => statement.get(...args),
+      };
+    },
+  });
+
+  it('walks on to the next name when the index refuses the first', async () => {
+    const { db, claimPersonalFolderName } = await build({
+      USER_FOLDER_NAME_ORDER: 'username,id',
+    });
+    const user = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    user.personal_folder_name = null;
+
+    const claimed = claimPersonalFolderName(refusingWrites(db, { count: 1 }), user);
+
+    expect(claimed).toBe('u-1');
+  });
+
+  it('records the name it settled on', async () => {
+    const { db, claimPersonalFolderName } = await build({
+      USER_FOLDER_NAME_ORDER: 'username,id',
+    });
+    const user = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    user.personal_folder_name = null;
+
+    claimPersonalFolderName(refusingWrites(db, { count: 1 }), user);
+
+    expect(nameOf(db, 'u-1')).toBe('u-1');
+  });
+
+  /**
+   * An error that is not the index refusing is not a race, and swallowing it
+   * would turn a broken database into a silent wrong answer.
+   */
+  it('does not mistake another failure for a lost race', async () => {
+    const { db, claimPersonalFolderName } = await build();
+    const user = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    user.personal_folder_name = null;
+    const broken = {
+      prepare: (sql) => {
+        const statement = db.prepare(sql);
+        if (!/UPDATE users SET personal_folder_name/i.test(sql)) return statement;
+        return {
+          ...statement,
+          run: () => {
+            throw new Error('database is locked');
+          },
+          all: (...args) => statement.all(...args),
+          get: (...args) => statement.get(...args),
+        };
+      },
+    };
+
+    expect(() => claimPersonalFolderName(broken, user)).toThrow(/database is locked/i);
+  });
+
+  /**
+   * Unreachable while `id` is in the order, which it always is. Losing every
+   * race is still not worth an exception on a sign-in path: the account gets no
+   * name, and the caller derives one as it did before any of this existed.
+   */
+  it('gives up quietly when every candidate is refused', async () => {
+    const { db, claimPersonalFolderName } = await build();
+    const user = addUser(db, {
+      id: 'u-1',
+      email: 'bob@a.com',
+      username: 'bob',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    user.personal_folder_name = null;
+
+    const claimed = claimPersonalFolderName(refusingWrites(db, { count: 99 }), user);
+
+    expect(claimed).toBeNull();
+  });
+});
+
+describe('an account with nothing to identify it', () => {
+  it('is given no name at all', async () => {
+    const { db, claimPersonalFolderName } = await build();
+
+    expect(claimPersonalFolderName(db, {})).toBeNull();
+    expect(claimPersonalFolderName(db, null)).toBeNull();
+  });
+});

--- a/backend/tests/utils/path-containment.test.js
+++ b/backend/tests/utils/path-containment.test.js
@@ -1,0 +1,395 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { setupTestEnv } from '../helpers/env-test-utils.js';
+
+/**
+ * Path containment used to be a pure string comparison, so a symbolic link
+ * planted inside the volume (an archive can carry one) pointed anywhere while
+ * still looking contained. These pin both halves: links inside are refused,
+ * and a volume root that is itself a link still works — which is the normal
+ * setup on a NAS and what a naive realpath check would break.
+ */
+
+let currentEnv;
+
+afterEach(async () => {
+  if (currentEnv) {
+    await currentEnv.cleanup();
+    currentEnv = null;
+  }
+});
+
+describe('Volume path containment', () => {
+  it('refuses a path that escapes through a symbolic link', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-symlink-',
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    const outside = path.join(env.tmpRoot, 'outside');
+    await fs.mkdir(outside, { recursive: true });
+    await fs.writeFile(path.join(outside, 'secret.txt'), 'not yours');
+    await fs.symlink(outside, path.join(env.volumeDir, 'escape'));
+
+    const { resolveVolumePath } = env.requireFresh('src/utils/pathUtils');
+
+    // The lexical check passes (the string starts with the volume root), so
+    // only the real-path check can catch this.
+    await expect(resolveVolumePath('escape/secret.txt')).rejects.toThrow(/outside the configured volume/i);
+    await expect(resolveVolumePath('escape')).rejects.toThrow(/outside the configured volume/i);
+  });
+
+  it('still resolves normal paths, including ones not created yet', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-normal-',
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    await fs.mkdir(path.join(env.volumeDir, 'docs'), { recursive: true });
+    const { resolveVolumePath } = env.requireFresh('src/utils/pathUtils');
+
+    expect(await resolveVolumePath('docs')).toContain('docs');
+    // A file about to be created must resolve through its existing parent.
+    expect(await resolveVolumePath('docs/new-file.txt')).toContain('new-file.txt');
+    expect(await resolveVolumePath('brand/new/tree.txt')).toContain('tree.txt');
+  });
+
+  it('accepts a volume root that is itself a symbolic link', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-linked-root-',
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    // Mimic /mnt -> /volume1: point VOLUME_ROOT at a link to the real dir.
+    const realStorage = path.join(env.tmpRoot, 'real-storage');
+    await fs.mkdir(path.join(realStorage, 'media'), { recursive: true });
+    const linkedRoot = path.join(env.tmpRoot, 'linked-root');
+    await fs.symlink(realStorage, linkedRoot);
+
+    process.env.VOLUME_ROOT = linkedRoot;
+    try {
+      const { resolveVolumePath } = env.requireFresh('src/utils/pathUtils');
+      await expect(resolveVolumePath('media')).resolves.not.toThrow();
+    } finally {
+      process.env.VOLUME_ROOT = env.volumeDir;
+    }
+  });
+
+  it('refuses a broken symbolic link pointing outside', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-dangling-',
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    // The target does not exist, so realpath fails on the link itself. Treating
+    // that as "not created yet" and checking the parent instead would accept it
+    // — and the next write would land in /etc.
+    await fs.symlink(path.join(env.tmpRoot, 'nowhere', 'passwd'), path.join(env.volumeDir, 'dead'));
+    const { resolveVolumePath } = env.requireFresh('src/utils/pathUtils');
+
+    await expect(resolveVolumePath('dead')).rejects.toThrow(/outside the configured volume/i);
+    await expect(resolveVolumePath('dead/child.txt')).rejects.toThrow(/outside the configured volume/i);
+  });
+
+  it('accepts a broken link whose target stays inside the volume', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-dangling-inside-',
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    await fs.symlink(path.join(env.volumeDir, 'not-yet.txt'), path.join(env.volumeDir, 'pending'));
+    const { resolveVolumePath } = env.requireFresh('src/utils/pathUtils');
+
+    await expect(resolveVolumePath('pending')).resolves.not.toThrow();
+  });
+
+  it('gives up on a symbolic link loop instead of spinning', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-loop-',
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    await fs.symlink(path.join(env.volumeDir, 'b'), path.join(env.volumeDir, 'a'));
+    await fs.symlink(path.join(env.volumeDir, 'a'), path.join(env.volumeDir, 'b'));
+    const { resolveVolumePath } = env.requireFresh('src/utils/pathUtils');
+
+    await expect(resolveVolumePath('a')).rejects.toThrow(/symbolic links/i);
+  });
+});
+
+/**
+ * The volume was the only space whose containment survived a symbolic link.
+ * A personal folder and an assigned user volume are just as reachable — the
+ * archive that plants the link does not care which space it lands in.
+ */
+describe('Other spaces containment', () => {
+  it('refuses an escape from a personal folder', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-personal-',
+      env: { USER_DIR_ENABLED: 'true' },
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    const { resolvePersonalPath } = env.requireFresh('src/utils/pathUtils');
+    const user = { id: 'user-1', username: 'alice' };
+    const userRoot = await resolvePersonalPath('', user);
+    await fs.mkdir(userRoot, { recursive: true });
+
+    const outside = path.join(env.tmpRoot, 'outside-personal');
+    await fs.mkdir(outside, { recursive: true });
+    await fs.writeFile(path.join(outside, 'secret.txt'), 'not yours');
+    await fs.symlink(outside, path.join(userRoot, 'escape'));
+
+    await expect(resolvePersonalPath('escape/secret.txt', user)).rejects.toThrow(
+      /outside the configured user directory/i
+    );
+    await expect(resolvePersonalPath('docs/report.txt', user)).resolves.not.toThrow();
+  });
+
+  /**
+   * The same escape, asked for the way the application asks for it.
+   *
+   * The test above calls `resolvePersonalPath` directly, one layer below where
+   * the application actually resolves a path — and that is why it went on
+   * passing while every personal path was broken. `resolveLogicalPath` called
+   * it without awaiting, so it handed back a promise as if it were a path:
+   * `pathExists` was given a promise, and My Files answered "Path not found"
+   * for a directory that was right there.
+   *
+   * The refusal went the same way. A promise nobody awaits is a rejection
+   * nobody handles, and Node ends the process for one of those — so a path that
+   * should have been turned down took the server with it instead. These three
+   * ask at the layer the defect was in.
+   */
+  it('resolves a personal path to a path, not to a promise', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-personal-logical-',
+      env: { USER_DIR_ENABLED: 'true' },
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    const { resolveLogicalPath, resolvePersonalPath } = env.requireFresh('src/utils/pathUtils');
+    const user = { id: 'user-1', username: 'alice' };
+    const userRoot = await resolvePersonalPath('', user);
+    await fs.mkdir(path.join(userRoot, 'docs'), { recursive: true });
+
+    const { absolutePath } = await resolveLogicalPath('personal/docs', { user });
+
+    expect(typeof absolutePath).toBe('string');
+    expect(absolutePath).toBe(path.join(userRoot, 'docs'));
+  });
+
+  it('refuses an escape asked for through the logical path', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-personal-escape-',
+      env: { USER_DIR_ENABLED: 'true' },
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    const { resolveLogicalPath, resolvePersonalPath } = env.requireFresh('src/utils/pathUtils');
+    const user = { id: 'user-1', username: 'alice' };
+    const userRoot = await resolvePersonalPath('', user);
+    await fs.mkdir(userRoot, { recursive: true });
+    const outside = path.join(env.tmpRoot, 'outside-personal-logical');
+    await fs.mkdir(outside, { recursive: true });
+    await fs.writeFile(path.join(outside, 'secret.txt'), 'not yours');
+    await fs.symlink(outside, path.join(userRoot, 'escape'));
+
+    await expect(
+      resolveLogicalPath('personal/escape/secret.txt', { user })
+    ).rejects.toThrow(/outside the configured user directory/i);
+  });
+
+  /** A refusal must reach the caller, not the process. */
+  it('leaves no unhandled rejection behind when it refuses', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-personal-unhandled-',
+      env: { USER_DIR_ENABLED: 'true' },
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    const { resolveLogicalPath, resolvePersonalPath } = env.requireFresh('src/utils/pathUtils');
+    const user = { id: 'user-1', username: 'alice' };
+    const userRoot = await resolvePersonalPath('', user);
+    await fs.mkdir(userRoot, { recursive: true });
+    const outside = path.join(env.tmpRoot, 'outside-personal-unhandled');
+    await fs.mkdir(outside, { recursive: true });
+    await fs.symlink(outside, path.join(userRoot, 'escape'));
+
+    const unhandled = [];
+    const collect = (reason) => unhandled.push(reason);
+    process.on('unhandledRejection', collect);
+    try {
+      await resolveLogicalPath('personal/escape', { user }).catch(() => {});
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', collect);
+    }
+  });
+
+  it('refuses an escape from an assigned user volume', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-user-volume-',
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+
+    const assigned = path.join(env.tmpRoot, 'assigned');
+    await fs.mkdir(assigned, { recursive: true });
+    const outside = path.join(env.tmpRoot, 'outside-assigned');
+    await fs.mkdir(outside, { recursive: true });
+    await fs.writeFile(path.join(outside, 'secret.txt'), 'not yours');
+    await fs.symlink(outside, path.join(assigned, 'escape'));
+
+    const { resolveLogicalPath } = env.requireFresh('src/utils/pathUtils');
+    const userVolume = { id: 'vol-1', userId: 'user-1', label: 'Work', path: assigned };
+
+    await expect(
+      resolveLogicalPath('Work/escape/secret.txt', { user: { id: 'user-1' }, userVolume })
+    ).rejects.toThrow(/outside the assigned volume/i);
+  });
+});
+
+/**
+ * Entries in a directory share every path segment but the last, so the check
+ * resolves the parent once and then only asks whether each entry is itself a
+ * link. That shortcut must not become a hole: the escapes below all sit in a
+ * directory whose parent is perfectly legitimate.
+ */
+describe('Containment with a warm parent', () => {
+  it('still refuses a link, a broken link and a nested escape', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-warm-parent-',
+      modules: [
+        'src/config/env',
+        'src/config/index',
+        'src/utils/requestContext',
+        'src/utils/pathUtils',
+      ],
+    });
+    currentEnv = env;
+
+    const context = env.requireFresh('src/utils/requestContext');
+    const { resolveVolumePath } = env.requireFresh('src/utils/pathUtils');
+
+    const outside = path.join(env.tmpRoot, 'outside-warm');
+    await fs.mkdir(outside, { recursive: true });
+    await fs.writeFile(path.join(outside, 'secret.txt'), 'not yours');
+
+    const inside = path.join(env.volumeDir, 'folder');
+    await fs.mkdir(inside, { recursive: true });
+    await fs.writeFile(path.join(inside, 'ok.txt'), 'fine');
+    await fs.symlink(outside, path.join(inside, 'escape'));
+    await fs.symlink(path.join(env.tmpRoot, 'nowhere'), path.join(inside, 'dead'));
+
+    await context.runInRequestContext(async () => {
+      // Warms the parent, which is what the shortcut relies on.
+      expect(await resolveVolumePath('folder/ok.txt')).toContain('ok.txt');
+
+      await expect(resolveVolumePath('folder/escape')).rejects.toThrow(/outside/i);
+      await expect(resolveVolumePath('folder/escape/secret.txt')).rejects.toThrow(/outside/i);
+      await expect(resolveVolumePath('folder/dead')).rejects.toThrow(/outside/i);
+
+      // And a legitimate sibling still resolves afterwards.
+      expect(await resolveVolumePath('folder/ok.txt')).toContain('ok.txt');
+    });
+  });
+
+  it('refuses an entry whose parent is itself a link out', async () => {
+    const env = await setupTestEnv({
+      tag: 'containment-warm-parent-link-',
+      modules: [
+        'src/config/env',
+        'src/config/index',
+        'src/utils/requestContext',
+        'src/utils/pathUtils',
+      ],
+    });
+    currentEnv = env;
+
+    const context = env.requireFresh('src/utils/requestContext');
+    const { resolveVolumePath } = env.requireFresh('src/utils/pathUtils');
+
+    const outside = path.join(env.tmpRoot, 'outside-parent');
+    await fs.mkdir(path.join(outside, 'sub'), { recursive: true });
+    await fs.writeFile(path.join(outside, 'sub', 'secret.txt'), 'not yours');
+    await fs.symlink(outside, path.join(env.volumeDir, 'linked'));
+
+    await context.runInRequestContext(async () => {
+      // The entry is a plain file; it is the directory holding it that escapes.
+      await expect(resolveVolumePath('linked/sub/secret.txt')).rejects.toThrow(/outside/i);
+    });
+  });
+});
+
+/**
+ * `assertRealPathWithinRoot` is the check the resolvers lean on, and its name
+ * is a promise. It used to accept a path it could not resolve once the walk
+ * climbed above the root — safe only because every caller happened to have
+ * checked containment just before. The promise is now the function's own.
+ */
+describe('the containment check on its own', () => {
+  const withRoot = async (tag) => {
+    const env = await setupTestEnv({
+      tag,
+      modules: ['src/config/env', 'src/config/index', 'src/utils/pathUtils'],
+    });
+    currentEnv = env;
+    const { assertRealPathWithinRoot } = env.requireFresh('src/utils/pathUtils');
+    return { env, assertRealPathWithinRoot };
+  };
+
+  // The caller this was waiting for: one that trusts the name and passes a
+  // path it has not checked itself.
+  it('refuses a path outside the root when none of it exists', async () => {
+    const { env, assertRealPathWithinRoot } = await withRoot('containment-direct-');
+
+    await expect(assertRealPathWithinRoot('/etc/nothing/here', env.volumeDir)).rejects.toThrow(
+      /outside the configured volume/i
+    );
+    await expect(assertRealPathWithinRoot(path.join(env.tmpRoot, 'elsewhere', 'file.txt'), env.volumeDir)).rejects.toThrow(/outside the configured volume/i);
+  });
+
+  it('refuses a path outside the root when it does exist', async () => {
+    const { env, assertRealPathWithinRoot } = await withRoot('containment-direct-real-');
+    const outside = path.join(env.tmpRoot, 'outside');
+    await fs.mkdir(outside, { recursive: true });
+    await fs.writeFile(path.join(outside, 'secret.txt'), 'not yours');
+
+    await expect(assertRealPathWithinRoot(path.join(outside, 'secret.txt'), env.volumeDir)).rejects.toThrow(
+      /outside the configured volume/i
+    );
+  });
+
+  it('accepts what is inside, existing or not', async () => {
+    const { env, assertRealPathWithinRoot } = await withRoot('containment-direct-inside-');
+    await fs.mkdir(path.join(env.volumeDir, 'Documents'), { recursive: true });
+
+    await expect(assertRealPathWithinRoot(path.join(env.volumeDir, 'Documents'), env.volumeDir)).resolves.not.toThrow();
+    // A file about to be created is not an escape.
+    await expect(assertRealPathWithinRoot(path.join(env.volumeDir, 'Documents', 'new.txt'), env.volumeDir)).resolves.not.toThrow();
+    await expect(assertRealPathWithinRoot(env.volumeDir, env.volumeDir)).resolves.not.toThrow();
+  });
+
+  // A volume root that has not been created yet is the startup case the walk
+  // was written to allow, and it still is.
+  it('accepts a root that does not exist yet', async () => {
+    const { env, assertRealPathWithinRoot } = await withRoot('containment-direct-absent-');
+    const absent = path.join(env.tmpRoot, 'not-mounted-yet');
+
+    await expect(assertRealPathWithinRoot(path.join(absent, 'file.txt'), absent)).resolves.not.toThrow();
+  });
+});

--- a/backend/tests/utils/path-utils.test.js
+++ b/backend/tests/utils/path-utils.test.js
@@ -30,10 +30,12 @@ describe('Path Utilities', () => {
   });
 
   describe('resolveVolumePath', () => {
-    it('should protect volume root boundaries', () => {
-      const resolved = pathUtils.resolveVolumePath('photo/jpg');
+    // `resolveVolumePath` became async when it started following symlinks to
+    // check where a path really lands, so both halves are awaited now.
+    it('should protect volume root boundaries', async () => {
+      const resolved = await pathUtils.resolveVolumePath('photo/jpg');
       expect(resolved).toBe(path.resolve(envContext.volumeDir, 'photo/jpg'));
-      expect(() => pathUtils.resolveVolumePath('../outside')).toThrow(/outside/);
+      await expect(pathUtils.resolveVolumePath('../outside')).rejects.toThrow(/outside/);
     });
   });
 


### PR DESCRIPTION
> ### ⚠️ Please merge #381 first
>
> #381 fixes the folder-size routes I broke in #380 — they use Express 5 wildcard syntax and **stop the server booting** on the Express 4 this tree declares. It is a boot failure, not a broken feature. This batch is cut from `main` at `fafd332`, which still has that bug; taking this one first would leave it in place longer.

Batch 8 of #373. **~500 lines of code, ~900 of tests. 39 tests, all passing.**

## The problem

Personal folders live inside the same volume everybody browses, under a directory named after the account. Being in the tree, they were reachable **through** it: another account could list one, open a file inside it, and delete it, simply by walking to the folder by name.

The space was private by convention, not by rule.

## What it does

**Refuses a path that lands inside a personal root**, by name rather than by touching the filesystem — so the check costs nothing per request and cannot be defeated by walking in from the side.

**Checks where a path really lands.** A symlink inside the volume can point outside it, and resolving the string alone never notices. `assertRealPathWithinRoot` walks the resolved path — bounded to 32 hops, so a symlink loop is refused rather than followed forever — and rejects one that leaves the root.

**Claims a folder name once and holds it.** Schema v11 adds `personal_folder_name` with a unique index, and the migration assigns one to every existing account. Two accounts whose email local part collides (`alice@example.com` and `alice@other.org`) no longer race for the same directory.

## The API change, stated plainly

`resolveVolumePath` and `resolvePersonalPath` **become async**, because following symlinks means touching the disk.

I checked the blast radius before doing it: outside `pathUtils` itself the only caller is `resolveLogicalPath`, which was already async, plus **one of your tests** — `path-utils.test.js > should protect volume root boundaries` — updated here to await both halves. Everything else in this tree resolves paths through `accessManager`, which is unaffected.

`requestContext` comes with it: the containment check reads the same few paths repeatedly within one request, and an `AsyncLocalStorage` cache removes the repetition. It is mounted as middleware in `app.js` and used nowhere else yet.

## Left out

`pathBindingsService` — the piece that keeps favourites and shares pointing at the right place when a folder is renamed — depends on a `recent_destinations` table that belongs to a different subject. It travels with that one.

## Tests

39 pass, run under **`express@4`**, which is what this tree declares. 8 failures on `main` before this branch and 8 after, none new.

That version note matters: I had been testing everything against Express 5 until yesterday, which is exactly how #380 got through. I now install `express@4` before running anything.