### PR TITLE
Fix: install p7zip and poppler-utils, without which archives and PDF search cannot run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,8 @@ RUN apk add --no-cache \
       ffmpeg \
       gosu \
       ripgrep \
+      p7zip \
+      poppler-utils \
       imagemagick \
       openssh-client \
       unzip \

--- a/backend/src/services/pdfTextExtract.js
+++ b/backend/src/services/pdfTextExtract.js
@@ -35,7 +35,10 @@ const hasPdfToText = async () => {
   });
 
   if (!available) {
-    logger.debug('pdftotext is not installed; PDF contents will not be searched');
+    // At debug level this said nothing on a default install, and a PDF search
+    // that quietly returns no match looks like a PDF with no matching text.
+    // Same level as the 7-Zip probe, for the same reason.
+    logger.warn('pdftotext is not installed; PDF contents will not be searched');
   }
   return available;
 };


### PR DESCRIPTION
As asked on #383 — the two packages, so you can start testing.

Not numbered, same as #381: it is a fix for something I shipped, not a batch. The count stays at 9/14.

```dockerfile
RUN apk add --no-cache \
      ffmpeg \
      gosu \
      ripgrep \
      p7zip \
      poppler-utils \
      imagemagick \
      ...
```

## What was missing

| Package | Spawned by | Behaviour without it |
|---|---|---|
| `p7zip` | `archiveService` → `7z` | probe fails, extraction limited to `.zip`, `.7z`/`.rar`/`.tar.*` refused — logged at `warn` |
| `poppler-utils` | `pdfTextExtract` → `pdftotext` | PDFs never searched; `.docx`/`.xlsx` still are, they are read in-process |

Neither crashes, which is why CI stayed green and why I did not see it: both were written to degrade, and my own image had the packages. Every other binary the backend spawns — `rg`, `unzip`, `convert`, `ffmpeg` — was already installed, so nothing else is affected. Full list, taken from the merged code rather than from memory:

```
rg × 3      → ripgrep        ✓ installed
pdftotext × 2 → poppler-utils  ✗ added here
unzip × 1   → unzip          ✓ installed
convert × 1 → imagemagick    ✓ installed
7z (SEVEN_ZIP_PATH default) → p7zip  ✗ added here
```

## One line beyond what you asked for

`pdfTextExtract` logged the missing binary at `debug`, so on a default install it said nothing at all, and a PDF search that returns nothing looks like a PDF with no matching text. Raised to `warn`, matching the 7-Zip probe next to it. It is there so your test session can tell "broken" from "not installed" — say the word and I will drop it and leave the Dockerfile alone.

## How this got past me

I validated those two batches against my own image, which carries both packages, instead of against yours. Same mistake as the Express version in #380: I checked my environment and called it your environment. Enumerating the binaries the code spawns and matching them against `Dockerfile` is now the first thing I do on a batch, before the tests — it takes a minute and it would have caught both.

While on that subject, a correction I owe you: several of my earlier PRs said "15 pre-existing failures, unchanged". That number came from the same broken environment — about seven of them were Express 5 resolving from my root `node_modules` against your declared Express 4. On Express 4 the real baseline was 8, and on `main` after #383 it should be lower still. If you see a different count, mine was the wrong one.

The test checklist is on #383, updated for the two features that can now actually run.