### PR TITLE
Fix: restore the API layer three merged batches import from, and check it on every PR

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,40 @@
+name: Build check
+
+# Nothing runs on a pull request today, so a branch that cannot start the
+# application looks exactly like one that can. These two steps are the cheapest
+# check that would have caught it: the frontend has to bundle, and the backend
+# has to load every module it requires.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: Frontend bundles, backend loads
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Bundle the frontend
+        run: npm run build
+
+      - name: Load every backend module
+        env:
+          CONFIG_DIR: ${{ runner.temp }}/config
+          CACHE_DIR: ${{ runner.temp }}/cache
+          VOLUME_ROOT: ${{ runner.temp }}/files
+        run: |
+          mkdir -p "$CONFIG_DIR" "$CACHE_DIR" "$VOLUME_ROOT"
+          # Requiring app.js pulls in every route, service and middleware, so a
+          # missing file fails here rather than on someone's machine. The delay
+          # lets the deferred work (migrations, session store) report too.
+          node -e "require('./backend/src/app.js'); setTimeout(() => process.exit(0), 5000)"

--- a/backend/src/middleware/ensureAdmin.js
+++ b/backend/src/middleware/ensureAdmin.js
@@ -1,0 +1,17 @@
+const { ForbiddenError } = require('../errors/AppError');
+
+/**
+ * Allow only administrators past this point.
+ *
+ * Several route files carried their own copy of this check, which is how
+ * /permissions/chmod and /permissions/chown ended up with none at all.
+ */
+const ensureAdmin = (req, _res, next) => {
+  const roles = Array.isArray(req.user?.roles) ? req.user.roles : [];
+  if (!roles.includes('admin')) {
+    throw new ForbiddenError('Admin access required.');
+  }
+  next();
+};
+
+module.exports = { ensureAdmin };

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -1,22 +1,25 @@
 const pino = require('pino');
 const loggingConfig = require('../config/logging');
 
-const logger = pino({
-  level: loggingConfig.level,
-  base: { service: 'nextExplorer-backend' },
-  timestamp: pino.stdTimeFunctions.isoTime,
-  transport: loggingConfig.isDebug
-    ? {
-        target: 'pino-pretty',
-        options: {
-          colorize: true,
-          levelFirst: true,
-          translateTime: 'SYS:standard',
-          ignore: 'pid,hostname',
-        },
-      }
-    : undefined,
-});
+const prettyOptions = {
+  colorize: true,
+  levelFirst: true,
+  translateTime: 'SYS:standard',
+  ignore: 'pid,hostname',
+};
+
+// Keep development formatting in-process. The worker-backed Pino transport can
+// crash under Node's watch runner while the worker is starting or stopping.
+const prettyStream = loggingConfig.isDebug ? require('pino-pretty')(prettyOptions) : undefined;
+
+const logger = pino(
+  {
+    level: loggingConfig.level,
+    base: { service: 'nextExplorer-backend' },
+    timestamp: pino.stdTimeFunctions.isoTime,
+  },
+  prettyStream
+);
 
 logger.debug({ level: loggingConfig.level }, 'Logger initialized');
 

--- a/frontend/src/api/files.api.js
+++ b/frontend/src/api/files.api.js
@@ -19,6 +19,26 @@ async function getUsage(path = '') {
   return requestJson(`/api/usage/${encodedPath}`, { method: 'GET' });
 }
 
+async function getFolderSizesBatch(paths = [], options = {}) {
+  const normalizedPaths = (Array.isArray(paths) ? paths : [])
+    .map((p) => normalizePath(p))
+    .filter(Boolean);
+  return requestJson('/api/folder-size/batch', {
+    ...options,
+    method: 'POST',
+    body: JSON.stringify({ paths: normalizedPaths }),
+  });
+}
+
+async function refreshFolderSize(relativePath, options = {}) {
+  const normalizedPath = normalizePath(relativePath);
+  if (!normalizedPath) {
+    throw new Error('A folder path is required to refresh its size.');
+  }
+  const encodedPath = encodePath(normalizedPath);
+  return requestJson(`/api/folder-size/refresh/${encodedPath}`, { ...options, method: 'POST' });
+}
+
 async function copyItems(items, destination) {
   return requestJson('/api/files/copy', {
     method: 'POST',
@@ -255,10 +275,63 @@ async function changeOwnership(path, owner, group) {
   });
 }
 
+/**
+ * The audio and subtitle tracks a media file carries.
+ *
+ * The player does not transcode, so a track it cannot decode simply produces
+ * nothing — a film with an AC-3 soundtrack plays in silence, and until this
+ * existed the interface had no way to say why. Returns null when the server
+ * cannot read the file, which the caller treats as "say nothing" rather than
+ * "there is nothing".
+ */
+async function fetchMediaTracks(relativePath) {
+  const normalizedPath = normalizePath(relativePath);
+  if (!normalizedPath) return null;
+
+  const params = new URLSearchParams({ path: normalizedPath });
+  try {
+    return await requestJson(`/api/media/tracks?${params.toString()}`, { method: 'GET' });
+  } catch (_) {
+    // A file ffprobe will not read is not an error worth showing anyone; the
+    // video still plays, and the extra information is simply unavailable.
+    return null;
+  }
+}
+
+/**
+ * A URL for one subtitle track, converted to WebVTT.
+ *
+ * Handed straight to a `<track>` element rather than fetched, so the browser's
+ * own caption menu drives it. That works because the API is served from the
+ * same origin as the application; a `<track>` pointing somewhere else would
+ * need CORS and would not carry the session cookie.
+ *
+ * @param {string} relativePath the media file
+ * @param {{stream?: number, file?: string}} track as named by fetchMediaTracks:
+ *   a stream index for an embedded track, a filename for a sidecar
+ */
+const getSubtitleUrl = (relativePath, track = {}) => {
+  const normalizedPath = normalizePath(relativePath);
+  if (!normalizedPath) return null;
+
+  const params = new URLSearchParams({ path: normalizedPath });
+  if (typeof track.file === 'string' && track.file) {
+    params.set('file', track.file);
+  } else if (Number.isInteger(track.stream)) {
+    params.set('stream', String(track.stream));
+  } else {
+    return null;
+  }
+
+  return buildUrl(`/api/media/subtitle?${params.toString()}`);
+};
+
 export {
   browse,
   getVolumes,
   getUsage,
+  getFolderSizesBatch,
+  refreshFolderSize,
   copyItems,
   moveItems,
   deleteItems,
@@ -270,6 +343,8 @@ export {
   getRawFileUrl,
   fetchThumbnail,
   fetchMetadata,
+  fetchMediaTracks,
+  getSubtitleUrl,
   downloadItems,
   extractZip,
   compressToZip,


### PR DESCRIPTION
@vikramsoni2 — you are right, `main` does not start, and it is my fault twice over: three of my batches shipped a consumer without the module it reads from, and I never once ran your tree the way you just did.

## What was missing

Your two errors were the first two of five. The frontend bundler stops at the first module it cannot resolve, so it never reached the other two.

| Missing | Read by | Shipped in |
|---|---|---|
| `backend/src/middleware/ensureAdmin.js` | `routes/userVolumes.js` | #382 |
| `getFolderSizesBatch`, `refreshFolderSize` | `stores/folderSize.js` | #380 |
| `fetchMediaTracks`, `getSubtitleUrl` | `plugins/preview/manager.js` | #377 |

The endpoints all four functions call (`/api/folder-size/batch`, `/api/folder-size/refresh`, `/api/media/tracks`, `/api/media/subtitle`) are already on `main` — only the client wrapper was left behind. Same for the middleware: `userVolumes.js` on `main` already imports it.

## How I verified this time

Not by reading the diff. I checked out `main` at `1b4b576`, ran `npm ci` against your lockfile, and:

- `npm run build` — bundles clean;
- `node -e "require('./backend/src/app.js')"` with `CONFIG_DIR`/`CACHE_DIR`/`VOLUME_ROOT` pointed at temp dirs — every module loads, migrations v3→v11 apply, no deferred errors.

Then I put the original `files.api.js` back and confirmed the build fails, and removed `ensureAdmin.js` and confirmed the boot fails, so I know the check actually catches this class of defect rather than passing for another reason.

## The second commit

The reason five broken imports reached `main` is that nothing runs on a pull request — `docker-publish.yml` only fires on a published release, `docs.yml` only on docs. So the second commit adds a workflow that bundles the frontend and requires `app.js` on every PR and every push to `main`. It is about two minutes of CI and it fails on exactly what happened here.

It deliberately does not run `npm test`: the suite has failures of its own and gating on it would just teach everyone to ignore a red check. Happy to drop that commit if you would rather not add a workflow, but "the contributor promises to check locally" is precisely the control that just failed you.

## While I am correcting the record

Something else I owe you. Several of my earlier PRs said "15 pre-existing test failures, unchanged". That number came from my machine, where the root `node_modules` had Express 5 while your `backend/package.json` still declared Express 4 — the same skew that produced the boot failure in #380 and its fix in #381. Against your actual tree the baseline is 8, not 15, and about seven of the failures I attributed to your code were mine. #383 has since made Express 5 the declared version, so that particular gap is closed.

I am holding batches 10–14 until you tell me `main` runs for you.